### PR TITLE
fix(site): set pathPrefix for GitHub pages

### DIFF
--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -30,5 +30,6 @@ module.exports = {
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
+    pathPrefix: "/capsize",
   ],
 };


### PR DESCRIPTION
link to [docs](https://www.gatsbyjs.org/docs/how-gatsby-works-with-github-pages/#deploying-to-a-path-on-github-pages)