### PR TITLE
Add `timesNewRoman` metrics

### DIFF
--- a/.changeset/wild-tables-argue.md
+++ b/.changeset/wild-tables-argue.md
@@ -1,0 +1,8 @@
+---
+'@capsizecss/metrics': minor
+---
+
+Add `timesNewRoman` metrics
+
+Provides metrics for the built in system font `Times New Roman`.
+Can be used by importing as `@capsizecss/metrics/timesNewRoman`.

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -6,6 +6,7 @@
     "clean": "ts-node scripts/clean",
     "prebuild": "yarn clean",
     "build": "ts-node scripts/build",
+    "extract-system-metrics": "ts-node scripts/extractSystemFontMetrics",
     "analyse": "ts-node scripts/analyse",
     "download": "ts-node scripts/download"
   },

--- a/packages/metrics/scripts/build.ts
+++ b/packages/metrics/scripts/build.ts
@@ -103,7 +103,6 @@ const buildFiles = async ({
   });
 
   progress.start(googleFonts.items.length + systemMetrics.length, 0);
-  progress.update(systemMetrics.length);
 
   const queue = new PQueue({ concurrency: 10 });
   queue.on('next', () => {

--- a/packages/metrics/scripts/extractSystemFontMetrics.ts
+++ b/packages/metrics/scripts/extractSystemFontMetrics.ts
@@ -1,0 +1,44 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fromFile } from '@capsizecss/unpack';
+
+(async () => {
+  const fontDirectory = process.env.FONT_DIRECTORY;
+
+  if (!fontDirectory) {
+    throw new Error(
+      'FONT_DIRECTORY not found. To run this script you must have a font directory locally containing all of the required system fonts.',
+    );
+  }
+
+  const arial = await fromFile(`${fontDirectory}/Arial.ttf`);
+  const sfPro = await fromFile(`${fontDirectory}/SF-Pro.ttf`);
+  const roboto = await fromFile(`${fontDirectory}/Roboto.ttf`);
+  const segoeui = await fromFile(`${fontDirectory}/SegoeUI.ttf`);
+  const oxygen = await fromFile(`${fontDirectory}/Oxygen.ttf`);
+  const helvetica = await fromFile(`${fontDirectory}/Helvetica.ttf`);
+  const helveticaNeue = await fromFile(`${fontDirectory}/HelveticaNeue.ttf`);
+  const timesNewRoman = await fromFile(`${fontDirectory}/Times New Roman.ttf`);
+
+  const content = JSON.stringify(
+    [
+      arial,
+      { ...sfPro, familyName: '-apple-system', descent: -420 },
+      { ...sfPro, familyName: 'BlinkMacSystemFont', descent: -420 },
+      roboto,
+      segoeui,
+      { ...oxygen, capHeight: 1468, xHeight: 1085 },
+      helvetica,
+      helveticaNeue,
+      timesNewRoman,
+    ],
+    null,
+    2,
+  );
+
+  await fs.writeFile(
+    path.join(__dirname, 'systemFonts.json'),
+    `${content}\n`,
+    'utf-8',
+  );
+})();

--- a/packages/metrics/scripts/systemFonts.json
+++ b/packages/metrics/scripts/systemFonts.json
@@ -24,7 +24,7 @@
     "descent": -420,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xHeight": 1045
+    "xHeight": 1040
   },
   {
     "familyName": "Roboto",
@@ -70,5 +70,14 @@
     "lineGap": 28,
     "unitsPerEm": 1000,
     "xHeight": 517
+  },
+  {
+    "familyName": "Times New Roman",
+    "capHeight": 1356,
+    "ascent": 1825,
+    "descent": -443,
+    "lineGap": 87,
+    "unitsPerEm": 2048,
+    "xHeight": 916
   }
 ]


### PR DESCRIPTION
Provides metrics for the built in system font `Times New Roman`.
Can be used by importing as `@capsizecss/metrics/timesNewRoman`.

#### Additional notes/changes
- Fixes order counting bug on the metrics build script
- Added script for extracting/updating system metrics. To run the script consumers require a directory locally with all the system fonts, and must set the `FONTS_DIRECTORY` env var with the path of the folder. Not expecting others to do this, but wanted to automate the process of updating these and cant commit the system files due to licenses on some of them.