### PR TITLE
Introduce a guard for family name to prevent page crashes for some fonts

### DIFF
--- a/site/src/components/FontSelector/FontInjector.tsx
+++ b/site/src/components/FontSelector/FontInjector.tsx
@@ -7,14 +7,14 @@ export default function FontInjector() {
   const { state } = useAppState();
 
   const { metrics, selectedFont } = state;
-
+  const familyName = metrics.familyName || 'Unknown Family';
   useEffect(() => {
     injectGlobal({
       '@font-face': {
         fontFamily:
-          metrics.familyName.indexOf(' ') > -1
-            ? `'${metrics.familyName}'`
-            : metrics.familyName,
+          familyName.indexOf(' ') > -1
+            ? `'${familyName}'`
+            : familyName,
         src: `url(${selectedFont.url}) format('${selectedFont.type}')`,
       },
     });

--- a/site/src/components/MetricsPreview.tsx
+++ b/site/src/components/MetricsPreview.tsx
@@ -111,6 +111,8 @@ const MetricsPreview = () => {
   const lineHeightScale = lineHeight / metrics.unitsPerEm;
   const lineHeightNormal = lineHeightScale * previewFontSize;
 
+  const familyName = metrics.familyName || 'Unknown Family';
+
   return (
     <Box
       d="flex"
@@ -118,9 +120,9 @@ const MetricsPreview = () => {
       alignItems="center"
       fontSize={previewFontSize}
       fontFamily={
-        metrics.familyName.indexOf(' ') > -1
-          ? `'${metrics.familyName}'`
-          : metrics.familyName
+        familyName.indexOf(' ') > -1
+          ? `'${familyName}'`
+          : familyName
       }
       lineHeight="normal"
       pos="relative"

--- a/site/src/components/Preview.tsx
+++ b/site/src/components/Preview.tsx
@@ -65,6 +65,8 @@ const Preview = () => {
     },
   };
 
+  const familyName = metrics.familyName || 'Unknown Family';
+  
   return (
     <Box
       color="black"
@@ -95,9 +97,9 @@ const Preview = () => {
         as="div"
         css={{
           fontFamily:
-            metrics.familyName.indexOf(' ') > -1
-              ? `'${metrics.familyName}'`
-              : metrics.familyName,
+            familyName.indexOf(' ') > -1
+              ? `'${familyName}'`
+              : familyName,
           fontWeight: 'normal',
           ...capsizeStyles,
         }}


### PR DESCRIPTION
Hey all, capsize is a really great project.
I attempted to use a web font I had downloaded from SkyFonts but it failed to load the font (Avenir Next) and crashed the app.

Did a quick inspect on the console and saw it was a simple guard fix. Introduced a guard wherever the family name is referenced by metrics. Could also potentially move this to a util since it is the same code everywhere...

App works fine with the guard, but I am not sure if it is affecting any core functionality of cap size especially since it is modifying the css..
