### PR TITLE
Add a comma in example code snippet

### DIFF
--- a/site/src/components/OutputCSS.tsx
+++ b/site/src/components/OutputCSS.tsx
@@ -93,12 +93,12 @@ const styles = createStyleObject({${
               }${
                 lineHeightStyle === 'lineGap'
                   ? `
-  lineGap: ${lineGap}`
+  lineGap: ${lineGap},`
                   : ''
               }${
                 lineHeightStyle === 'leading'
                   ? `
-  leading: ${leading}`
+  leading: ${leading},`
                   : ''
               }
   ${fontMetricsUsage[selectedFont.source]}


### PR DESCRIPTION
There doesn't appear to be a comma after line-gap on the example on the site.

As far as I can tell there is always some value after these lines, so we can just hard-code the commas like previous lines.

Before:
<img width="500" alt="Screen Shot 2022-12-07 at 5 06 26 pm" src="https://user-images.githubusercontent.com/13903378/206176898-c4c30760-8778-4e3f-9c71-e42e2d81f245.png">

After:
<img width="500" alt="Screen Shot 2022-12-07 at 11 18 06 pm" src="https://user-images.githubusercontent.com/13903378/206177676-a2ba380c-23bd-4c8a-b1d6-9e5b4f4e1989.png">
