### PR TITLE
Add getCapHeight utility & round decimal precision to 4 places

### DIFF
--- a/.changeset/great-singers-sparkle.md
+++ b/.changeset/great-singers-sparkle.md
@@ -1,0 +1,14 @@
+---
+'capsize': minor
+---
+
+Add getCapHeight utility and round decimal precision to 4 places
+
+**Add `getCapHeight({ fontSize: number, fontMetrics: FontMetrics }): number`**
+Utility to get the actual rendered cap height for a specific font size given the provided font metrics.
+
+**CSS property precision**
+Based on discovering that browser implementations of layout units fall between 1/60th and 1/64th of a pixel, rounding all property values to 4 decimal precision.
+
+Reference: https://trac.webkit.org/wiki/LayoutUnit
+(also mentions Mozilla - https://trac.webkit.org/wiki/LayoutUnit#Notes)

--- a/packages/capsize/README.md
+++ b/packages/capsize/README.md
@@ -77,6 +77,25 @@ Sets the line height to the provided value as measured from the baseline of the 
 This metadata is extracted from the metrics tables inside the font itself. You can use [the Capsize website](https://seek-oss.github.io/capsize/) to find these by selecting a font and referencing `JavaScript` tab in step 3.
 
 <br />
+
+# Utilities
+
+### getCapHeight
+
+Returns the actual rendered cap height for a specific font size given the provided font metrics.
+
+```ts
+import { getCapHeight } from 'capsize';
+
+const actualCapHeight = getCapHeight({
+  fontSize: 24,
+  fontMetrics: {
+    ...
+  }
+})
+```
+
+<br />
 <br />
 
 # License

--- a/packages/capsize/package.json
+++ b/packages/capsize/package.json
@@ -29,7 +29,9 @@
     "leading"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "round-to": "^4.1.0"
+  },
   "devDependencies": {
     "@types/blob-to-buffer": "^1.2.0",
     "@types/fontkit": "^1.8.0",

--- a/packages/capsize/src/index.ts
+++ b/packages/capsize/src/index.ts
@@ -1,3 +1,5 @@
+import roundTo from 'round-to';
+
 export interface FontMetrics {
   ascent: number;
   descent: number;
@@ -108,6 +110,16 @@ interface CapsizeInternal {
   fontSize: number;
   fontMetrics: FontMetrics;
 }
+
+/*
+   Rounding all values to a precision of `4` based on discovering that browser
+   implementations of layout units fall between 1/60th and 1/64th of a pixel.
+
+   Reference: https://trac.webkit.org/wiki/LayoutUnit
+   (above wiki also mentions Mozilla - https://trac.webkit.org/wiki/LayoutUnit#Notes)
+*/
+const PRECISION = 4;
+
 function createCss({
   lineHeight,
   fontSize,
@@ -134,20 +146,24 @@ function createCss({
     value - toScale(specifiedLineHeightOffset) + toScale(preventCollapse);
 
   return {
-    fontSize: `${fontSize}px`,
-    lineHeight: lineHeight ? `${lineHeight}px` : 'normal',
+    fontSize: `${roundTo(fontSize, PRECISION)}px`,
+    lineHeight: lineHeight ? `${roundTo(lineHeight, PRECISION)}px` : 'normal',
     padding: `${preventCollapse}px 0`,
     '::before': {
       content: "''",
-      marginTop: `${
-        leadingTrim(ascentScale - capHeightScale + lineGapScale / 2) * -1
-      }em`,
+      marginTop: `${roundTo(
+        leadingTrim(ascentScale - capHeightScale + lineGapScale / 2) * -1,
+        PRECISION,
+      )}em`,
       display: 'block',
       height: 0,
     },
     '::after': {
       content: "''",
-      marginBottom: `${leadingTrim(descentScale + lineGapScale / 2) * -1}em`,
+      marginBottom: `${roundTo(
+        leadingTrim(descentScale + lineGapScale / 2) * -1,
+        PRECISION,
+      )}em`,
       display: 'block',
       height: 0,
     },
@@ -155,3 +171,15 @@ function createCss({
 }
 
 export default capsize;
+
+export const getCapHeight = ({
+  fontSize,
+  fontMetrics,
+}: {
+  fontSize: number;
+  fontMetrics: FontMetrics;
+}) =>
+  roundTo(
+    (fontSize * fontMetrics.capHeight) / fontMetrics.unitsPerEm,
+    PRECISION,
+  );

--- a/site/src/components/Preview.tsx
+++ b/site/src/components/Preview.tsx
@@ -2,7 +2,7 @@
 import { jsx } from '@emotion/core'; // eslint-disable-line
 import React, { useRef } from 'react'; // eslint-disable-line
 import { Box, useTheme, Text } from '@chakra-ui/core';
-import capsize from 'capsize';
+import capsize, { getCapHeight } from 'capsize';
 import hexRgb from 'hex-rgb';
 
 import { useAppState } from './AppStateContext';
@@ -45,7 +45,7 @@ const Preview = () => {
     });
   }
 
-  const actualFontSize = fontSize * (metrics.capHeight / metrics.unitsPerEm);
+  const actualFontSize = getCapHeight({ fontSize, fontMetrics: metrics });
   const textRhythm = textSizeStyle === 'capHeight' ? capHeight : actualFontSize;
 
   const absoluteDescent = Math.abs(metrics.descent);
@@ -168,8 +168,7 @@ const Preview = () => {
       </Box>
       {textSizeStyle === 'fontSize' && (
         <Text color="gray.500" textAlign="center" paddingTop={2}>
-          Actual cap height:{' '}
-          {fontSize * (metrics.capHeight / metrics.unitsPerEm)}px
+          Actual cap height: {actualFontSize}px
         </Text>
       )}
     </Box>

--- a/site/src/components/Preview.tsx
+++ b/site/src/components/Preview.tsx
@@ -45,8 +45,12 @@ const Preview = () => {
     });
   }
 
-  const actualFontSize = getCapHeight({ fontSize, fontMetrics: metrics });
-  const textRhythm = textSizeStyle === 'capHeight' ? capHeight : actualFontSize;
+  const resolvedCapHeightFromFontSize = getCapHeight({
+    fontSize,
+    fontMetrics: metrics,
+  });
+  const textRhythm =
+    textSizeStyle === 'capHeight' ? capHeight : resolvedCapHeightFromFontSize;
 
   const absoluteDescent = Math.abs(metrics.descent);
   const contentArea = metrics.ascent + metrics.lineGap + absoluteDescent;
@@ -83,11 +87,11 @@ const Preview = () => {
       lineHeightStyle === 'lineGap'
         ? {
             backgroundImage: `linear-gradient(180deg, ${highlight} ${lineHeightNormal}px, transparent ${lineHeightNormal}px, transparent ${
-              lineHeightNormal + actualFontSize + lineGap
+              lineHeightNormal + resolvedCapHeightFromFontSize + lineGap
             }px)`,
-            backgroundSize: `100% ${actualFontSize + lineGap}px`,
+            backgroundSize: `100% ${resolvedCapHeightFromFontSize + lineGap}px`,
             backgroundPosition: `0 calc((${
-              (actualFontSize + lineGap - lineHeightNormal) / 2
+              (resolvedCapHeightFromFontSize + lineGap - lineHeightNormal) / 2
             }px) + ${capsizeStyles?.['::before'].marginTop})`,
           }
         : {
@@ -168,7 +172,7 @@ const Preview = () => {
       </Box>
       {textSizeStyle === 'fontSize' && (
         <Text color="gray.500" textAlign="center" paddingTop={2}>
-          Actual cap height: {actualFontSize}px
+          Actual cap height: {resolvedCapHeightFromFontSize}px
         </Text>
       )}
     </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14325,6 +14325,11 @@ rollup@^1.30.1:
     "@types/node" "*"
     acorn "^7.1.0"
 
+round-to@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/round-to/-/round-to-4.1.0.tgz#148d768d18b2f127f78e6648cb8b0a5943c416bf"
+  integrity sha512-H/4z+4QdWS82iMZ23+5St302Mv2jJws0hUvEogrD6gC8NN6Z5TalDtbg51owCrVy4V/4c8ePvwVLNtlhEfPo5g==
+
 rtl-css-js@^1.9.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.14.0.tgz#daa4f192a92509e292a0519f4b255e6e3c076b7d"


### PR DESCRIPTION
Provides a new utility `getCapHeight`, useful for determining the rendered cap height for a given font size. Also given [the recent information discovered](https://trac.webkit.org/wiki/LayoutUnit), deciding to round the precision of the CSS properties to 4 places.