### PR TITLE
Update round.ts to use 6 digit rounding

### DIFF
--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -5,4 +5,4 @@
    Reference: https://trac.webkit.org/wiki/LayoutUnit
    (above wiki also mentions Mozilla - https://trac.webkit.org/wiki/LayoutUnit#Notes)
 */
-export const round = (value: number) => parseFloat(value.toFixed(4));
+export const round = (value: number) => parseFloat(value.toFixed(6));


### PR DESCRIPTION
I've noticed accumulating error for multiple high blocks of differently sized texts (blocks > 100 retina px) Per referenced article, layout engine precision is ~ 0.2 pixel. So for 1000 px block, with 4 digits rounding we have noise of  for em values we going to have 3 calculations: (3x1000x1.0100^2)-(3x1000x1.0099^2) = 0.60597 pixel noise, which is 3 times worse than what layout engine is capable of doing. 6 digit rounding makes much more sense.
In my case I've noticed an improvement from 6 digit rounding. Hope it makes sense.