### PR TITLE
Change margin collapse guard from padding to display table

### DIFF
--- a/.changeset/quick-rabbits-cheat.md
+++ b/.changeset/quick-rabbits-cheat.md
@@ -1,0 +1,5 @@
+---
+'capsize': patch
+---
+
+Internalise rounding function to remove dependencies

--- a/.changeset/shaggy-comics-leave.md
+++ b/.changeset/shaggy-comics-leave.md
@@ -4,7 +4,7 @@
 
 **Change margin collapse guard from padding to display table**
 
-The styles object returned from `capsize` no longer contains a `padding` property (also removed the `height` property from the psuedo elements). This was previously used to prevent the negative margins from collapsing.
+The styles object returned from `capsize` no longer contains a `padding` property (also removed the `height` property from the pseudo elements). This was previously used to prevent the negative margins from collapsing.
 
 The technique has been swapped out in favour of using `display: table` on the pseudo elements, which also required an inversion of the negative margin direction.
 

--- a/.changeset/shaggy-comics-leave.md
+++ b/.changeset/shaggy-comics-leave.md
@@ -1,0 +1,33 @@
+---
+'capsize': major
+---
+
+**Change margin collapse guard from padding to display table**
+
+The styles object returned from `capsize` no longer contains a `padding` property (also removed the `height` property from the psuedo elements). This was previously used to prevent the negative margins from collapsing.
+
+The technique has been swapped out in favour of using `display: table` on the pseudo elements, which also required an inversion of the negative margin direction.
+
+```diff
+{
+  "fontSize": "67.5165px",
+  "lineHeight": "72px",
+-  "padding": "0.05px 0",
+  "::before": {
+    "content": "''",
++    "marginBottom": "-0.1648em",
++    "display": "table",
+-    "marginTop": "-0.1648em",
+-    "display": "block",
+-    "height": 0
+  },
+  "::after": {
+    "content": "''",
++    "marginTop": "-0.1921em",
++    "display": "table",
+-    "marginBottom": "-0.1921em",
+-    "display": "block",
+-    "height": 0
+  }
+}
+```

--- a/packages/capsize/package.json
+++ b/packages/capsize/package.json
@@ -32,9 +32,7 @@
     "leading"
   ],
   "license": "MIT",
-  "dependencies": {
-    "round-to": "^4.1.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "^7.13.8",
     "@storybook/addon-actions": "^6.1.20",

--- a/packages/capsize/src/index.ts
+++ b/packages/capsize/src/index.ts
@@ -11,18 +11,15 @@ export interface FontMetrics {
 export interface CapsizeStyles {
   fontSize: string;
   lineHeight: string;
-  padding: string;
   '::before': {
-    content: string;
-    marginTop: string;
-    display: string;
-    height: number;
-  };
-  '::after': {
     content: string;
     marginBottom: string;
     display: string;
-    height: number;
+  };
+  '::after': {
+    content: string;
+    marginTop: string;
+    display: string;
   };
 }
 
@@ -49,8 +46,6 @@ type FontSizeWithLineGap = {
   lineGap: number;
   fontMetrics: FontMetrics;
 };
-
-const preventCollapse = 0.05;
 
 export type CapsizeOptions =
   | CapHeightWithLineGap
@@ -143,29 +138,26 @@ function createCss({
     : 0;
 
   const leadingTrim = (value: number) =>
-    value - toScale(specifiedLineHeightOffset) + toScale(preventCollapse);
+    value - toScale(specifiedLineHeightOffset);
 
   return {
     fontSize: `${roundTo(fontSize, PRECISION)}px`,
     lineHeight: lineHeight ? `${roundTo(lineHeight, PRECISION)}px` : 'normal',
-    padding: `${preventCollapse}px 0`,
     '::before': {
       content: "''",
-      marginTop: `${roundTo(
+      marginBottom: `${roundTo(
         leadingTrim(ascentScale - capHeightScale + lineGapScale / 2) * -1,
         PRECISION,
       )}em`,
-      display: 'block',
-      height: 0,
+      display: 'table',
     },
     '::after': {
       content: "''",
-      marginBottom: `${roundTo(
+      marginTop: `${roundTo(
         leadingTrim(descentScale + lineGapScale / 2) * -1,
         PRECISION,
       )}em`,
-      display: 'block',
-      height: 0,
+      display: 'table',
     },
   };
 }

--- a/packages/capsize/src/index.ts
+++ b/packages/capsize/src/index.ts
@@ -1,4 +1,26 @@
-import roundTo from 'round-to';
+// adapted from https://github.com/sindresorhus/round-to
+function roundTo(number: number, precision: number) {
+  if (typeof number !== 'number') {
+    throw new TypeError('Expected value to be a number');
+  }
+
+  if (precision === Infinity) {
+    return number;
+  }
+
+  if (!Number.isInteger(precision)) {
+    throw new TypeError('Expected precision to be an integer');
+  }
+
+  const isNegative = number < 0;
+  const inputNumber = isNegative ? Math.abs(number) : number;
+
+  const power = 10 ** precision;
+  const result =
+    Math.round(Number((inputNumber * power).toPrecision(15))) / power;
+
+  return isNegative ? -result : result;
+}
 
 export interface FontMetrics {
   ascent: number;

--- a/packages/capsize/src/renderToStyleRules.ts
+++ b/packages/capsize/src/renderToStyleRules.ts
@@ -1,0 +1,33 @@
+import capsize from '.';
+
+export default (
+  capsizeStyles: ReturnType<typeof capsize>,
+  ruleName: string,
+) => {
+  const {
+    '::before': beforePseudo,
+    '::after': afterPseudo,
+    ...rootStyles
+  } = capsizeStyles;
+
+  const objToCSSRules = <Property extends string>(
+    stylesObj: Record<Property, string>,
+    psuedoName?: string,
+  ) => `
+.${ruleName}${psuedoName ? `::${psuedoName}` : ''} {
+${Object.keys(stylesObj)
+  .map(
+    (property) =>
+      `  ${property.replace(/[A-Z]/g, '-$&').toLowerCase()}: ${stylesObj[
+        property as keyof typeof stylesObj
+      ].replace(/'/g, '"')}`,
+  )
+  .join(';\n')};
+}`;
+
+  return [
+    objToCSSRules(rootStyles),
+    objToCSSRules(beforePseudo, 'before'),
+    objToCSSRules(afterPseudo, 'after'),
+  ].join('\n');
+};

--- a/packages/capsize/src/stories/tests.stories.ts
+++ b/packages/capsize/src/stories/tests.stories.ts
@@ -17,6 +17,36 @@ const metrics = {
   unitsPerEm: 2048,
 };
 
+const convertToCSS = (capsizeStyles: ReturnType<typeof capsize>) => {
+  const {
+    '::before': beforePseudo,
+    '::after': afterPseudo,
+    ...rootStyles
+  } = capsizeStyles;
+
+  const objToCSSRules = <Property extends string>(
+    stylesObj: Record<Property, string>,
+    ruleName: string,
+    psuedoName?: string,
+  ) => `
+.${ruleName}${psuedoName ? `::${psuedoName}` : ''} {
+${Object.keys(stylesObj)
+  .map(
+    (property) =>
+      `  ${property.replace(/[A-Z]/g, '-$&').toLowerCase()}: ${stylesObj[
+        property as keyof typeof stylesObj
+      ].replace(/'/g, '"')}`,
+  )
+  .join(';\n')};
+}`;
+
+  return [
+    objToCSSRules(rootStyles, className),
+    objToCSSRules(beforePseudo, className, 'before'),
+    objToCSSRules(afterPseudo, className, 'after'),
+  ].join('\n');
+};
+
 const createStyles = (
   fontFamily: string,
   capsizeStyles: ReturnType<typeof capsize>,
@@ -24,31 +54,9 @@ const createStyles = (
 <style>
   * {
     color: #1a365d;
-  }
-  .${className} {
     font-family: ${fontFamily};
-    font-size: ${capsizeStyles.fontSize};${
-  'lineHeight' in capsizeStyles
-    ? `
-    line-height: ${capsizeStyles.lineHeight};`
-    : ''
-}
-    padding: ${capsizeStyles.padding};
   }
-
-  .${className}::before {	
-    content: "";	
-    margin-top: ${capsizeStyles['::before'].marginTop};	
-    display: ${capsizeStyles['::before'].display};	
-    height: ${capsizeStyles['::before'].height};	
-  }
-
-  .${className}::after {	
-    content: "";	
-    margin-bottom: ${capsizeStyles['::after'].marginBottom};	
-    display: ${capsizeStyles['::after'].display};	
-    height: ${capsizeStyles['::after'].height};	
-  }
+  ${convertToCSS(capsizeStyles)}
 </style>
 `;
 

--- a/packages/capsize/src/stories/tests.stories.ts
+++ b/packages/capsize/src/stories/tests.stories.ts
@@ -1,4 +1,5 @@
 import capsize from '../';
+import renderToStyleRules from '../renderToStyleRules';
 
 export default {
   title: 'Examples',
@@ -17,36 +18,6 @@ const metrics = {
   unitsPerEm: 2048,
 };
 
-const convertToCSS = (capsizeStyles: ReturnType<typeof capsize>) => {
-  const {
-    '::before': beforePseudo,
-    '::after': afterPseudo,
-    ...rootStyles
-  } = capsizeStyles;
-
-  const objToCSSRules = <Property extends string>(
-    stylesObj: Record<Property, string>,
-    ruleName: string,
-    psuedoName?: string,
-  ) => `
-.${ruleName}${psuedoName ? `::${psuedoName}` : ''} {
-${Object.keys(stylesObj)
-  .map(
-    (property) =>
-      `  ${property.replace(/[A-Z]/g, '-$&').toLowerCase()}: ${stylesObj[
-        property as keyof typeof stylesObj
-      ].replace(/'/g, '"')}`,
-  )
-  .join(';\n')};
-}`;
-
-  return [
-    objToCSSRules(rootStyles, className),
-    objToCSSRules(beforePseudo, className, 'before'),
-    objToCSSRules(afterPseudo, className, 'after'),
-  ].join('\n');
-};
-
 const createStyles = (
   fontFamily: string,
   capsizeStyles: ReturnType<typeof capsize>,
@@ -56,7 +27,7 @@ const createStyles = (
     color: #1a365d;
     font-family: ${fontFamily};
   }
-  ${convertToCSS(capsizeStyles)}
+  ${renderToStyleRules(capsizeStyles, className)}
 </style>
 `;
 

--- a/site/src/components/OutputCSS.tsx
+++ b/site/src/components/OutputCSS.tsx
@@ -6,31 +6,35 @@ import { useAppState } from './AppStateContext';
 import tabStyles from '../tabStyles';
 import Code from './Code';
 
-const convertToCSS = (capsizeStyles: ReturnType<typeof capsize>) => `
-.capsizedText {
-  font-size: ${capsizeStyles.fontSize};${
-  'lineHeight' in capsizeStyles
-    ? `
-  line-height: ${capsizeStyles.lineHeight};`
-    : ''
-}
-  padding: ${capsizeStyles.padding};
-}
+const convertToCSS = (capsizeStyles: ReturnType<typeof capsize>) => {
+  const {
+    '::before': beforePseudo,
+    '::after': afterPseudo,
+    ...rootStyles
+  } = capsizeStyles;
 
-.capsizedText::before {	
-  content: "";	
-  margin-top: ${capsizeStyles['::before'].marginTop};	
-  display: ${capsizeStyles['::before'].display};	
-  height: ${capsizeStyles['::before'].height};	
-}
+  const objToCSSRules = <Property extends string>(
+    stylesObj: Record<Property, string>,
+    ruleName: string,
+    psuedoName?: string,
+  ) => `
+.${ruleName}${psuedoName ? `::${psuedoName}` : ''} {
+${Object.keys(stylesObj)
+  .map(
+    (property) =>
+      `  ${property.replace(/[A-Z]/g, '-$&').toLowerCase()}: ${stylesObj[
+        property as keyof typeof stylesObj
+      ].replace(/'/g, '"')}`,
+  )
+  .join(';\n')};
+}`;
 
-.capsizedText::after {	
-  content: "";	
-  margin-bottom: ${capsizeStyles['::after'].marginBottom};	
-  display: ${capsizeStyles['::after'].display};	
-  height: ${capsizeStyles['::after'].height};	
-}
-`;
+  return [
+    objToCSSRules(rootStyles, 'capsizedText'),
+    objToCSSRules(beforePseudo, 'capsizedText', 'before'),
+    objToCSSRules(afterPseudo, 'capsizedText', 'after'),
+  ].join('\n');
+};
 
 const OutputCSS = () => {
   const { state } = useAppState();

--- a/site/src/components/OutputCSS.tsx
+++ b/site/src/components/OutputCSS.tsx
@@ -1,40 +1,11 @@
 import React from 'react';
 import { Tabs, TabList, Tab, TabPanels, TabPanel, Box } from '@chakra-ui/core';
 import capsize from 'capsize';
+import renderToStyleRules from 'capsize/src/renderToStyleRules';
 
 import { useAppState } from './AppStateContext';
 import tabStyles from '../tabStyles';
 import Code from './Code';
-
-const convertToCSS = (capsizeStyles: ReturnType<typeof capsize>) => {
-  const {
-    '::before': beforePseudo,
-    '::after': afterPseudo,
-    ...rootStyles
-  } = capsizeStyles;
-
-  const objToCSSRules = <Property extends string>(
-    stylesObj: Record<Property, string>,
-    ruleName: string,
-    psuedoName?: string,
-  ) => `
-.${ruleName}${psuedoName ? `::${psuedoName}` : ''} {
-${Object.keys(stylesObj)
-  .map(
-    (property) =>
-      `  ${property.replace(/[A-Z]/g, '-$&').toLowerCase()}: ${stylesObj[
-        property as keyof typeof stylesObj
-      ].replace(/'/g, '"')}`,
-  )
-  .join(';\n')};
-}`;
-
-  return [
-    objToCSSRules(rootStyles, 'capsizedText'),
-    objToCSSRules(beforePseudo, 'capsizedText', 'before'),
-    objToCSSRules(afterPseudo, 'capsizedText', 'after'),
-  ].join('\n');
-};
 
 const OutputCSS = () => {
   const { state } = useAppState();
@@ -123,7 +94,9 @@ const styles = capsize({
           <Box paddingY={4} paddingX={2} paddingTop={2}>
             <Box overflow="auto">
               <Code language="css">
-                {capsizeStyles ? convertToCSS(capsizeStyles) : ''}
+                {capsizeStyles
+                  ? renderToStyleRules(capsizeStyles, 'capsizedText')
+                  : ''}
               </Code>
             </Box>
           </Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -18782,11 +18782,6 @@ rollup@^1.30.1:
     "@types/node" "*"
     acorn "^7.1.0"
 
-round-to@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/round-to/-/round-to-4.1.0.tgz#148d768d18b2f127f78e6648cb8b0a5943c416bf"
-  integrity sha512-H/4z+4QdWS82iMZ23+5St302Mv2jJws0hUvEogrD6gC8NN6Z5TalDtbg51owCrVy4V/4c8ePvwVLNtlhEfPo5g==
-
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"


### PR DESCRIPTION
The styles object returned from `capsize` no longer contains a `padding` property (also removed the `height` property from the pseudo elements). This was previously used to prevent the negative margins from collapsing.

The technique has been swapped out in favour of using `display: table` on the pseudo elements, which also required an inversion of the negative margin direction.

```diff
{
  "fontSize": "67.5165px",
  "lineHeight": "72px",
-  "padding": "0.05px 0",
  "::before": {
    "content": "''",
+    "marginBottom": "-0.1648em",
+    "display": "table",
-    "marginTop": "-0.1648em",
-    "display": "block",
-    "height": 0
  },
  "::after": {
    "content": "''",
+    "marginTop": "-0.1921em",
+    "display": "table",
-    "marginBottom": "-0.1921em",
-    "display": "block",
-    "height": 0
  }
}
```

Closes https://github.com/seek-oss/capsize/issues/26 and https://github.com/seek-oss/capsize/issues/30