### PR TITLE
Fix Changesets PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Deploy site & create release PR or publish to npm
         uses: changesets/action@c2918239208f2162b9d27a87f491375c51592434
         with:
+          version: pnpm run version
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "manypkg check && prettier --check . && tsc",
     "build": "preconstruct build && pnpm metrics:build",
     "copy-readme": "node scripts/copy-readme",
+    "version": "changeset version && pnpm install --lockfile-only",
     "prepare-release": "pnpm copy-readme && pnpm build",
     "release": "pnpm prepare-release && pnpm site:build && pnpm site:deploy && changeset publish",
     "chromatic": "chromatic",


### PR DESCRIPTION
Running an install as part of the version process to fix lock file issues on Version Package PR.

```bash
 ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date
```

This makes the repo workflow consistent with our other packages/repos too.