### PR TITLE
Calculation can be based on fontSize or capHeight

### DIFF
--- a/.changeset/shaggy-lies-suffer.md
+++ b/.changeset/shaggy-lies-suffer.md
@@ -1,0 +1,6 @@
+---
+'capsize': minor
+'capsize-site': minor
+---
+
+Calculation can be based on fontSize or capHeight

--- a/site/src/components/AppStateContext.tsx
+++ b/site/src/components/AppStateContext.tsx
@@ -26,24 +26,35 @@ interface Font {
 }
 
 type LineHeightStyle = 'gap' | 'leading';
+type CalculationBasis = 'capheight' | 'fontsize';
 
 interface AppState {
   capHeight: number;
+  fontSize: number;
   leading: number;
   lineGap: number;
   gridStep: number;
   lineHeightStyle: LineHeightStyle;
+  calculationBasis: CalculationBasis;
   metrics: FontMetrics;
   selectedFont: Font;
-  focusedField: 'grid' | 'capheight' | 'leading' | 'linegap' | null;
+  focusedField:
+    | 'grid'
+    | 'capheight'
+    | 'fontsize'
+    | 'leading'
+    | 'linegap'
+    | null;
   scaleLeading: boolean;
 }
 
 type Action =
   | { type: 'UPDATE_CAPHEIGHT'; capHeight: number; leading: number }
+  | { type: 'UPDATE_FONTSIZE'; fontSize: number }
   | { type: 'UPDATE_LEADING'; value: number }
   | { type: 'UPDATE_LINEGAP'; value: number }
   | { type: 'UPDATE_LINEHEIGHT_STYLE'; value: LineHeightStyle }
+  | { type: 'UPDATE_CALCULATIONBASIS'; value: CalculationBasis }
   | { type: 'UPDATE_GRID_STEP'; value: number }
   | { type: 'FIELD_FOCUS'; value: AppState['focusedField'] }
   | { type: 'FIELD_BLUR' }
@@ -61,6 +72,16 @@ function reducer(state: AppState, action: Action): AppState {
         capHeight: action.capHeight,
         leading: state.scaleLeading
           ? Math.round((state.leading / state.capHeight) * action.capHeight)
+          : state.leading,
+      };
+    }
+
+    case 'UPDATE_FONTSIZE': {
+      return {
+        ...state,
+        fontSize: action.fontSize,
+        leading: state.scaleLeading
+          ? Math.round((state.leading / state.fontSize) * action.fontSize)
           : state.leading,
       };
     }
@@ -90,6 +111,14 @@ function reducer(state: AppState, action: Action): AppState {
         ...state,
         lineHeightStyle: action.value,
         focusedField: action.value === 'gap' ? 'linegap' : 'leading',
+      };
+    }
+
+    case 'UPDATE_CALCULATIONBASIS': {
+      return {
+        ...state,
+        calculationBasis: action.value,
+        focusedField: action.value === 'capheight' ? 'capHeight' : 'fontSize',
       };
     }
 
@@ -139,10 +168,12 @@ const initialFontSize = 48;
 const intialState: AppState = {
   metrics: robotoMetrics,
   capHeight: initialFontSize,
+  fontSize: initialFontSize,
   leading: Math.round(initialFontSize * 1.5),
   lineGap: 24,
   gridStep: 4,
   lineHeightStyle: 'gap',
+  calculationBasis: 'capheight',
   selectedFont: roboto,
   focusedField: null,
   scaleLeading: true,

--- a/site/src/components/CapSizeSelector.tsx
+++ b/site/src/components/CapSizeSelector.tsx
@@ -169,9 +169,11 @@ const CapSizeSelector = () => {
   const {
     leading,
     capHeight,
+    fontSize,
     scaleLeading,
     lineGap,
     lineHeightStyle,
+    calculationBasis,
     gridStep,
   } = state;
 
@@ -185,7 +187,7 @@ const CapSizeSelector = () => {
           min={0}
           max={10}
           value={gridStep}
-          onChange={(newStep) =>
+          onChange={newStep =>
             dispatch({ type: 'UPDATE_GRID_STEP', value: newStep })
           }
           onFocus={() => dispatch({ type: 'FIELD_FOCUS', value: 'grid' })}
@@ -226,23 +228,95 @@ const CapSizeSelector = () => {
       </Box>
 
       <Box>
-        <Setting
-          name="capHeight"
-          label="Cap Height"
-          gridStep={useGrid ? gridStep : undefined}
-          min={10}
-          max={200}
-          value={capHeight}
-          onChange={(newValue) =>
-            dispatch({
-              type: 'UPDATE_CAPHEIGHT',
-              capHeight: newValue,
-              leading,
-            })
-          }
-          onFocus={() => dispatch({ type: 'FIELD_FOCUS', value: 'capheight' })}
-          onBlur={() => dispatch({ type: 'FIELD_BLUR' })}
-        />
+        <Stack isInline alignItems="center" spacing={5}>
+          <Box w={[130, 150]} flexShrink={0}>
+            <SettingLabel
+              id="calculationBasisType"
+              htmlFor="calculationBasisType"
+            >
+              Calculation basis
+            </SettingLabel>
+          </Box>
+
+          <Box w="100%">
+            <RadioButtonGroup
+              id="calculationBasisType"
+              value={calculationBasis}
+              onChange={style =>
+                dispatch({
+                  type: 'UPDATE_CALCULATIONBASIS',
+                  value: style as typeof calculationBasis,
+                })
+              }
+              isInline
+            >
+              <CustomRadio
+                isChecked={calculationBasis === 'capheight'}
+                value="capheight"
+                onFocus={() =>
+                  dispatch({ type: 'FIELD_FOCUS', value: 'capheight' })
+                }
+                onBlur={() => dispatch({ type: 'FIELD_BLUR' })}
+              >
+                Cap Height
+              </CustomRadio>
+              <CustomRadio
+                isChecked={calculationBasis === 'fontsize'}
+                value="fontsize"
+                onFocus={() =>
+                  dispatch({ type: 'FIELD_FOCUS', value: 'fontSize' })
+                }
+                onBlur={() => dispatch({ type: 'FIELD_BLUR' })}
+              >
+                Font Size
+              </CustomRadio>
+            </RadioButtonGroup>
+          </Box>
+        </Stack>
+      </Box>
+
+      <Box pos="relative" h={16} margin={-2} overflow="hidden">
+        <Mask hide={calculationBasis === 'fontsize'}>
+          <Setting
+            name="capHeight"
+            label="Cap Height"
+            gridStep={useGrid ? gridStep : undefined}
+            min={10}
+            max={200}
+            value={capHeight}
+            active={calculationBasis === 'capheight'}
+            onChange={newValue =>
+              dispatch({
+                type: 'UPDATE_CAPHEIGHT',
+                capHeight: newValue,
+                leading,
+              })
+            }
+            onFocus={() =>
+              dispatch({ type: 'FIELD_FOCUS', value: 'capheight' })
+            }
+            onBlur={() => dispatch({ type: 'FIELD_BLUR' })}
+          />
+        </Mask>
+
+        <Mask hide={calculationBasis === 'capheight'}>
+          <Setting
+            name="fontSize"
+            label="Font Size"
+            min={1}
+            max={200}
+            value={fontSize}
+            active={calculationBasis === 'fontsize'}
+            onChange={newValue =>
+              dispatch({
+                type: 'UPDATE_FONTSIZE',
+                fontSize: newValue,
+              })
+            }
+            onFocus={() => dispatch({ type: 'FIELD_FOCUS', value: 'fontsize' })}
+            onBlur={() => dispatch({ type: 'FIELD_BLUR' })}
+          />
+        </Mask>
       </Box>
 
       <Box>
@@ -257,7 +331,7 @@ const CapSizeSelector = () => {
             <RadioButtonGroup
               id="lineHeightType"
               value={lineHeightStyle}
-              onChange={(style) =>
+              onChange={style =>
                 dispatch({
                   type: 'UPDATE_LINEHEIGHT_STYLE',
                   value: style as typeof lineHeightStyle,
@@ -296,10 +370,10 @@ const CapSizeSelector = () => {
             name="leading"
             label="Leading"
             gridStep={useGrid ? gridStep : undefined}
-            min={capHeight}
-            max={capHeight * 2}
+            min={calculationBasis === 'capheight' ? capHeight : fontSize}
+            max={(calculationBasis === 'capheight' ? capHeight : fontSize) * 2}
             value={leading}
-            onChange={(newValue) =>
+            onChange={newValue =>
               dispatch({
                 type: 'UPDATE_LEADING',
                 value: newValue,
@@ -335,7 +409,7 @@ const CapSizeSelector = () => {
             label="Line Gap"
             gridStep={useGrid ? gridStep : undefined}
             value={lineGap}
-            onChange={(newValue) =>
+            onChange={newValue =>
               dispatch({
                 type: 'UPDATE_LINEGAP',
                 value: newValue,

--- a/site/src/components/OutputCSS.tsx
+++ b/site/src/components/OutputCSS.tsx
@@ -84,11 +84,20 @@ const editorTheme = ({
 const OutputCSS = () => {
   const { state } = useAppState();
 
-  const { leading, capHeight, metrics, lineHeightStyle, lineGap } = state;
+  const {
+    leading,
+    capHeight,
+    fontSize,
+    calculationBasis,
+    metrics,
+    lineHeightStyle,
+    lineGap,
+  } = state;
   const { colors } = useTheme();
 
   const capsizeStyles = capsize({
-    capHeight,
+    capHeight: calculationBasis === 'capheight' ? capHeight : undefined,
+    fontSize: calculationBasis === 'fontsize' ? fontSize : undefined,
     leading: lineHeightStyle === 'leading' ? leading : undefined,
     gap: lineHeightStyle === 'gap' ? lineGap : undefined,
     fontMetrics: metrics,

--- a/site/src/components/Preview.tsx
+++ b/site/src/components/Preview.tsx
@@ -15,6 +15,8 @@ const Preview = () => {
   const {
     leading,
     capHeight,
+    fontSize,
+    calculationBasis,
     metrics,
     focusedField,
     lineGap,
@@ -23,11 +25,18 @@ const Preview = () => {
   } = state;
 
   const capsizeStyles = capsize({
-    capHeight,
+    capHeight: calculationBasis === 'capheight' ? capHeight : undefined,
+    fontSize: calculationBasis === 'fontsize' ? fontSize : undefined,
     leading: lineHeightStyle === 'leading' ? leading : undefined,
     gap: lineHeightStyle === 'gap' ? lineGap : undefined,
     fontMetrics: metrics,
   });
+
+  let calculatedCapHeight = capHeight;
+
+  if (calculationBasis === 'fontsize') {
+    calculatedCapHeight = fontSize * (metrics.capHeight / metrics.unitsPerEm);
+  }
 
   const overlayStyles = {
     grid: {
@@ -39,29 +48,31 @@ const Preview = () => {
     capheight:
       lineHeightStyle === 'gap'
         ? {
-            backgroundImage: `linear-gradient(180deg, currentColor ${capHeight}px, transparent ${capHeight}px, transparent ${
-              capHeight + lineGap
+            backgroundImage: `linear-gradient(180deg, currentColor ${calculatedCapHeight}px, transparent ${calculatedCapHeight}px, transparent ${
+              calculatedCapHeight + lineGap
             }px)`,
-            backgroundSize: `100% ${capHeight + lineGap}px`,
+            backgroundSize: `100% ${calculatedCapHeight + lineGap}px`,
           }
         : {
-            backgroundImage: `linear-gradient(180deg, currentColor ${capHeight}px, transparent ${capHeight}px, transparent ${
-              capHeight + (leading - capHeight)
+            backgroundImage: `linear-gradient(180deg, currentColor ${calculatedCapHeight}px, transparent ${calculatedCapHeight}px, transparent ${
+              calculatedCapHeight + (leading - calculatedCapHeight)
             }px)`,
-            backgroundSize: `100% ${capHeight + (leading - capHeight)}px`,
+            backgroundSize: `100% ${
+              calculatedCapHeight + (leading - calculatedCapHeight)
+            }px`,
           },
     leading: {
       backgroundImage: `linear-gradient(180deg, transparent ${leading}px, currentColor ${leading}px, currentColor ${
         leading * 2
       }px)`,
-      backgroundPosition: `0 -${leading - capHeight}px`,
+      backgroundPosition: `0 -${leading - calculatedCapHeight}px`,
       backgroundSize: `100% ${leading * 2}px`,
     },
     linegap: {
-      backgroundImage: `linear-gradient(180deg, transparent ${capHeight}px, currentColor ${capHeight}px, currentColor ${
-        capHeight + lineGap
+      backgroundImage: `linear-gradient(180deg, transparent ${calculatedCapHeight}px, currentColor ${calculatedCapHeight}px, currentColor ${
+        calculatedCapHeight + lineGap
       }px)`,
-      backgroundSize: `100% ${capHeight + lineGap}px`,
+      backgroundSize: `100% ${calculatedCapHeight + lineGap}px`,
     },
   };
 


### PR DESCRIPTION
<img width="1121" alt="Screen Shot 2020-07-08 at 8 33 56 pm" src="https://user-images.githubusercontent.com/612020/86909042-dac85180-c15a-11ea-99fa-bd4f879c9208.png">

Using the default settings, with `capHeight` set to `32` produces:

```
{
  "fontSize": "45.010989010989015px",
  "lineHeight": "56px",
  "transform": "translateY(0.28027343749999994em)",
  "paddingTop": "0.05px",
  "marginTop": "-0.5332031249999999em"
}
```

Then changing to "Font Size" and setting it to `45` produces:

```
{
  "fontSize": "45px",
  "lineHeight": "55.9921875px",
  "transform": "translateY(0.28033854166666666em)",
  "paddingTop": "0.05px",
  "marginTop": "-0.5333333333333333em"
}
```

---

## Motivation

I have a design I need to match the font size to, so need the calculation to be derived from those pixel sizes as a basis.