### PR TITLE
metrics, unpack: Cut v1 release

### DIFF
--- a/.changeset/clever-mangos-clap.md
+++ b/.changeset/clever-mangos-clap.md
@@ -1,0 +1,8 @@
+---
+'@capsizecss/metrics': major
+'@capsizecss/unpack': major
+---
+
+metrics, unpack: Cut v1 release
+
+No actual breaking change here, but cutting the v1 release to mark the packages moving out of experimental phase.


### PR DESCRIPTION
No actual breaking change here, but cutting the v1 release to mark the packages moving out of experimental phase.