### PR TITLE
Add more system fonts

### DIFF
--- a/.changeset/thin-cows-think.md
+++ b/.changeset/thin-cows-think.md
@@ -1,0 +1,7 @@
+---
+'@capsizecss/metrics': patch
+---
+
+oxygen: Refine missing metrics
+
+Refines the missing `capHeight` and `xHeight` metrics to align with anchor co-ordinates of relevant glyphs — `H` for capHeight and `x` for xHeight. Previously these values where subjectively observed using the Capsize website.

--- a/.changeset/tricky-teachers-warn.md
+++ b/.changeset/tricky-teachers-warn.md
@@ -1,0 +1,16 @@
+---
+'@capsizecss/metrics': patch
+---
+
+Add more system fonts
+
+Expands the metrics library to include more system fonts. Fonts added are:
+- `Tahoma`
+- `Lucida Grande`
+- `Verdana`
+- `Trebuchet MS`
+- `Georgia`
+- `Courier New`
+- `Brush Script`
+
+The library now support all the [Best Web Safe Fonts](https://www.w3schools.com/cssref/css_websafe_fonts.php).

--- a/packages/metrics/scripts/extractSystemFontMetrics.ts
+++ b/packages/metrics/scripts/extractSystemFontMetrics.ts
@@ -19,6 +19,13 @@ import { fromFile } from '@capsizecss/unpack';
   const helvetica = await fromFile(`${fontDirectory}/Helvetica.ttf`);
   const helveticaNeue = await fromFile(`${fontDirectory}/HelveticaNeue.ttf`);
   const timesNewRoman = await fromFile(`${fontDirectory}/Times New Roman.ttf`);
+  const tahoma = await fromFile(`${fontDirectory}/Tahoma.ttf`);
+  const lucidaGrande = await fromFile(`${fontDirectory}/LucidaGrande.ttf`);
+  const verdana = await fromFile(`${fontDirectory}/Verdana.ttf`);
+  const trebuchetMS = await fromFile(`${fontDirectory}/Trebuchet MS.ttf`);
+  const georgia = await fromFile(`${fontDirectory}/Georgia.ttf`);
+  const courierNew = await fromFile(`${fontDirectory}/Courier New.ttf`);
+  const brushScript = await fromFile(`${fontDirectory}/Brush Script.ttf`);
 
   const content = JSON.stringify(
     [
@@ -37,11 +44,33 @@ import { fromFile } from '@capsizecss/unpack';
       },
       { ...roboto, category: 'sans-serif' },
       { ...segoeui, category: 'sans-serif' },
-      { ...oxygen, capHeight: 1468, xHeight: 1085, category: 'sans-serif' },
+      { ...oxygen, capHeight: 1479, xHeight: 1097, category: 'sans-serif' },
       { ...helvetica, category: 'sans-serif' },
       { ...helveticaNeue, category: 'sans-serif' },
       { ...timesNewRoman, category: 'serif' },
-    ],
+      { ...tahoma, category: 'sans-serif' },
+      { ...lucidaGrande, category: 'sans-serif' },
+      { ...verdana, category: 'sans-serif' },
+      {
+        ...trebuchetMS,
+        capHeight: 1465,
+        xHeight: 1071,
+        category: 'sans-serif',
+      },
+      { ...georgia, category: 'serif' },
+      { ...courierNew, category: 'monospace' },
+      {
+        ...brushScript,
+        capHeight: 1230,
+        xHeight: 709,
+        category: 'handwriting',
+      },
+    ].sort((a, b) => {
+      const fontA = a.familyName.toUpperCase();
+      const fontB = b.familyName.toUpperCase();
+
+      return fontA < fontB ? -1 : fontA > fontB ? 1 : 0;
+    }),
     null,
     2,
   );

--- a/packages/metrics/scripts/systemFonts.json
+++ b/packages/metrics/scripts/systemFonts.json
@@ -1,16 +1,5 @@
 [
   {
-    "familyName": "Arial",
-    "capHeight": 1467,
-    "ascent": 1854,
-    "descent": -434,
-    "lineGap": 67,
-    "unitsPerEm": 2048,
-    "xHeight": 1062,
-    "xWidthAvg": 904,
-    "category": "sans-serif"
-  },
-  {
     "familyName": "-apple-system",
     "capHeight": 1443,
     "ascent": 1950,
@@ -22,6 +11,17 @@
     "category": "sans-serif"
   },
   {
+    "familyName": "Arial",
+    "capHeight": 1467,
+    "ascent": 1854,
+    "descent": -434,
+    "lineGap": 67,
+    "unitsPerEm": 2048,
+    "xHeight": 1062,
+    "xWidthAvg": 904,
+    "category": "sans-serif"
+  },
+  {
     "familyName": "BlinkMacSystemFont",
     "capHeight": 1443,
     "ascent": 1950,
@@ -30,6 +30,83 @@
     "unitsPerEm": 2048,
     "xHeight": 1040,
     "xWidthAvg": 842,
+    "category": "sans-serif"
+  },
+  {
+    "familyName": "Brush Script MT",
+    "capHeight": 1230,
+    "ascent": 1820,
+    "descent": -692,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 709,
+    "xWidthAvg": 655,
+    "category": "handwriting"
+  },
+  {
+    "familyName": "Courier New",
+    "capHeight": 1170,
+    "ascent": 1705,
+    "descent": -615,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 866,
+    "xWidthAvg": 1229,
+    "category": "monospace"
+  },
+  {
+    "familyName": "Georgia",
+    "capHeight": 1419,
+    "ascent": 1878,
+    "descent": -449,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 986,
+    "xWidthAvg": 899,
+    "category": "serif"
+  },
+  {
+    "familyName": "Helvetica",
+    "capHeight": 1469,
+    "ascent": 1577,
+    "descent": -471,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1071,
+    "xWidthAvg": 904,
+    "category": "sans-serif"
+  },
+  {
+    "familyName": "Helvetica Neue",
+    "capHeight": 714,
+    "ascent": 952,
+    "descent": -213,
+    "lineGap": 28,
+    "unitsPerEm": 1000,
+    "xHeight": 517,
+    "xWidthAvg": 447,
+    "category": "sans-serif"
+  },
+  {
+    "familyName": "Lucida Grande",
+    "capHeight": 1480,
+    "ascent": 1980,
+    "descent": -432,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1086,
+    "xWidthAvg": 1002,
+    "category": "sans-serif"
+  },
+  {
+    "familyName": "Oxygen",
+    "capHeight": 1479,
+    "ascent": 2103,
+    "descent": -483,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1097,
+    "xWidthAvg": 918,
     "category": "sans-serif"
   },
   {
@@ -55,36 +132,14 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Oxygen",
-    "capHeight": 1468,
-    "ascent": 2103,
-    "descent": -483,
+    "familyName": "Tahoma",
+    "capHeight": 1489,
+    "ascent": 2049,
+    "descent": -423,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xHeight": 1085,
-    "xWidthAvg": 918,
-    "category": "sans-serif"
-  },
-  {
-    "familyName": "Helvetica",
-    "capHeight": 1469,
-    "ascent": 1577,
-    "descent": -471,
-    "lineGap": 0,
-    "unitsPerEm": 2048,
-    "xHeight": 1071,
-    "xWidthAvg": 904,
-    "category": "sans-serif"
-  },
-  {
-    "familyName": "Helvetica Neue",
-    "capHeight": 714,
-    "ascent": 952,
-    "descent": -213,
-    "lineGap": 28,
-    "unitsPerEm": 1000,
-    "xHeight": 517,
-    "xWidthAvg": 447,
+    "xHeight": 1117,
+    "xWidthAvg": 912,
     "category": "sans-serif"
   },
   {
@@ -97,5 +152,27 @@
     "xHeight": 916,
     "xWidthAvg": 819,
     "category": "serif"
+  },
+  {
+    "familyName": "Trebuchet MS",
+    "capHeight": 1465,
+    "ascent": 1923,
+    "descent": -455,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1071,
+    "xWidthAvg": 929,
+    "category": "sans-serif"
+  },
+  {
+    "familyName": "Verdana",
+    "capHeight": 1489,
+    "ascent": 2059,
+    "descent": -430,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1117,
+    "xWidthAvg": 1041,
+    "category": "sans-serif"
   }
 ]

--- a/site/@types/detect-font.d.ts
+++ b/site/@types/detect-font.d.ts
@@ -1,3 +1,9 @@
 declare module 'detect-font' {
-  function detectFont(el: HTMLElement): string | false;
+  interface Options {
+    text?: string;
+    fontSize?: number;
+    baseFont?: string;
+  }
+
+  function detectFont(el: HTMLElement, opts?: Options): string | false;
 }

--- a/site/src/components/FontSelector/SystemFontSelector.tsx
+++ b/site/src/components/FontSelector/SystemFontSelector.tsx
@@ -28,7 +28,12 @@ export default function SystemFontSelector() {
 
   useEffect(() => {
     if (state.selectedFont.name && testRef.current) {
-      const wrongSystem = detectFont(testRef.current) === false;
+      const wrongSystem =
+        detectFont(testRef.current, {
+          // Switching the base font for comparison to ensure default `monospace` fonts are not compared with themselves.
+          baseFont:
+            state.metrics.category === 'monospace' ? 'serif' : 'monospace',
+        }) === false;
 
       setMessage(
         wrongSystem


### PR DESCRIPTION
Expands the metrics library to include more system fonts. Fonts added are:
- `Tahoma`
- `Lucida Grande`
- `Verdana`
- `Trebuchet MS`
- `Georgia`
- `Courier New`
- `Brush Script`

The library now support all the [Best Web Safe Fonts](https://www.w3schools.com/cssref/css_websafe_fonts.php).