### PR TITLE
Remove `fullName`, `postscriptName` and `subfamilyName` fields

### DIFF
--- a/.changeset/wet-ads-confess.md
+++ b/.changeset/wet-ads-confess.md
@@ -1,0 +1,22 @@
+---
+'@capsizecss/unpack': minor
+---
+
+Remove `fullName`, `postscriptName` and `subfamilyName` fields
+
+The `fullName`, `postscriptName` and `subfamilyName` data fields were originally returned solely to support the website. These are no longer required, and looking to simplify this data structure in the lead up to version 1.
+
+```diff
+{
+  "familyName": "Abril Fatface",
+-  "fullName": "Abril Fatface",
+-  "postscriptName": "AbrilFatface-Regular",
+-  "subfamilyName": "Regular",
+  "capHeight": 700,
+  "ascent": 1058,
+  "descent": -291,
+  "lineGap": 0,
+  "unitsPerEm": 1000,
+  "xHeight": 476
+}
+```

--- a/packages/metrics/scripts/build.ts
+++ b/packages/metrics/scripts/build.ts
@@ -29,7 +29,7 @@ const buildFiles = async ({
   lineGap,
   unitsPerEm,
   xHeight,
-}: Pick<Font, keyof typeof systemMetrics[0]>) => {
+}: Font) => {
   const fileName = toCamelCase(familyName);
 
   await writeFile(

--- a/packages/unpack/README.md
+++ b/packages/unpack/README.md
@@ -45,18 +45,15 @@ const metrics = await fromFile(filePath);
 
 The font metrics object returned contains the following properties:
 
-| Property       | Type   | Description                                      |
-| -------------- | ------ | ------------------------------------------------ |
-| familyName     | string | Font family name as authored by font creator     |
-| fullName       | string | Font full name as authored by font creator       |
-| postscriptName | string | Postscript name as authored by font creator      |
-| subfamilyName  | string | Subfamily name as authored by font creator       |
-| capHeight      | number | The height of capital letters above the baseline |
-| ascent         | number | The height of the ascenders above baseline       |
-| descent        | number | The descent of the descenders below baseline     |
-| lineGap        | number | The amount of space included between lines       |
-| unitsPerEm     | number | The size of the font’s internal coordinate grid  |
-| xHeight        | number | The height of lower case letters                 |
+| Property   | Type   | Description                                      |
+| ---------- | ------ | ------------------------------------------------ |
+| familyName | string | Font family name as authored by font creator     |
+| capHeight  | number | The height of capital letters above the baseline |
+| ascent     | number | The height of the ascenders above baseline       |
+| descent    | number | The descent of the descenders below baseline     |
+| lineGap    | number | The amount of space included between lines       |
+| unitsPerEm | number | The size of the font’s internal coordinate grid  |
+| xHeight    | number | The height of lower case letters                 |
 
 ## Thanks
 

--- a/packages/unpack/src/index.ts
+++ b/packages/unpack/src/index.ts
@@ -11,17 +11,11 @@ const unpackMetricsFromFont = (font: FontKitFont) => {
     lineGap,
     unitsPerEm,
     familyName,
-    fullName,
-    postscriptName,
-    subfamilyName,
     xHeight,
   } = font;
 
   return {
     familyName,
-    fullName,
-    postscriptName,
-    subfamilyName,
     capHeight,
     ascent,
     descent,

--- a/site/src/components/AppStateContext.tsx
+++ b/site/src/components/AppStateContext.tsx
@@ -179,7 +179,7 @@ function reducer(state: AppState, action: Action): AppState {
 
     case 'UPDATE_FONT': {
       const font = action.value.font;
-      const { familyName, fullName, postscriptName } = action.value.metrics;
+      const { familyName } = action.value.metrics;
       const fileName = 'fileName' in font ? font.fileName : '';
       const extension = 'extension' in font ? font.extension : '';
 
@@ -188,7 +188,7 @@ function reducer(state: AppState, action: Action): AppState {
         metrics: filterInternalMetrics(action.value.metrics),
         selectedFont: {
           ...font,
-          name: familyName || fullName || postscriptName || fileName || '',
+          name: familyName || fileName || '',
           format: resolveFormatFromExtension(extension),
         },
       };

--- a/site/src/components/FontSelector/SystemFontSelector.tsx
+++ b/site/src/components/FontSelector/SystemFontSelector.tsx
@@ -12,21 +12,6 @@ import { detectFont } from 'detect-font';
 import { useAppState } from '../AppStateContext';
 import fontData from '../../../../packages/metrics/scripts/systemFonts.json';
 
-const getMetricsFor = (selectedFontName: string) => {
-  const metrics = fontData.filter(
-    (font) => font.familyName === selectedFontName,
-  )[0];
-
-  return {
-    ...metrics,
-    familyName: metrics.familyName,
-    fullName: metrics.familyName,
-    postscriptName: metrics.familyName,
-    subfamilyName: metrics.familyName,
-    xHeight: 0,
-  };
-};
-
 export default function SystemFontSelector() {
   const { dispatch, state } = useAppState();
   const testRef = useRef<HTMLDivElement | null>(null);
@@ -73,7 +58,9 @@ export default function SystemFontSelector() {
             dispatch({
               type: 'UPDATE_FONT',
               value: {
-                metrics: getMetricsFor(newValue),
+                metrics: fontData.filter(
+                  (font) => font.familyName === newValue,
+                )[0],
                 font: {
                   source: 'SYSTEM_FONT',
                 },

--- a/site/src/components/MetricsPreview.tsx
+++ b/site/src/components/MetricsPreview.tsx
@@ -167,6 +167,10 @@ const MetricsPreview = () => {
           overflow="auto"
           paddingLeft="130px" // cater for arrow offsets
           paddingRight="150px" // cater for arrow offsets
+          paddingTop="40px" // cater for ascender overflow
+          marginTop="-40px" // cater for ascender overflow
+          paddingBottom="60px" // cater for descender overflow
+          marginBottom="-60px" // cater for descender overflow
         >
           <Box d="inline-flex" justifyContent="center" pos="relative">
             <Box


### PR DESCRIPTION
The `fullName`, `postscriptName` and `subfamilyName` data fields were originally returned solely to support the website. These are no longer required, and looking to simplify this data structure in the lead up to version 1.

```diff
{
  "familyName": "Abril Fatface",
-  "fullName": "Abril Fatface",
-  "postscriptName": "AbrilFatface-Regular",
-  "subfamilyName": "Regular",
  "capHeight": 700,
  "ascent": 1058,
  "descent": -291,
  "lineGap": 0,
  "unitsPerEm": 1000,
  "xHeight": 476
}
```

Also fixing an overflow cropping issue with certain fonts on the metrics preview panel.