### PR TITLE
Expose new `entireMetricsCollection` and `fontFamilyToCamelCase` APIs

### DIFF
--- a/.changeset/ninety-dodos-sparkle.md
+++ b/.changeset/ninety-dodos-sparkle.md
@@ -1,0 +1,14 @@
+---
+'@capsizecss/metrics': minor
+---
+
+**fontFamilyToCamelCase**: Expose utility to convert family name to import name
+
+A helper function to support tooling that needs to convert the font family name to the correct casing for the relevant metrics import.
+
+```ts
+import { fontFamilyToCamelCase } from '@capsizecss/metrics';
+
+const familyName = fontFamilyToCamelCase('--apple-system'); // => `appleSystem`
+const metrics = await import(`@capsizecss/metrics/${familyName}`);
+```

--- a/.changeset/yellow-rings-exist.md
+++ b/.changeset/yellow-rings-exist.md
@@ -1,0 +1,21 @@
+---
+'@capsizecss/metrics': minor
+---
+
+**entireMetricsCollection**: Expose all metrics indexed by family name
+
+Provides the entire metrics collection as a JSON object, keyed by font family name.
+
+---
+
+**⚠️ CAUTION: Importing this will result in a _large JSON structure_ being pulled into your project!**
+
+**It is not recommended to use this client side.**
+
+---
+
+```ts
+import { entireMetricsCollection } from '@capsizecss/metrics/entireMetricsCollection';
+
+const metrics = entireMetricsCollection['arial'];
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "jest",
     "format": "prettier --write .",
     "lint": "manypkg check && prettier --check . && tsc",
-    "build": "preconstruct build && pnpm metrics:build",
+    "build": "pnpm metrics:build && preconstruct build",
     "copy-readme": "node scripts/copy-readme",
     "version": "changeset version && pnpm install --lockfile-only",
     "prepare-release": "pnpm copy-readme && pnpm build",
@@ -33,6 +33,7 @@
   "preconstruct": {
     "packages": [
       "packages/core",
+      "packages/metrics",
       "packages/unpack",
       "packages/vanilla-extract"
     ]

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -56,6 +56,37 @@ The font metrics object returned contains the following properties if available:
 [character frequencies]: https://en.wikipedia.org/wiki/Letter_frequency#Relative_frequencies_of_letters_in_other_languages
 [xavgcharwidth]: https://learn.microsoft.com/en-us/typography/opentype/spec/os2#xavgcharwidth
 
+## Supporting APIs
+
+### `fontFamilyToCamelCase`
+
+A helper function to support tooling that needs to convert the font family name to the correct casing for the relevant metrics import.
+
+```ts
+import { fontFamilyToCamelCase } from '@capsizecss/metrics';
+
+const familyName = fontFamilyToCamelCase('--apple-system'); // => `appleSystem`
+const metrics = await import(`@capsizecss/metrics/${familyName}`);
+```
+
+### `entireMetricsCollection`
+
+Provides the entire metrics collection as a JSON object, keyed by font family name.
+
+---
+
+**⚠️ CAUTION: Importing this will result in a _large JSON structure_ being pulled into your project!**
+
+**It is not recommended to use this client side.**
+
+---
+
+```ts
+import { entireMetricsCollection } from '@capsizecss/metrics/entireMetricsCollection';
+
+const metrics = entireMetricsCollection['arial'];
+```
+
 ## Thanks
 
 - [SEEK](https://www.seek.com.au) for giving us the space to do interesting work.

--- a/packages/metrics/entireMetricsCollection/package.json
+++ b/packages/metrics/entireMetricsCollection/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "dist/capsizecss-metrics-entireMetricsCollection.cjs.js",
+  "module": "dist/capsizecss-metrics-entireMetricsCollection.esm.js",
+  "browser": {
+    "./dist/capsizecss-metrics-entireMetricsCollection.cjs.js": "./dist/capsizecss-metrics-entireMetricsCollection.browser.cjs.js",
+    "./dist/capsizecss-metrics-entireMetricsCollection.esm.js": "./dist/capsizecss-metrics-entireMetricsCollection.browser.esm.js"
+  }
+}

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -2,6 +2,22 @@
   "name": "@capsizecss/metrics",
   "version": "1.0.1",
   "description": "Font metrics library for system and Google fonts",
+  "main": "dist/capsizecss-metrics.cjs.js",
+  "module": "dist/capsizecss-metrics.esm.js",
+  "browser": {
+    "./dist/capsizecss-metrics.cjs.js": "./dist/capsizecss-metrics.browser.cjs.js",
+    "./dist/capsizecss-metrics.esm.js": "./dist/capsizecss-metrics.browser.esm.js"
+  },
+  "preconstruct": {
+    "entrypoints": [
+      "index.ts",
+      "entireMetricsCollection.ts"
+    ]
+  },
+  "files": [
+    "/dist",
+    "/entireMetricsCollection"
+  ],
   "scripts": {
     "clean": "ts-node scripts/clean",
     "prebuild": "pnpm clean",

--- a/packages/metrics/src/entireMetricsCollection.json
+++ b/packages/metrics/src/entireMetricsCollection.json
@@ -1,16257 +1,16411 @@
-[
-  {
+{
+  "appleSystem": {
+    "familyName": "-apple-system",
+    "category": "sans-serif",
+    "capHeight": 1443,
+    "ascent": 1950,
+    "descent": -420,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1040,
+    "xWidthAvg": 842
+  },
+  "arial": {
+    "familyName": "Arial",
+    "category": "sans-serif",
+    "capHeight": 1467,
+    "ascent": 1854,
+    "descent": -434,
+    "lineGap": 67,
+    "unitsPerEm": 2048,
+    "xHeight": 1062,
+    "xWidthAvg": 904
+  },
+  "blinkMacSystemFont": {
+    "familyName": "BlinkMacSystemFont",
+    "category": "sans-serif",
+    "capHeight": 1443,
+    "ascent": 1950,
+    "descent": -420,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1040,
+    "xWidthAvg": 842
+  },
+  "brushScriptMT": {
+    "familyName": "Brush Script MT",
+    "category": "handwriting",
+    "capHeight": 1230,
+    "ascent": 1820,
+    "descent": -692,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 709,
+    "xWidthAvg": 655
+  },
+  "courierNew": {
+    "familyName": "Courier New",
+    "category": "monospace",
+    "capHeight": 1170,
+    "ascent": 1705,
+    "descent": -615,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 866,
+    "xWidthAvg": 1229
+  },
+  "georgia": {
+    "familyName": "Georgia",
+    "category": "serif",
+    "capHeight": 1419,
+    "ascent": 1878,
+    "descent": -449,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 986,
+    "xWidthAvg": 899
+  },
+  "helvetica": {
+    "familyName": "Helvetica",
+    "category": "sans-serif",
+    "capHeight": 1469,
+    "ascent": 1577,
+    "descent": -471,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1071,
+    "xWidthAvg": 904
+  },
+  "helveticaNeue": {
+    "familyName": "Helvetica Neue",
+    "category": "sans-serif",
+    "capHeight": 714,
+    "ascent": 952,
+    "descent": -213,
+    "lineGap": 28,
+    "unitsPerEm": 1000,
+    "xHeight": 517,
+    "xWidthAvg": 447
+  },
+  "lucidaGrande": {
+    "familyName": "Lucida Grande",
+    "category": "sans-serif",
+    "capHeight": 1480,
+    "ascent": 1980,
+    "descent": -432,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1086,
+    "xWidthAvg": 1002
+  },
+  "oxygen": {
+    "familyName": "Oxygen",
+    "category": "sans-serif",
+    "ascent": 2103,
+    "descent": -483,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xWidthAvg": 918
+  },
+  "roboto": {
+    "familyName": "Roboto",
+    "category": "sans-serif",
+    "capHeight": 1456,
+    "ascent": 1900,
+    "descent": -500,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1082,
+    "xWidthAvg": 905
+  },
+  "segoeUI": {
+    "familyName": "Segoe UI",
+    "category": "sans-serif",
+    "capHeight": 1434,
+    "ascent": 2210,
+    "descent": -514,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1024,
+    "xWidthAvg": 906
+  },
+  "tahoma": {
+    "familyName": "Tahoma",
+    "category": "sans-serif",
+    "capHeight": 1489,
+    "ascent": 2049,
+    "descent": -423,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1117,
+    "xWidthAvg": 912
+  },
+  "timesNewRoman": {
+    "familyName": "Times New Roman",
+    "category": "serif",
+    "capHeight": 1356,
+    "ascent": 1825,
+    "descent": -443,
+    "lineGap": 87,
+    "unitsPerEm": 2048,
+    "xHeight": 916,
+    "xWidthAvg": 819
+  },
+  "trebuchetMS": {
+    "familyName": "Trebuchet MS",
+    "category": "sans-serif",
+    "capHeight": 1465,
+    "ascent": 1923,
+    "descent": -455,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1071,
+    "xWidthAvg": 929
+  },
+  "verdana": {
+    "familyName": "Verdana",
+    "category": "sans-serif",
+    "capHeight": 1489,
+    "ascent": 2059,
+    "descent": -430,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1117,
+    "xWidthAvg": 1041
+  },
+  "abel": {
     "familyName": "Abel",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 2006,
     "descent": -604,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1044,
-    "xWidthAvg": 780,
-    "category": "sans-serif"
+    "xWidthAvg": 780
   },
-  {
+  "abrilFatface": {
     "familyName": "Abril Fatface",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1058,
     "descent": -291,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 476,
-    "xWidthAvg": 455,
-    "category": "display"
+    "xWidthAvg": 455
   },
-  {
+  "aclonica": {
     "familyName": "Aclonica",
+    "category": "sans-serif",
     "capHeight": 1440,
     "ascent": 1687,
     "descent": -533,
     "lineGap": 101,
     "unitsPerEm": 2048,
     "xHeight": 1155,
-    "xWidthAvg": 1125,
-    "category": "sans-serif"
+    "xWidthAvg": 1125
   },
-  {
+  "acme": {
     "familyName": "Acme",
+    "category": "sans-serif",
     "capHeight": 695,
     "ascent": 959,
     "descent": -307,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 107,
-    "xWidthAvg": 388,
-    "category": "sans-serif"
+    "xWidthAvg": 388
   },
-  {
+  "abyssinicaSIL": {
     "familyName": "Abyssinica SIL",
+    "category": "serif",
     "capHeight": 1108,
     "ascent": 2034,
     "descent": -682,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 983,
-    "xWidthAvg": 973,
-    "category": "serif"
+    "xWidthAvg": 973
   },
-  {
+  "actor": {
     "familyName": "Actor",
+    "category": "sans-serif",
     "capHeight": 682,
     "ascent": 941,
     "descent": -262,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 503,
-    "xWidthAvg": 424,
-    "category": "sans-serif"
+    "xWidthAvg": 424
   },
-  {
+  "adamina": {
     "familyName": "Adamina",
+    "category": "serif",
     "capHeight": 796,
     "ascent": 1072,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 471,
-    "category": "serif"
+    "xWidthAvg": 471
   },
-  {
+  "abhayaLibre": {
     "familyName": "Abhaya Libre",
+    "category": "serif",
     "ascent": 860,
     "descent": -348,
     "lineGap": 0,
     "unitsPerEm": 1024,
-    "xWidthAvg": 414,
-    "category": "serif"
+    "xWidthAvg": 414
   },
-  {
+  "aBeeZee": {
     "familyName": "ABeeZee",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 920,
     "descent": -262,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 480,
-    "category": "sans-serif"
+    "xWidthAvg": 480
   },
-  {
+  "aboreto": {
     "familyName": "Aboreto",
+    "category": "display",
     "capHeight": 700,
     "ascent": 930,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 700,
-    "xWidthAvg": 592,
-    "category": "display"
+    "xWidthAvg": 592
   },
-  {
+  "adventPro": {
     "familyName": "Advent Pro",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 964,
     "descent": -232,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 368,
-    "category": "sans-serif"
+    "xWidthAvg": 368
   },
-  {
+  "aguafinaScript": {
     "familyName": "Aguafina Script",
+    "category": "handwriting",
     "capHeight": 780,
     "ascent": 966,
     "descent": -581,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 356,
-    "xWidthAvg": 287,
-    "category": "handwriting"
+    "xWidthAvg": 287
   },
-  {
+  "aladin": {
     "familyName": "Aladin",
+    "category": "handwriting",
     "capHeight": 387,
     "ascent": 905,
     "descent": -321,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 337,
-    "xWidthAvg": 328,
-    "category": "handwriting"
+    "xWidthAvg": 328
   },
-  {
+  "albertSans": {
     "familyName": "Albert Sans",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 460,
-    "category": "sans-serif"
+    "xWidthAvg": 460
   },
-  {
+  "aldrich": {
     "familyName": "Aldrich",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 1475,
     "descent": -430,
     "lineGap": 98,
     "unitsPerEm": 2048,
     "xHeight": 1065,
-    "xWidthAvg": 1052,
-    "category": "sans-serif"
+    "xWidthAvg": 1052
   },
-  {
+  "alatsi": {
     "familyName": "Alatsi",
+    "category": "sans-serif",
     "capHeight": 1394,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 996,
-    "xWidthAvg": 860,
-    "category": "sans-serif"
+    "xWidthAvg": 860
   },
-  {
+  "akshar": {
     "familyName": "Akshar",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 990,
     "descent": -390,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 382,
-    "category": "sans-serif"
+    "xWidthAvg": 382
   },
-  {
+  "akronim": {
     "familyName": "Akronim",
+    "category": "display",
     "capHeight": 730,
     "ascent": 785,
     "descent": -314,
     "lineGap": 43,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 327,
-    "category": "display"
+    "xWidthAvg": 327
   },
-  {
+  "akayaKanadaka": {
     "familyName": "Akaya Kanadaka",
+    "category": "display",
     "capHeight": 634,
     "ascent": 920,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 396,
-    "xWidthAvg": 406,
-    "category": "display"
+    "xWidthAvg": 406
   },
-  {
+  "alef": {
     "familyName": "Alef",
+    "category": "sans-serif",
     "capHeight": 1438,
     "ascent": 2067,
     "descent": -722,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1040,
-    "xWidthAvg": 934,
-    "category": "sans-serif"
+    "xWidthAvg": 934
   },
-  {
+  "akayaTelivigala": {
     "familyName": "Akaya Telivigala",
+    "category": "display",
     "capHeight": 613,
     "ascent": 920,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 409,
-    "category": "display"
+    "xWidthAvg": 409
   },
-  {
+  "alata": {
     "familyName": "Alata",
+    "category": "sans-serif",
     "capHeight": 735,
     "ascent": 1100,
     "descent": -280,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 459,
-    "xWidthAvg": 453,
-    "category": "sans-serif"
+    "xWidthAvg": 453
   },
-  {
+  "alegreya": {
     "familyName": "Alegreya",
+    "category": "serif",
     "capHeight": 637,
     "ascent": 1016,
     "descent": -345,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 452,
-    "xWidthAvg": 404,
-    "category": "serif"
+    "xWidthAvg": 404
   },
-  {
+  "aleo": {
     "familyName": "Aleo",
+    "category": "serif",
     "capHeight": 716,
     "ascent": 805,
     "descent": -195,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 446,
-    "category": "serif"
+    "xWidthAvg": 446
   },
-  {
+  "alexBrush": {
     "familyName": "Alex Brush",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 825,
     "descent": -425,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 316,
-    "category": "handwriting"
+    "xWidthAvg": 316
   },
-  {
+  "alegreyaSans": {
     "familyName": "Alegreya Sans",
+    "category": "sans-serif",
     "capHeight": 641,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 458,
-    "xWidthAvg": 384,
-    "category": "sans-serif"
+    "xWidthAvg": 384
   },
-  {
+  "alegreyaSansSC": {
     "familyName": "Alegreya Sans SC",
+    "category": "sans-serif",
     "capHeight": 641,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 458,
-    "xWidthAvg": 428,
-    "category": "sans-serif"
+    "xWidthAvg": 428
   },
-  {
+  "alfaSlabOne": {
     "familyName": "Alfa Slab One",
+    "category": "display",
     "capHeight": 778,
     "ascent": 1036,
     "descent": -333,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 556,
-    "xWidthAvg": 535,
-    "category": "display"
+    "xWidthAvg": 535
   },
-  {
+  "alexandria": {
     "familyName": "Alexandria",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 968,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 531,
-    "xWidthAvg": 501,
-    "category": "sans-serif"
+    "xWidthAvg": 501
   },
-  {
+  "alice": {
     "familyName": "Alice",
+    "category": "serif",
     "capHeight": 631,
     "ascent": 909,
     "descent": -234,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 453,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "alike": {
     "familyName": "Alike",
+    "category": "serif",
     "capHeight": 705,
     "ascent": 984,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "alegreyaSC": {
     "familyName": "Alegreya SC",
+    "category": "serif",
     "capHeight": 636,
     "ascent": 1016,
     "descent": -345,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 452,
-    "xWidthAvg": 466,
-    "category": "serif"
+    "xWidthAvg": 466
   },
-  {
+  "alikeAngular": {
     "familyName": "Alike Angular",
+    "category": "serif",
     "capHeight": 705,
     "ascent": 984,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "allertaStencil": {
     "familyName": "Allerta Stencil",
+    "category": "sans-serif",
     "capHeight": 737,
     "ascent": 1057,
     "descent": -252,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 564,
-    "xWidthAvg": 520,
-    "category": "sans-serif"
+    "xWidthAvg": 520
   },
-  {
+  "allerta": {
     "familyName": "Allerta",
+    "category": "sans-serif",
     "capHeight": 737,
     "ascent": 1057,
     "descent": -252,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 564,
-    "xWidthAvg": 520,
-    "category": "sans-serif"
+    "xWidthAvg": 520
   },
-  {
+  "allan": {
     "familyName": "Allan",
+    "category": "display",
     "capHeight": 1483,
     "ascent": 1928,
     "descent": -412,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1040,
-    "xWidthAvg": 630,
-    "category": "display"
+    "xWidthAvg": 630
   },
-  {
+  "alkalami": {
     "familyName": "Alkalami",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 1035,
     "descent": -857,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 430,
-    "xWidthAvg": 435,
-    "category": "serif"
+    "xWidthAvg": 435
   },
-  {
+  "allison": {
     "familyName": "Allison",
+    "category": "handwriting",
     "capHeight": 630,
     "ascent": 890,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 220,
-    "xWidthAvg": 229,
-    "category": "handwriting"
+    "xWidthAvg": 229
   },
-  {
+  "allura": {
     "familyName": "Allura",
+    "category": "handwriting",
     "capHeight": 590,
     "ascent": 800,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 295,
-    "xWidthAvg": 325,
-    "category": "handwriting"
+    "xWidthAvg": 325
   },
-  {
+  "almarai": {
     "familyName": "Almarai",
+    "category": "sans-serif",
     "capHeight": 716,
     "ascent": 905,
     "descent": -211,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "almendraSC": {
     "familyName": "Almendra SC",
+    "category": "serif",
     "capHeight": 271,
     "ascent": 939,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 193,
-    "xWidthAvg": 440,
-    "category": "serif"
+    "xWidthAvg": 440
   },
-  {
+  "almendraDisplay": {
     "familyName": "Almendra Display",
+    "category": "display",
     "capHeight": 666,
     "ascent": 951,
     "descent": -345,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 405,
-    "category": "display"
+    "xWidthAvg": 405
   },
-  {
+  "almendra": {
     "familyName": "Almendra",
+    "category": "serif",
     "capHeight": 666,
     "ascent": 951,
     "descent": -345,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 404,
-    "category": "serif"
+    "xWidthAvg": 404
   },
-  {
+  "alumniSans": {
     "familyName": "Alumni Sans",
+    "category": "sans-serif",
     "capHeight": 591,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 299,
-    "category": "sans-serif"
+    "xWidthAvg": 299
   },
-  {
+  "alumniSansInlineOne": {
     "familyName": "Alumni Sans Inline One",
+    "category": "display",
     "capHeight": 591,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 322,
-    "category": "display"
+    "xWidthAvg": 322
   },
-  {
+  "alumniSansPinstripe": {
     "familyName": "Alumni Sans Pinstripe",
+    "category": "sans-serif",
     "capHeight": 591,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 289,
-    "category": "sans-serif"
+    "xWidthAvg": 289
   },
-  {
+  "alumniSansCollegiateOne": {
     "familyName": "Alumni Sans Collegiate One",
+    "category": "sans-serif",
     "capHeight": 591,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 305,
-    "category": "sans-serif"
+    "xWidthAvg": 305
   },
-  {
+  "amaranth": {
     "familyName": "Amaranth",
+    "category": "sans-serif",
     "capHeight": 677,
     "ascent": 976,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "amarante": {
     "familyName": "Amarante",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1010,
-    "xWidthAvg": 906,
-    "category": "display"
+    "xWidthAvg": 906
   },
-  {
+  "amethysta": {
     "familyName": "Amethysta",
+    "category": "serif",
     "capHeight": 1475,
     "ascent": 2022,
     "descent": -563,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 1003,
-    "category": "serif"
+    "xWidthAvg": 1003
   },
-  {
+  "amaticSC": {
     "familyName": "Amatic SC",
+    "category": "handwriting",
     "capHeight": 754,
     "ascent": 1016,
     "descent": -245,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 659,
-    "xWidthAvg": 287,
-    "category": "handwriting"
+    "xWidthAvg": 287
   },
-  {
+  "amiko": {
     "familyName": "Amiko",
+    "category": "sans-serif",
     "capHeight": 696,
     "ascent": 928,
     "descent": -406,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 522,
-    "xWidthAvg": 498,
-    "category": "sans-serif"
+    "xWidthAvg": 498
   },
-  {
+  "anaheim": {
     "familyName": "Anaheim",
+    "category": "sans-serif",
     "ascent": 1968,
     "descent": -672,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 863,
-    "category": "sans-serif"
+    "xWidthAvg": 863
   },
-  {
+  "amiri": {
     "familyName": "Amiri",
+    "category": "serif",
     "capHeight": 646,
     "ascent": 1124,
     "descent": -634,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 433,
-    "xWidthAvg": 401,
-    "category": "serif"
+    "xWidthAvg": 401
   },
-  {
+  "amiriQuran": {
     "familyName": "Amiri Quran",
+    "category": "serif",
     "capHeight": 646,
     "ascent": 1815,
     "descent": -634,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 433,
-    "xWidthAvg": 401,
-    "category": "serif"
+    "xWidthAvg": 401
   },
-  {
+  "andadaPro": {
     "familyName": "Andada Pro",
+    "category": "serif",
     "capHeight": 705,
     "ascent": 942,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 494,
-    "xWidthAvg": 453,
-    "category": "serif"
+    "xWidthAvg": 453
   },
-  {
+  "amita": {
     "familyName": "Amita",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 1292,
     "descent": -650,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 446,
-    "category": "handwriting"
+    "xWidthAvg": 446
   },
-  {
+  "anekBangla": {
     "familyName": "Anek Bangla",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 2500,
     "descent": -1232,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 827,
-    "category": "sans-serif"
+    "xWidthAvg": 827
   },
-  {
+  "andika": {
     "familyName": "Andika",
+    "category": "sans-serif",
     "capHeight": 1485,
     "ascent": 2500,
     "descent": -800,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1040,
-    "xWidthAvg": 946,
-    "category": "sans-serif"
+    "xWidthAvg": 946
   },
-  {
+  "anekGurmukhi": {
     "familyName": "Anek Gurmukhi",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 1500,
     "descent": -900,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 494,
-    "xWidthAvg": 863,
-    "category": "sans-serif"
+    "xWidthAvg": 863
   },
-  {
+  "anekGujarati": {
     "familyName": "Anek Gujarati",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 1975,
     "descent": -1064,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 835,
-    "category": "sans-serif"
+    "xWidthAvg": 835
   },
-  {
+  "anekDevanagari": {
     "familyName": "Anek Devanagari",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 2026,
     "descent": -1385,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 839,
-    "category": "sans-serif"
+    "xWidthAvg": 839
   },
-  {
+  "anekKannada": {
     "familyName": "Anek Kannada",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 2030,
     "descent": -1310,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 849,
-    "category": "sans-serif"
+    "xWidthAvg": 849
   },
-  {
+  "anekTamil": {
     "familyName": "Anek Tamil",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 1963,
     "descent": -853,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 863,
-    "category": "sans-serif"
+    "xWidthAvg": 863
   },
-  {
+  "anekOdia": {
     "familyName": "Anek Odia",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 1960,
     "descent": -1400,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 838,
-    "category": "sans-serif"
+    "xWidthAvg": 838
   },
-  {
+  "anekLatin": {
     "familyName": "Anek Latin",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 1800,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 838,
-    "category": "sans-serif"
+    "xWidthAvg": 838
   },
-  {
+  "anekMalayalam": {
     "familyName": "Anek Malayalam",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 2035,
     "descent": -830,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 849,
-    "category": "sans-serif"
+    "xWidthAvg": 849
   },
-  {
+  "angkor": {
     "familyName": "Angkor",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1174,
-    "category": "display"
+    "xWidthAvg": 1174
   },
-  {
+  "anekTelugu": {
     "familyName": "Anek Telugu",
+    "category": "sans-serif",
     "capHeight": 1278,
     "ascent": 1800,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 978,
-    "xWidthAvg": 846,
-    "category": "sans-serif"
+    "xWidthAvg": 846
   },
-  {
+  "annieUseYourTelescope": {
     "familyName": "Annie Use Your Telescope",
+    "category": "handwriting",
     "capHeight": 730,
     "ascent": 1049,
     "descent": -419,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 427,
-    "xWidthAvg": 357,
-    "category": "handwriting"
+    "xWidthAvg": 357
   },
-  {
+  "antic": {
     "familyName": "Antic",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 940,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 429,
-    "category": "sans-serif"
+    "xWidthAvg": 429
   },
-  {
+  "anonymousPro": {
     "familyName": "Anonymous Pro",
+    "category": "monospace",
     "capHeight": 1305,
     "ascent": 1675,
     "descent": -373,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 932,
-    "xWidthAvg": 1118,
-    "category": "monospace"
+    "xWidthAvg": 1118
   },
-  {
+  "anticDidone": {
     "familyName": "Antic Didone",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 940,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 475,
-    "category": "serif"
+    "xWidthAvg": 475
   },
-  {
+  "antonio": {
     "familyName": "Antonio",
+    "category": "sans-serif",
     "capHeight": 1760,
     "ascent": 2365,
     "descent": -285,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1500,
-    "xWidthAvg": 768,
-    "category": "sans-serif"
+    "xWidthAvg": 768
   },
-  {
+  "anticSlab": {
     "familyName": "Antic Slab",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 940,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 475,
-    "category": "serif"
+    "xWidthAvg": 475
   },
-  {
+  "anybody": {
     "familyName": "Anybody",
+    "category": "display",
     "capHeight": 1350,
     "ascent": 1590,
     "descent": -480,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1200,
-    "xWidthAvg": 988,
-    "category": "display"
+    "xWidthAvg": 988
   },
-  {
+  "anton": {
     "familyName": "Anton",
+    "category": "sans-serif",
     "capHeight": 1760,
     "ascent": 2409,
     "descent": -674,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1500,
-    "xWidthAvg": 832,
-    "category": "sans-serif"
+    "xWidthAvg": 832
   },
-  {
+  "arapey": {
     "familyName": "Arapey",
+    "category": "serif",
     "capHeight": 639,
     "ascent": 868,
     "descent": -228,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 438,
-    "xWidthAvg": 399,
-    "category": "serif"
+    "xWidthAvg": 399
   },
-  {
+  "arbutus": {
     "familyName": "Arbutus",
+    "category": "display",
     "capHeight": 103,
     "ascent": 2010,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 234,
-    "xWidthAvg": 1299,
-    "category": "display"
+    "xWidthAvg": 1299
   },
-  {
+  "arbutusSlab": {
     "familyName": "Arbutus Slab",
+    "category": "serif",
     "capHeight": 1500,
     "ascent": 2010,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1014,
-    "xWidthAvg": 1012,
-    "category": "serif"
+    "xWidthAvg": 1012
   },
-  {
+  "architectsDaughter": {
     "familyName": "Architects Daughter",
+    "category": "handwriting",
     "capHeight": 675,
     "ascent": 1010,
     "descent": -413,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 439,
-    "xWidthAvg": 486,
-    "category": "handwriting"
+    "xWidthAvg": 486
   },
-  {
+  "archivo": {
     "familyName": "Archivo",
+    "category": "sans-serif",
     "capHeight": 686,
     "ascent": 878,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 526,
-    "xWidthAvg": 433,
-    "category": "sans-serif"
+    "xWidthAvg": 433
   },
-  {
+  "archivoNarrow": {
     "familyName": "Archivo Narrow",
+    "category": "sans-serif",
     "capHeight": 686,
     "ascent": 1035,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 526,
-    "xWidthAvg": 364,
-    "category": "sans-serif"
+    "xWidthAvg": 364
   },
-  {
+  "archivoBlack": {
     "familyName": "Archivo Black",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 878,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 528,
-    "xWidthAvg": 551,
-    "category": "sans-serif"
+    "xWidthAvg": 551
   },
-  {
+  "areYouSerious": {
     "familyName": "Are You Serious",
+    "category": "handwriting",
     "capHeight": 660,
     "ascent": 880,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 307,
-    "category": "handwriting"
+    "xWidthAvg": 307
   },
-  {
+  "arefRuqaa": {
     "familyName": "Aref Ruqaa",
+    "category": "serif",
     "capHeight": 683,
     "ascent": 1221,
     "descent": -244,
     "lineGap": 98,
     "unitsPerEm": 1000,
     "xHeight": 462,
-    "xWidthAvg": 430,
-    "category": "serif"
+    "xWidthAvg": 430
   },
-  {
+  "arimaMadurai": {
     "familyName": "Arima Madurai",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1073,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 509,
-    "xWidthAvg": 443,
-    "category": "display"
+    "xWidthAvg": 443
   },
-  {
+  "arima": {
     "familyName": "Arima",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1073,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 447,
-    "category": "display"
+    "xWidthAvg": 447
   },
-  {
+  "arefRuqaaInk": {
     "familyName": "Aref Ruqaa Ink",
+    "category": "serif",
     "capHeight": 683,
     "ascent": 1221,
     "descent": -244,
     "lineGap": 98,
     "unitsPerEm": 1000,
     "xHeight": 462,
-    "xWidthAvg": 430,
-    "category": "serif"
+    "xWidthAvg": 430
   },
-  {
+  "arimo": {
     "familyName": "Arimo",
+    "category": "sans-serif",
     "capHeight": 1409,
     "ascent": 1854,
     "descent": -434,
     "lineGap": 67,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 904,
-    "category": "sans-serif"
+    "xWidthAvg": 904
   },
-  {
+  "arvo": {
     "familyName": "Arvo",
+    "category": "serif",
     "capHeight": 1516,
     "ascent": 1968,
     "descent": -506,
     "lineGap": 55,
     "unitsPerEm": 2048,
     "xHeight": 1036,
-    "xWidthAvg": 991,
-    "category": "serif"
+    "xWidthAvg": 991
   },
-  {
+  "armata": {
     "familyName": "Armata",
+    "category": "sans-serif",
     "capHeight": 1530,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1190,
-    "xWidthAvg": 1080,
-    "category": "sans-serif"
+    "xWidthAvg": 1080
   },
-  {
+  "artifika": {
     "familyName": "Artifika",
+    "category": "serif",
     "capHeight": 1433,
     "ascent": 1984,
     "descent": -508,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1045,
-    "xWidthAvg": 1073,
-    "category": "serif"
+    "xWidthAvg": 1073
   },
-  {
+  "arizonia": {
     "familyName": "Arizonia",
+    "category": "handwriting",
     "capHeight": 660,
     "ascent": 900,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 280,
-    "xWidthAvg": 349,
-    "category": "handwriting"
+    "xWidthAvg": 349
   },
-  {
+  "asap": {
     "familyName": "Asap",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 934,
     "descent": -212,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 523,
-    "xWidthAvg": 441,
-    "category": "sans-serif"
+    "xWidthAvg": 441
   },
-  {
+  "asapCondensed": {
     "familyName": "Asap Condensed",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 934,
     "descent": -212,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 523,
-    "xWidthAvg": 360,
-    "category": "sans-serif"
+    "xWidthAvg": 360
   },
-  {
+  "arya": {
     "familyName": "Arya",
+    "category": "sans-serif",
     "capHeight": 579,
     "ascent": 1265,
     "descent": -544,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 392,
-    "xWidthAvg": 422,
-    "category": "sans-serif"
+    "xWidthAvg": 422
   },
-  {
+  "arsenal": {
     "familyName": "Arsenal",
+    "category": "sans-serif",
     "capHeight": 650,
     "ascent": 1000,
     "descent": -254,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 396,
-    "category": "sans-serif"
+    "xWidthAvg": 396
   },
-  {
+  "asset": {
     "familyName": "Asset",
+    "category": "display",
     "capHeight": 1291,
     "ascent": 1971,
     "descent": -589,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1047,
-    "xWidthAvg": 2292,
-    "category": "display"
+    "xWidthAvg": 2292
   },
-  {
+  "asul": {
     "familyName": "Asul",
+    "category": "sans-serif",
     "capHeight": 703,
     "ascent": 949,
     "descent": -264,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 441,
-    "category": "sans-serif"
+    "xWidthAvg": 441
   },
-  {
+  "astloch": {
     "familyName": "Astloch",
+    "category": "display",
     "capHeight": 1567,
     "ascent": 1948,
     "descent": -526,
     "lineGap": 53,
     "unitsPerEm": 2048,
     "xHeight": 1200,
-    "xWidthAvg": 674,
-    "category": "display"
+    "xWidthAvg": 674
   },
-  {
+  "atkinsonHyperlegible": {
     "familyName": "Atkinson Hyperlegible",
+    "category": "sans-serif",
     "capHeight": 668,
     "ascent": 950,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 496,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "athiti": {
     "familyName": "Athiti",
+    "category": "sans-serif",
     "capHeight": 614,
     "ascent": 1150,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 423,
-    "category": "sans-serif"
+    "xWidthAvg": 423
   },
-  {
+  "atma": {
     "familyName": "Atma",
+    "category": "display",
     "capHeight": 750,
     "ascent": 1101,
     "descent": -518,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 372,
-    "category": "display"
+    "xWidthAvg": 372
   },
-  {
+  "atomicAge": {
     "familyName": "Atomic Age",
+    "category": "display",
     "capHeight": 1516,
     "ascent": 2091,
     "descent": -656,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1047,
-    "xWidthAvg": 1076,
-    "category": "display"
+    "xWidthAvg": 1076
   },
-  {
+  "averageSans": {
     "familyName": "Average Sans",
+    "category": "sans-serif",
     "capHeight": 691,
     "ascent": 1027,
     "descent": -269,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 410,
-    "category": "sans-serif"
+    "xWidthAvg": 410
   },
-  {
+  "autourOne": {
     "familyName": "Autour One",
+    "category": "display",
     "capHeight": 1561,
     "ascent": 2010,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1190,
-    "xWidthAvg": 1255,
-    "category": "display"
+    "xWidthAvg": 1255
   },
-  {
+  "assistant": {
     "familyName": "Assistant",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 1021,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 412,
-    "category": "sans-serif"
+    "xWidthAvg": 412
   },
-  {
+  "aubrey": {
     "familyName": "Aubrey",
+    "category": "display",
     "capHeight": 616,
     "ascent": 830,
     "descent": -212,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 339,
-    "category": "display"
+    "xWidthAvg": 339
   },
-  {
+  "audiowide": {
     "familyName": "Audiowide",
+    "category": "display",
     "capHeight": 1434,
     "ascent": 2027,
     "descent": -584,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1083,
-    "xWidthAvg": 1153,
-    "category": "display"
+    "xWidthAvg": 1153
   },
-  {
+  "asar": {
     "familyName": "Asar",
+    "category": "serif",
     "capHeight": 680,
     "ascent": 1196,
     "descent": -557,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 484,
-    "xWidthAvg": 420,
-    "category": "serif"
+    "xWidthAvg": 420
   },
-  {
+  "averiaGruesaLibre": {
     "familyName": "Averia Gruesa Libre",
+    "category": "display",
     "ascent": 1952,
     "descent": -492,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 907,
-    "category": "display"
+    "xWidthAvg": 907
   },
-  {
+  "average": {
     "familyName": "Average",
+    "category": "serif",
     "capHeight": 691,
     "ascent": 953,
     "descent": -263,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 420,
-    "category": "serif"
+    "xWidthAvg": 420
   },
-  {
+  "averiaSansLibre": {
     "familyName": "Averia Sans Libre",
+    "category": "display",
     "ascent": 2035,
     "descent": -499,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 898,
-    "category": "display"
+    "xWidthAvg": 898
   },
-  {
+  "averiaSerifLibre": {
     "familyName": "Averia Serif Libre",
+    "category": "display",
     "ascent": 1828,
     "descent": -465,
     "lineGap": 184,
     "unitsPerEm": 2048,
-    "xWidthAvg": 935,
-    "category": "display"
+    "xWidthAvg": 935
   },
-  {
+  "azeretMono": {
     "familyName": "Azeret Mono",
+    "category": "monospace",
     "capHeight": 698,
     "ascent": 937,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 544,
-    "xWidthAvg": 650,
-    "category": "monospace"
+    "xWidthAvg": 650
   },
-  {
+  "b612": {
     "familyName": "B612",
+    "category": "sans-serif",
     "capHeight": 1500,
     "ascent": 1930,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1100,
-    "xWidthAvg": 975,
-    "category": "sans-serif"
+    "xWidthAvg": 975
   },
-  {
+  "b612Mono": {
     "familyName": "B612 Mono",
+    "category": "monospace",
     "capHeight": 1500,
     "ascent": 1930,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1100,
-    "xWidthAvg": 1300,
-    "category": "monospace"
+    "xWidthAvg": 1300
   },
-  {
+  "bahiana": {
     "familyName": "Bahiana",
+    "category": "display",
     "capHeight": 710,
     "ascent": 900,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 284,
-    "category": "display"
+    "xWidthAvg": 284
   },
-  {
+  "badScript": {
     "familyName": "Bad Script",
+    "category": "handwriting",
     "capHeight": 1966,
     "ascent": 2710,
     "descent": -1327,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1034,
-    "xWidthAvg": 784,
-    "category": "handwriting"
+    "xWidthAvg": 784
   },
-  {
+  "bahianita": {
     "familyName": "Bahianita",
+    "category": "display",
     "capHeight": 710,
     "ascent": 962,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 582,
-    "xWidthAvg": 242,
-    "category": "display"
+    "xWidthAvg": 242
   },
-  {
+  "baiJamjuree": {
     "familyName": "Bai Jamjuree",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 499,
-    "xWidthAvg": 459,
-    "category": "sans-serif"
+    "xWidthAvg": 459
   },
-  {
+  "bakbakOne": {
     "familyName": "Bakbak One",
+    "category": "display",
     "capHeight": 607,
     "ascent": 1050,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 470,
-    "category": "display"
+    "xWidthAvg": 470
   },
-  {
+  "babylonica": {
     "familyName": "Babylonica",
+    "category": "handwriting",
     "capHeight": 630,
     "ascent": 875,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 220,
-    "xWidthAvg": 252,
-    "category": "handwriting"
+    "xWidthAvg": 252
   },
-  {
+  "ballet16pt": {
     "familyName": "Ballet 16pt",
+    "category": "handwriting",
     "capHeight": 1209,
     "ascent": 1130,
     "descent": -770,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 339,
-    "xWidthAvg": 282,
-    "category": "handwriting"
+    "xWidthAvg": 282
   },
-  {
+  "baloo2": {
     "familyName": "Baloo 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1078,
     "descent": -524,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "averiaLibre": {
     "familyName": "Averia Libre",
+    "category": "display",
     "ascent": 1952,
     "descent": -492,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 915,
-    "category": "display"
+    "xWidthAvg": 915
   },
-  {
+  "balooBhaijaan2": {
     "familyName": "Baloo Bhaijaan 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1080,
     "descent": -632,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooBhaina2": {
     "familyName": "Baloo Bhaina 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1185,
     "descent": -827,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooBhai2": {
     "familyName": "Baloo Bhai 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1078,
     "descent": -544,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooDa2": {
     "familyName": "Baloo Da 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1095,
     "descent": -589,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooPaaji2": {
     "familyName": "Baloo Paaji 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1157,
     "descent": -614,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooChettan2": {
     "familyName": "Baloo Chettan 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1078,
     "descent": -392,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balooTamma2": {
     "familyName": "Baloo Tamma 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1078,
     "descent": -673,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 445,
-    "category": "display"
+    "xWidthAvg": 445
   },
-  {
+  "bIZUDGothic": {
     "familyName": "BIZ UDGothic",
+    "category": "sans-serif",
     "capHeight": 1567,
     "ascent": 1802,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1108,
-    "xWidthAvg": 1024,
-    "category": "sans-serif"
+    "xWidthAvg": 1024
   },
-  {
+  "balthazar": {
     "familyName": "Balthazar",
+    "category": "serif",
     "capHeight": 605,
     "ascent": 796,
     "descent": -222,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 399,
-    "xWidthAvg": 380,
-    "category": "serif"
+    "xWidthAvg": 380
   },
-  {
+  "balooTammudu2": {
     "familyName": "Baloo Tammudu 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1177,
     "descent": -1119,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "balsamiqSans": {
     "familyName": "Balsamiq Sans",
+    "category": "display",
     "capHeight": 715,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 450,
-    "category": "display"
+    "xWidthAvg": 450
   },
-  {
+  "balooThambi2": {
     "familyName": "Baloo Thambi 2",
+    "category": "display",
     "capHeight": 602,
     "ascent": 1078,
     "descent": -486,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 427,
-    "category": "display"
+    "xWidthAvg": 427
   },
-  {
+  "bangers": {
     "familyName": "Bangers",
+    "category": "display",
     "capHeight": 721,
     "ascent": 883,
     "descent": -181,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 721,
-    "xWidthAvg": 367,
-    "category": "display"
+    "xWidthAvg": 367
   },
-  {
+  "barlow": {
     "familyName": "Barlow",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 428,
-    "category": "sans-serif"
+    "xWidthAvg": 428
   },
-  {
+  "barlowCondensed": {
     "familyName": "Barlow Condensed",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 341,
-    "category": "sans-serif"
+    "xWidthAvg": 341
   },
-  {
+  "barlowSemiCondensed": {
     "familyName": "Barlow Semi Condensed",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 385,
-    "category": "sans-serif"
+    "xWidthAvg": 385
   },
-  {
+  "barriecito": {
     "familyName": "Barriecito",
+    "category": "display",
     "capHeight": 710,
     "ascent": 962,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 582,
-    "xWidthAvg": 424,
-    "category": "display"
+    "xWidthAvg": 424
   },
-  {
+  "barrio": {
     "familyName": "Barrio",
+    "category": "display",
     "capHeight": 710,
     "ascent": 880,
     "descent": -247,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 507,
-    "category": "display"
+    "xWidthAvg": 507
   },
-  {
+  "baskervville": {
     "familyName": "Baskervville",
+    "category": "serif",
     "capHeight": 710,
     "ascent": 998,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 436,
-    "xWidthAvg": 439,
-    "category": "serif"
+    "xWidthAvg": 439
   },
-  {
+  "basic": {
     "familyName": "Basic",
+    "category": "sans-serif",
     "capHeight": 1358,
     "ascent": 2066,
     "descent": -511,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1022,
-    "xWidthAvg": 889,
-    "category": "sans-serif"
+    "xWidthAvg": 889
   },
-  {
+  "baumans": {
     "familyName": "Baumans",
+    "category": "display",
     "capHeight": 700,
     "ascent": 942,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 429,
-    "category": "display"
+    "xWidthAvg": 429
   },
-  {
+  "battambang": {
     "familyName": "Battambang",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1004,
-    "category": "display"
+    "xWidthAvg": 1004
   },
-  {
+  "bayon": {
     "familyName": "Bayon",
+    "category": "sans-serif",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 819,
-    "category": "sans-serif"
+    "xWidthAvg": 819
   },
-  {
+  "beVietnamPro": {
     "familyName": "Be Vietnam Pro",
+    "category": "sans-serif",
     "capHeight": 740,
     "ascent": 1000,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 487,
-    "category": "sans-serif"
+    "xWidthAvg": 487
   },
-  {
+  "bIZUDMincho": {
     "familyName": "BIZ UDMincho",
+    "category": "serif",
     "capHeight": 1567,
     "ascent": 1802,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1108,
-    "xWidthAvg": 1024,
-    "category": "serif"
+    "xWidthAvg": 1024
   },
-  {
+  "belgrano": {
     "familyName": "Belgrano",
+    "category": "serif",
     "capHeight": 706,
     "ascent": 990,
     "descent": -278,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 499,
-    "xWidthAvg": 499,
-    "category": "serif"
+    "xWidthAvg": 499
   },
-  {
+  "belleza": {
     "familyName": "Belleza",
+    "category": "sans-serif",
     "capHeight": 662,
     "ascent": 928,
     "descent": -224,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 452,
-    "xWidthAvg": 397,
-    "category": "sans-serif"
+    "xWidthAvg": 397
   },
-  {
+  "bellefair": {
     "familyName": "Bellefair",
+    "category": "serif",
     "capHeight": 688,
     "ascent": 869,
     "descent": -277,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 364,
-    "xWidthAvg": 368,
-    "category": "serif"
+    "xWidthAvg": 368
   },
-  {
+  "beauRivage": {
     "familyName": "Beau Rivage",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 940,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 258,
-    "category": "handwriting"
+    "xWidthAvg": 258
   },
-  {
+  "bellota": {
     "familyName": "Bellota",
+    "category": "display",
     "capHeight": 684,
     "ascent": 968,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 455,
-    "category": "display"
+    "xWidthAvg": 455
   },
-  {
+  "bebasNeue": {
     "familyName": "Bebas Neue",
+    "category": "display",
     "capHeight": 700,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 700,
-    "xWidthAvg": 341,
-    "category": "display"
+    "xWidthAvg": 341
   },
-  {
+  "benchNine": {
     "familyName": "BenchNine",
+    "category": "sans-serif",
     "capHeight": 1438,
     "ascent": 2020,
     "descent": -720,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1006,
-    "xWidthAvg": 577,
-    "category": "sans-serif"
+    "xWidthAvg": 577
   },
-  {
+  "berkshireSwash": {
     "familyName": "Berkshire Swash",
+    "category": "handwriting",
     "capHeight": 1858,
     "ascent": 2007,
     "descent": -537,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1038,
-    "xWidthAvg": 852,
-    "category": "handwriting"
+    "xWidthAvg": 852
   },
-  {
+  "bellotaText": {
     "familyName": "Bellota Text",
+    "category": "display",
     "capHeight": 684,
     "ascent": 968,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 435,
-    "category": "display"
+    "xWidthAvg": 435
   },
-  {
+  "besley": {
     "familyName": "Besley",
+    "category": "serif",
     "capHeight": 1500,
     "ascent": 2500,
     "descent": -850,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1040,
-    "xWidthAvg": 996,
-    "category": "serif"
+    "xWidthAvg": 996
   },
-  {
+  "bentham": {
     "familyName": "Bentham",
+    "category": "serif",
     "ascent": 879,
     "descent": -260,
     "lineGap": 92,
     "unitsPerEm": 1024,
-    "xWidthAvg": 421,
-    "category": "serif"
+    "xWidthAvg": 421
   },
-  {
+  "bIZUDPMincho": {
     "familyName": "BIZ UDPMincho",
+    "category": "serif",
     "capHeight": 1567,
     "ascent": 1802,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1108,
-    "xWidthAvg": 1085,
-    "category": "serif"
+    "xWidthAvg": 1085
   },
-  {
+  "bethEllen": {
     "familyName": "Beth Ellen",
+    "category": "handwriting",
     "capHeight": 2248,
     "ascent": 3250,
     "descent": -1190,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1208,
-    "xWidthAvg": 1076,
-    "category": "handwriting"
+    "xWidthAvg": 1076
   },
-  {
+  "bIZUDPGothic": {
     "familyName": "BIZ UDPGothic",
+    "category": "sans-serif",
     "capHeight": 1567,
     "ascent": 1802,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1108,
-    "xWidthAvg": 1145,
-    "category": "sans-serif"
+    "xWidthAvg": 1145
   },
-  {
+  "bevan": {
     "familyName": "Bevan",
+    "category": "display",
     "capHeight": 1592,
     "ascent": 2366,
     "descent": -925,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1072,
-    "xWidthAvg": 1136,
-    "category": "display"
+    "xWidthAvg": 1136
   },
-  {
+  "bigShouldersStencilDisplay": {
     "familyName": "Big Shoulders Stencil Display",
+    "category": "display",
     "capHeight": 1600,
     "ascent": 1968,
     "descent": -426,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1200,
-    "xWidthAvg": 602,
-    "category": "display"
+    "xWidthAvg": 602
   },
-  {
+  "benne": {
     "familyName": "Benne",
+    "category": "serif",
     "capHeight": 655,
     "ascent": 630,
     "descent": -370,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 404,
-    "xWidthAvg": 383,
-    "category": "serif"
+    "xWidthAvg": 383
   },
-  {
+  "bhuTukaExpandedOne": {
     "familyName": "BhuTuka Expanded One",
+    "category": "display",
     "capHeight": 520,
     "ascent": 826,
     "descent": -182,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 357,
-    "xWidthAvg": 690,
-    "category": "display"
+    "xWidthAvg": 690
   },
-  {
+  "bigShouldersDisplay": {
     "familyName": "Big Shoulders Display",
+    "category": "display",
     "capHeight": 1600,
     "ascent": 1968,
     "descent": -426,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1200,
-    "xWidthAvg": 601,
-    "category": "display"
+    "xWidthAvg": 601
   },
-  {
+  "bigShouldersInlineText": {
     "familyName": "Big Shoulders Inline Text",
+    "category": "display",
     "capHeight": 3200,
     "ascent": 3936,
     "descent": -852,
     "lineGap": 0,
     "unitsPerEm": 4000,
     "xHeight": 2400,
-    "xWidthAvg": 1338,
-    "category": "display"
+    "xWidthAvg": 1338
   },
-  {
+  "bigShouldersInlineDisplay": {
     "familyName": "Big Shoulders Inline Display",
+    "category": "display",
     "capHeight": 3200,
     "ascent": 3936,
     "descent": -852,
     "lineGap": 0,
     "unitsPerEm": 4000,
     "xHeight": 2400,
-    "xWidthAvg": 1213,
-    "category": "display"
+    "xWidthAvg": 1213
   },
-  {
+  "bigShouldersText": {
     "familyName": "Big Shoulders Text",
+    "category": "display",
     "capHeight": 1600,
     "ascent": 1968,
     "descent": -426,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1200,
-    "xWidthAvg": 665,
-    "category": "display"
+    "xWidthAvg": 665
   },
-  {
+  "bigShouldersStencilText": {
     "familyName": "Big Shoulders Stencil Text",
+    "category": "display",
     "capHeight": 1600,
     "ascent": 1968,
     "descent": -426,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1200,
-    "xWidthAvg": 667,
-    "category": "display"
+    "xWidthAvg": 667
   },
-  {
+  "bigelowRules": {
     "familyName": "Bigelow Rules",
+    "category": "display",
     "capHeight": 1528,
     "ascent": 1857,
     "descent": -516,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1227,
-    "xWidthAvg": 514,
-    "category": "display"
+    "xWidthAvg": 514
   },
-  {
+  "bigshotOne": {
     "familyName": "Bigshot One",
+    "category": "display",
     "capHeight": 615,
     "ascent": 869,
     "descent": -179,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 449,
-    "xWidthAvg": 436,
-    "category": "display"
+    "xWidthAvg": 436
   },
-  {
+  "bilbo": {
     "familyName": "Bilbo",
+    "category": "handwriting",
     "capHeight": 650,
     "ascent": 850,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 375,
-    "xWidthAvg": 264,
-    "category": "handwriting"
+    "xWidthAvg": 264
   },
-  {
+  "bilboSwashCaps": {
     "familyName": "Bilbo Swash Caps",
+    "category": "handwriting",
     "capHeight": 542,
     "ascent": 850,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 327,
-    "xWidthAvg": 264,
-    "category": "handwriting"
+    "xWidthAvg": 264
   },
-  {
+  "bioRhymeExpanded": {
     "familyName": "BioRhyme Expanded",
+    "category": "serif",
     "capHeight": 686,
     "ascent": 1127,
     "descent": -422,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 471,
-    "xWidthAvg": 896,
-    "category": "serif"
+    "xWidthAvg": 896
   },
-  {
+  "bioRhyme": {
     "familyName": "BioRhyme",
+    "category": "serif",
     "capHeight": 686,
     "ascent": 1127,
     "descent": -422,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 471,
-    "xWidthAvg": 531,
-    "category": "serif"
+    "xWidthAvg": 531
   },
-  {
+  "birthstoneBounce": {
     "familyName": "Birthstone Bounce",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 950,
     "descent": -410,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 390,
-    "xWidthAvg": 312,
-    "category": "handwriting"
+    "xWidthAvg": 312
   },
-  {
+  "birthstone": {
     "familyName": "Birthstone",
+    "category": "handwriting",
     "capHeight": 880,
     "ascent": 950,
     "descent": -410,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 277,
-    "category": "handwriting"
+    "xWidthAvg": 277
   },
-  {
+  "bitter": {
     "familyName": "Bitter",
+    "category": "serif",
     "capHeight": 692,
     "ascent": 935,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 522,
-    "xWidthAvg": 461,
-    "category": "serif"
+    "xWidthAvg": 461
   },
-  {
+  "blackHanSans": {
     "familyName": "Black Han Sans",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 790,
     "descent": -210,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 561,
-    "category": "sans-serif"
+    "xWidthAvg": 561
   },
-  {
+  "blaka": {
     "familyName": "Blaka",
+    "category": "display",
     "capHeight": 666,
     "ascent": 932,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 352,
-    "category": "display"
+    "xWidthAvg": 352
   },
-  {
+  "blackOpsOne": {
     "familyName": "Black Ops One",
+    "category": "display",
     "capHeight": 1327,
     "ascent": 1871,
     "descent": -689,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1062,
-    "xWidthAvg": 1114,
-    "category": "display"
+    "xWidthAvg": 1114
   },
-  {
+  "blinker": {
     "familyName": "Blinker",
+    "category": "sans-serif",
     "capHeight": 627,
     "ascent": 960,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 494,
-    "xWidthAvg": 412,
-    "category": "sans-serif"
+    "xWidthAvg": 412
   },
-  {
+  "blakaInk": {
     "familyName": "Blaka Ink",
+    "category": "display",
     "capHeight": 666,
     "ascent": 932,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 352,
-    "category": "display"
+    "xWidthAvg": 352
   },
-  {
+  "bodoniModa11pt": {
     "familyName": "Bodoni Moda 11pt",
+    "category": "serif",
     "capHeight": 1500,
     "ascent": 2250,
     "descent": -800,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 920,
-    "xWidthAvg": 920,
-    "category": "serif"
+    "xWidthAvg": 920
   },
-  {
+  "biryani": {
     "familyName": "Biryani",
+    "category": "sans-serif",
     "capHeight": 758,
     "ascent": 1109,
     "descent": -656,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 563,
-    "xWidthAvg": 483,
-    "category": "sans-serif"
+    "xWidthAvg": 483
   },
-  {
+  "bokor": {
     "familyName": "Bokor",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 746,
-    "category": "display"
+    "xWidthAvg": 746
   },
-  {
+  "blakaHollow": {
     "familyName": "Blaka Hollow",
+    "category": "display",
     "capHeight": 666,
     "ascent": 932,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 352,
-    "category": "display"
+    "xWidthAvg": 352
   },
-  {
+  "bonheurRoyale": {
     "familyName": "Bonheur Royale",
+    "category": "handwriting",
     "capHeight": 620,
     "ascent": 780,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 280,
-    "xWidthAvg": 268,
-    "category": "handwriting"
+    "xWidthAvg": 268
   },
-  {
+  "bonbon": {
     "familyName": "Bonbon",
+    "category": "handwriting",
     "capHeight": 644,
     "ascent": 845,
     "descent": -330,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 504,
-    "xWidthAvg": 494,
-    "category": "handwriting"
+    "xWidthAvg": 494
   },
-  {
+  "bonaNova": {
     "familyName": "Bona Nova",
+    "category": "serif",
     "capHeight": 665,
     "ascent": 932,
     "descent": -268,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 440,
-    "xWidthAvg": 441,
-    "category": "serif"
+    "xWidthAvg": 441
   },
-  {
+  "boogaloo": {
     "familyName": "Boogaloo",
+    "category": "display",
     "capHeight": 469,
     "ascent": 943,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 338,
-    "xWidthAvg": 342,
-    "category": "display"
+    "xWidthAvg": 342
   },
-  {
+  "bowlbyOne": {
     "familyName": "Bowlby One",
+    "category": "display",
     "capHeight": 1520,
     "ascent": 2276,
     "descent": -932,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1196,
-    "xWidthAvg": 1268,
-    "category": "display"
+    "xWidthAvg": 1268
   },
-  {
+  "breeSerif": {
     "familyName": "Bree Serif",
+    "category": "serif",
     "capHeight": 665,
     "ascent": 1077,
     "descent": -281,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 503,
-    "xWidthAvg": 447,
-    "category": "serif"
+    "xWidthAvg": 447
   },
-  {
+  "bowlbyOneSC": {
     "familyName": "Bowlby One SC",
+    "category": "display",
     "capHeight": 1520,
     "ascent": 2248,
     "descent": -876,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1392,
-    "xWidthAvg": 1206,
-    "category": "display"
+    "xWidthAvg": 1206
   },
-  {
+  "brawler": {
     "familyName": "Brawler",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 971,
     "descent": -248,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 469,
-    "category": "serif"
+    "xWidthAvg": 469
   },
-  {
+  "brygada1918": {
     "familyName": "Brygada 1918",
+    "category": "serif",
     "capHeight": 670,
     "ascent": 920,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 463,
-    "category": "serif"
+    "xWidthAvg": 463
   },
-  {
+  "bubblerOne": {
     "familyName": "Bubbler One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 900,
     "descent": -263,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 372,
-    "category": "sans-serif"
+    "xWidthAvg": 372
   },
-  {
+  "bubblegumSans": {
     "familyName": "Bubblegum Sans",
+    "category": "display",
     "capHeight": 470,
     "ascent": 852,
     "descent": -311,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 410,
-    "xWidthAvg": 364,
-    "category": "display"
+    "xWidthAvg": 364
   },
-  {
+  "budaLight": {
     "familyName": "Buda Light",
+    "category": "display",
     "ascent": 1836,
     "descent": -724,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 781,
-    "category": "display"
+    "xWidthAvg": 781
   },
-  {
+  "bungeeHairline": {
     "familyName": "Bungee Hairline",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 616,
-    "category": "display"
+    "xWidthAvg": 616
   },
-  {
+  "buenard": {
     "familyName": "Buenard",
+    "category": "serif",
     "capHeight": 178,
     "ascent": 1031,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 95,
-    "xWidthAvg": 411,
-    "category": "serif"
+    "xWidthAvg": 411
   },
-  {
+  "bungeeInline": {
     "familyName": "Bungee Inline",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 616,
-    "category": "display"
+    "xWidthAvg": 616
   },
-  {
+  "bungee": {
     "familyName": "Bungee",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 616,
-    "category": "display"
+    "xWidthAvg": 616
   },
-  {
+  "butcherman": {
     "familyName": "Butcherman",
+    "category": "display",
     "capHeight": 1509,
     "ascent": 2600,
     "descent": -1363,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1521,
-    "xWidthAvg": 1046,
-    "category": "display"
+    "xWidthAvg": 1046
   },
-  {
+  "bungeeShade": {
     "familyName": "Bungee Shade",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 716,
-    "category": "display"
+    "xWidthAvg": 716
   },
-  {
+  "butterflyKids": {
     "familyName": "Butterfly Kids",
+    "category": "handwriting",
     "capHeight": 802,
     "ascent": 917,
     "descent": -304,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 338,
-    "xWidthAvg": 300,
-    "category": "handwriting"
+    "xWidthAvg": 300
   },
-  {
+  "cabinCondensed": {
     "familyName": "Cabin Condensed",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 965,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 490,
-    "xWidthAvg": 366,
-    "category": "sans-serif"
+    "xWidthAvg": 366
   },
-  {
+  "bungeeSpiceRegular": {
     "familyName": "Bungee Spice Regular",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 616,
-    "category": "display"
+    "xWidthAvg": 616
   },
-  {
+  "cabinSketch": {
     "familyName": "Cabin Sketch",
+    "category": "display",
     "capHeight": 652,
     "ascent": 873,
     "descent": -298,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 438,
-    "category": "display"
+    "xWidthAvg": 438
   },
-  {
+  "cabin": {
     "familyName": "Cabin",
+    "category": "sans-serif",
     "capHeight": 1400,
     "ascent": 1930,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 980,
-    "xWidthAvg": 837,
-    "category": "sans-serif"
+    "xWidthAvg": 837
   },
-  {
+  "bungeeOutline": {
     "familyName": "Bungee Outline",
+    "category": "display",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 616,
-    "category": "display"
+    "xWidthAvg": 616
   },
-  {
+  "caesarDressing": {
     "familyName": "Caesar Dressing",
+    "category": "display",
     "capHeight": 773,
     "ascent": 1017,
     "descent": -226,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 772,
-    "xWidthAvg": 460,
-    "category": "display"
+    "xWidthAvg": 460
   },
-  {
+  "cairo": {
     "familyName": "Cairo",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1303,
     "descent": -571,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 420,
-    "category": "sans-serif"
+    "xWidthAvg": 420
   },
-  {
+  "cagliostro": {
     "familyName": "Cagliostro",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 998,
     "descent": -355,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 444,
-    "xWidthAvg": 428,
-    "category": "sans-serif"
+    "xWidthAvg": 428
   },
-  {
+  "caladea": {
     "familyName": "Caladea",
+    "category": "serif",
     "capHeight": 667,
     "ascent": 900,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 467,
-    "xWidthAvg": 408,
-    "category": "serif"
+    "xWidthAvg": 408
   },
-  {
+  "cairoPlay": {
     "familyName": "Cairo Play",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1303,
     "descent": -571,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 420,
-    "category": "display"
+    "xWidthAvg": 420
   },
-  {
+  "calligraffitti": {
     "familyName": "Calligraffitti",
+    "category": "handwriting",
     "capHeight": 841,
     "ascent": 986,
     "descent": -607,
     "lineGap": 14,
     "unitsPerEm": 1024,
     "xHeight": 819,
-    "xWidthAvg": 384,
-    "category": "handwriting"
+    "xWidthAvg": 384
   },
-  {
+  "cambo": {
     "familyName": "Cambo",
+    "category": "serif",
     "capHeight": 676,
     "ascent": 879,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "blackAndWhitePicture": {
     "familyName": "Black And White Picture",
+    "category": "sans-serif",
     "capHeight": 648,
     "ascent": 800,
     "descent": -200,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 442,
-    "xWidthAvg": 375,
-    "category": "sans-serif"
+    "xWidthAvg": 375
   },
-  {
+  "calistoga": {
     "familyName": "Calistoga",
+    "category": "display",
     "capHeight": 698,
     "ascent": 1000,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 449,
-    "category": "display"
+    "xWidthAvg": 449
   },
-  {
+  "cambay": {
     "familyName": "Cambay",
+    "category": "sans-serif",
     "capHeight": 550,
     "ascent": 800,
     "descent": -503,
     "lineGap": 0,
     "unitsPerEm": 800,
     "xHeight": 384,
-    "xWidthAvg": 350,
-    "category": "sans-serif"
+    "xWidthAvg": 350
   },
-  {
+  "cantarell": {
     "familyName": "Cantarell",
+    "category": "sans-serif",
     "ascent": 2240,
     "descent": -660,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 944,
-    "category": "sans-serif"
+    "xWidthAvg": 944
   },
-  {
+  "cantataOne": {
     "familyName": "Cantata One",
+    "category": "serif",
     "capHeight": 1530,
     "ascent": 2040,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1023,
-    "xWidthAvg": 1062,
-    "category": "serif"
+    "xWidthAvg": 1062
   },
-  {
+  "candal": {
     "familyName": "Candal",
+    "category": "sans-serif",
     "capHeight": 1414,
     "ascent": 2226,
     "descent": -432,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1079,
-    "xWidthAvg": 1190,
-    "category": "sans-serif"
+    "xWidthAvg": 1190
   },
-  {
+  "capriola": {
     "familyName": "Capriola",
+    "category": "sans-serif",
     "capHeight": 1533,
     "ascent": 1992,
     "descent": -568,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1128,
-    "xWidthAvg": 1039,
-    "category": "sans-serif"
+    "xWidthAvg": 1039
   },
-  {
+  "caramel": {
     "familyName": "Caramel",
+    "category": "handwriting",
     "capHeight": 650,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 270,
-    "xWidthAvg": 250,
-    "category": "handwriting"
+    "xWidthAvg": 250
   },
-  {
+  "cantoraOne": {
     "familyName": "Cantora One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 412,
-    "category": "sans-serif"
+    "xWidthAvg": 412
   },
-  {
+  "carme": {
     "familyName": "Carme",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 1946,
     "descent": -513,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 939,
-    "category": "sans-serif"
+    "xWidthAvg": 939
   },
-  {
+  "carroisGothicSC": {
     "familyName": "Carrois Gothic SC",
+    "category": "sans-serif",
     "capHeight": 720,
     "ascent": 922,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 560,
-    "xWidthAvg": 485,
-    "category": "sans-serif"
+    "xWidthAvg": 485
   },
-  {
+  "carroisGothic": {
     "familyName": "Carrois Gothic",
+    "category": "sans-serif",
     "capHeight": 720,
     "ascent": 922,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 560,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "cardo": {
     "familyName": "Cardo",
+    "category": "serif",
     "capHeight": 1410,
     "ascent": 2028,
     "descent": -745,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 900,
-    "xWidthAvg": 862,
-    "category": "serif"
+    "xWidthAvg": 862
   },
-  {
+  "carterOne": {
     "familyName": "Carter One",
+    "category": "display",
     "capHeight": 1481,
     "ascent": 2264,
     "descent": -890,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 473,
-    "xWidthAvg": 999,
-    "category": "display"
+    "xWidthAvg": 999
   },
-  {
+  "castoro": {
     "familyName": "Castoro",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 444,
-    "category": "serif"
+    "xWidthAvg": 444
   },
-  {
+  "catamaran": {
     "familyName": "Catamaran",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 1100,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 485,
-    "xWidthAvg": 410,
-    "category": "sans-serif"
+    "xWidthAvg": 410
   },
-  {
+  "cevicheOne": {
     "familyName": "Ceviche One",
+    "category": "display",
     "capHeight": 425,
     "ascent": 806,
     "descent": -237,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 451,
-    "xWidthAvg": 353,
-    "category": "display"
+    "xWidthAvg": 353
   },
-  {
+  "chakraPetch": {
     "familyName": "Chakra Petch",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 992,
     "descent": -308,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "cedarvilleCursive": {
     "familyName": "Cedarville Cursive",
+    "category": "handwriting",
     "capHeight": 775,
     "ascent": 1279,
     "descent": -663,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 400,
-    "xWidthAvg": 459,
-    "category": "handwriting"
+    "xWidthAvg": 459
   },
-  {
+  "carattere": {
     "familyName": "Carattere",
+    "category": "handwriting",
     "capHeight": 690,
     "ascent": 800,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 283,
-    "category": "handwriting"
+    "xWidthAvg": 283
   },
-  {
+  "caveat": {
     "familyName": "Caveat",
+    "category": "handwriting",
     "capHeight": 610,
     "ascent": 960,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 338,
-    "category": "handwriting"
+    "xWidthAvg": 338
   },
-  {
+  "caudex": {
     "familyName": "Caudex",
+    "category": "serif",
     "ascent": 2034,
     "descent": -606,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 924,
-    "category": "serif"
+    "xWidthAvg": 924
   },
-  {
+  "caveatBrush": {
     "familyName": "Caveat Brush",
+    "category": "handwriting",
     "capHeight": 660,
     "ascent": 960,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 420,
-    "xWidthAvg": 351,
-    "category": "handwriting"
+    "xWidthAvg": 351
   },
-  {
+  "changa": {
     "familyName": "Changa",
+    "category": "sans-serif",
     "capHeight": 625,
     "ascent": 1227,
     "descent": -613,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 445,
-    "category": "sans-serif"
+    "xWidthAvg": 445
   },
-  {
+  "changaOne": {
     "familyName": "Changa One",
+    "category": "display",
     "capHeight": 625,
     "ascent": 882,
     "descent": -180,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 449,
-    "category": "display"
+    "xWidthAvg": 449
   },
-  {
+  "chango": {
     "familyName": "Chango",
+    "category": "display",
     "capHeight": 700,
     "ascent": 995,
     "descent": -216,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 509,
-    "xWidthAvg": 683,
-    "category": "display"
+    "xWidthAvg": 683
   },
-  {
+  "chauPhilomeneOne": {
     "familyName": "Chau Philomene One",
+    "category": "sans-serif",
     "capHeight": 752,
     "ascent": 1033,
     "descent": -334,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 512,
-    "xWidthAvg": 397,
-    "category": "sans-serif"
+    "xWidthAvg": 397
   },
-  {
+  "chelaOne": {
     "familyName": "Chela One",
+    "category": "display",
     "capHeight": 721,
     "ascent": 942,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 372,
-    "category": "display"
+    "xWidthAvg": 372
   },
-  {
+  "charisSIL": {
     "familyName": "Charis SIL",
+    "category": "serif",
     "capHeight": 1374,
     "ascent": 2450,
     "descent": -900,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 987,
-    "xWidthAvg": 915,
-    "category": "serif"
+    "xWidthAvg": 915
   },
-  {
+  "charm": {
     "familyName": "Charm",
+    "category": "handwriting",
     "capHeight": 684,
     "ascent": 1115,
     "descent": -434,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 466,
-    "xWidthAvg": 381,
-    "category": "handwriting"
+    "xWidthAvg": 381
   },
-  {
+  "chathura": {
     "familyName": "Chathura",
+    "category": "sans-serif",
     "capHeight": 404,
     "ascent": 1020,
     "descent": -602,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 294,
-    "xWidthAvg": 220,
-    "category": "sans-serif"
+    "xWidthAvg": 220
   },
-  {
+  "chenla": {
     "familyName": "Chenla",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 67,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 1360,
-    "category": "display"
+    "xWidthAvg": 1360
   },
-  {
+  "cherish": {
     "familyName": "Cherish",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 850,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 330,
-    "xWidthAvg": 231,
-    "category": "handwriting"
+    "xWidthAvg": 231
   },
-  {
+  "cherryCreamSoda": {
     "familyName": "Cherry Cream Soda",
+    "category": "display",
     "capHeight": 741,
     "ascent": 1006,
     "descent": -247,
     "lineGap": 29,
     "unitsPerEm": 1024,
     "xHeight": 502,
-    "xWidthAvg": 562,
-    "category": "display"
+    "xWidthAvg": 562
   },
-  {
+  "cherrySwash": {
     "familyName": "Cherry Swash",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1025,
     "descent": -301,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 464,
-    "category": "display"
+    "xWidthAvg": 464
   },
-  {
+  "chewy": {
     "familyName": "Chewy",
+    "category": "display",
     "capHeight": 768,
     "ascent": 1003,
     "descent": -310,
     "lineGap": 25,
     "unitsPerEm": 1024,
     "xHeight": 577,
-    "xWidthAvg": 407,
-    "category": "display"
+    "xWidthAvg": 407
   },
-  {
+  "charmonman": {
     "familyName": "Charmonman",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1200,
     "descent": -700,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 420,
-    "xWidthAvg": 395,
-    "category": "handwriting"
+    "xWidthAvg": 395
   },
-  {
+  "chicle": {
     "familyName": "Chicle",
+    "category": "display",
     "capHeight": 513,
     "ascent": 915,
     "descent": -294,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 277,
-    "xWidthAvg": 336,
-    "category": "display"
+    "xWidthAvg": 336
   },
-  {
+  "chelseaMarket": {
     "familyName": "Chelsea Market",
+    "category": "display",
     "capHeight": 796,
     "ascent": 1029,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 608,
-    "xWidthAvg": 564,
-    "category": "display"
+    "xWidthAvg": 564
   },
-  {
+  "chivo": {
     "familyName": "Chivo",
+    "category": "sans-serif",
     "capHeight": 686,
     "ascent": 940,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 511,
-    "xWidthAvg": 474,
-    "category": "sans-serif"
+    "xWidthAvg": 474
   },
-  {
+  "chivoMono": {
     "familyName": "Chivo Mono",
+    "category": "monospace",
     "capHeight": 686,
     "ascent": 940,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 511,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "chilanka": {
     "familyName": "Chilanka",
+    "category": "handwriting",
     "capHeight": 1448,
     "ascent": 1500,
     "descent": -750,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 999,
-    "xWidthAvg": 947,
-    "category": "handwriting"
+    "xWidthAvg": 947
   },
-  {
+  "cinzel": {
     "familyName": "Cinzel",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 976,
     "descent": -372,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 561,
-    "category": "serif"
+    "xWidthAvg": 561
   },
-  {
+  "chonburi": {
     "familyName": "Chonburi",
+    "category": "display",
     "capHeight": 714,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 567,
-    "category": "display"
+    "xWidthAvg": 567
   },
-  {
+  "cinzelDecorative": {
     "familyName": "Cinzel Decorative",
+    "category": "display",
     "capHeight": 700,
     "ascent": 976,
     "descent": -372,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 714,
-    "xWidthAvg": 596,
-    "category": "display"
+    "xWidthAvg": 596
   },
-  {
+  "clickerScript": {
     "familyName": "Clicker Script",
+    "category": "handwriting",
     "capHeight": 1358,
     "ascent": 1898,
     "descent": -807,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 621,
-    "xWidthAvg": 613,
-    "category": "handwriting"
+    "xWidthAvg": 613
   },
-  {
+  "codaCaptionExtraBold": {
     "familyName": "Coda Caption ExtraBold",
+    "category": "sans-serif",
     "ascent": 2450,
     "descent": -783,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 1230,
-    "category": "sans-serif"
+    "xWidthAvg": 1230
   },
-  {
+  "coda": {
     "familyName": "Coda",
+    "category": "display",
     "ascent": 2124,
     "descent": -784,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 903,
-    "category": "display"
+    "xWidthAvg": 903
   },
-  {
+  "codystar": {
     "familyName": "Codystar",
+    "category": "display",
     "capHeight": 761,
     "ascent": 953,
     "descent": -255,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 753,
-    "xWidthAvg": 628,
-    "category": "display"
+    "xWidthAvg": 628
   },
-  {
+  "coiny": {
     "familyName": "Coiny",
+    "category": "display",
     "ascent": 750,
     "descent": 250,
     "lineGap": 600,
     "unitsPerEm": 1000,
-    "xWidthAvg": 515,
-    "category": "display"
+    "xWidthAvg": 515
   },
-  {
+  "comicNeue": {
     "familyName": "Comic Neue",
+    "category": "handwriting",
     "capHeight": 670,
     "ascent": 900,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 487,
-    "xWidthAvg": 432,
-    "category": "handwriting"
+    "xWidthAvg": 432
   },
-  {
+  "comforter": {
     "familyName": "Comforter",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 930,
     "descent": -480,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 284,
-    "category": "handwriting"
+    "xWidthAvg": 284
   },
-  {
+  "comfortaa": {
     "familyName": "Comfortaa",
+    "category": "display",
     "capHeight": 781,
     "ascent": 881,
     "descent": -234,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 547,
-    "xWidthAvg": 524,
-    "category": "display"
+    "xWidthAvg": 524
   },
-  {
+  "combo": {
     "familyName": "Combo",
+    "category": "display",
     "capHeight": 670,
     "ascent": 907,
     "descent": -269,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 401,
-    "category": "display"
+    "xWidthAvg": 401
   },
-  {
+  "comingSoon": {
     "familyName": "Coming Soon",
+    "category": "handwriting",
     "capHeight": 763,
     "ascent": 1053,
     "descent": -498,
     "lineGap": 21,
     "unitsPerEm": 1024,
     "xHeight": 569,
-    "xWidthAvg": 475,
-    "category": "handwriting"
+    "xWidthAvg": 475
   },
-  {
+  "commissioner": {
     "familyName": "Commissioner",
+    "category": "sans-serif",
     "capHeight": 1426,
     "ascent": 2034,
     "descent": -412,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 988,
-    "xWidthAvg": 890,
-    "category": "sans-serif"
+    "xWidthAvg": 890
   },
-  {
+  "condiment": {
     "familyName": "Condiment",
+    "category": "handwriting",
     "capHeight": 327,
     "ascent": 882,
     "descent": -641,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 317,
-    "xWidthAvg": 340,
-    "category": "handwriting"
+    "xWidthAvg": 340
   },
-  {
+  "content": {
     "familyName": "Content",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 67,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 1360,
-    "category": "display"
+    "xWidthAvg": 1360
   },
-  {
+  "concertOne": {
     "familyName": "Concert One",
+    "category": "display",
     "capHeight": 1400,
     "ascent": 2005,
     "descent": 410,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1004,
-    "xWidthAvg": 930,
-    "category": "display"
+    "xWidthAvg": 930
   },
-  {
+  "cookie": {
     "familyName": "Cookie",
+    "category": "handwriting",
     "capHeight": 312,
     "ascent": 789,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 115,
-    "xWidthAvg": 288,
-    "category": "handwriting"
+    "xWidthAvg": 288
   },
-  {
+  "contrailOne": {
     "familyName": "Contrail One",
+    "category": "display",
     "capHeight": 421,
     "ascent": 1939,
     "descent": -625,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 255,
-    "xWidthAvg": 835,
-    "category": "display"
+    "xWidthAvg": 835
   },
-  {
+  "copse": {
     "familyName": "Copse",
+    "category": "serif",
     "capHeight": 1505,
     "ascent": 1991,
     "descent": -483,
     "lineGap": 57,
     "unitsPerEm": 2048,
     "xHeight": 1001,
-    "xWidthAvg": 925,
-    "category": "serif"
+    "xWidthAvg": 925
   },
-  {
+  "corben": {
     "familyName": "Corben",
+    "category": "display",
     "capHeight": 1404,
     "ascent": 2826,
     "descent": -969,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 958,
-    "xWidthAvg": 934,
-    "category": "display"
+    "xWidthAvg": 934
   },
-  {
+  "convergence": {
     "familyName": "Convergence",
+    "category": "sans-serif",
     "capHeight": 727,
     "ascent": 943,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 541,
-    "xWidthAvg": 488,
-    "category": "sans-serif"
+    "xWidthAvg": 488
   },
-  {
+  "corinthia": {
     "familyName": "Corinthia",
+    "category": "handwriting",
     "capHeight": 535,
     "ascent": 760,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 240,
-    "xWidthAvg": 236,
-    "category": "handwriting"
+    "xWidthAvg": 236
   },
-  {
+  "cormorant": {
     "familyName": "Cormorant",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 389,
-    "category": "serif"
+    "xWidthAvg": 389
   },
-  {
+  "comforterBrush": {
     "familyName": "Comforter Brush",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 930,
     "descent": -480,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 282,
-    "category": "handwriting"
+    "xWidthAvg": 282
   },
-  {
+  "courgette": {
     "familyName": "Courgette",
+    "category": "handwriting",
     "capHeight": 301,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 112,
-    "xWidthAvg": 915,
-    "category": "handwriting"
+    "xWidthAvg": 915
   },
-  {
+  "cormorantUpright": {
     "familyName": "Cormorant Upright",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 374,
-    "category": "serif"
+    "xWidthAvg": 374
   },
-  {
+  "cormorantSC": {
     "familyName": "Cormorant SC",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 461,
-    "category": "serif"
+    "xWidthAvg": 461
   },
-  {
+  "cormorantGaramond": {
     "familyName": "Cormorant Garamond",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 389,
-    "category": "serif"
+    "xWidthAvg": 389
   },
-  {
+  "courierPrime": {
     "familyName": "Courier Prime",
+    "category": "monospace",
     "capHeight": 1187,
     "ascent": 1600,
     "descent": -700,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 924,
-    "xWidthAvg": 1228,
-    "category": "monospace"
+    "xWidthAvg": 1228
   },
-  {
+  "coveredByYourGrace": {
     "familyName": "Covered By Your Grace",
+    "category": "handwriting",
     "capHeight": 795,
     "ascent": 995,
     "descent": -384,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 500,
-    "xWidthAvg": 385,
-    "category": "handwriting"
+    "xWidthAvg": 385
   },
-  {
+  "coustard": {
     "familyName": "Coustard",
+    "category": "serif",
     "capHeight": 346,
     "ascent": 2095,
     "descent": -781,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1095,
-    "xWidthAvg": 1004,
-    "category": "serif"
+    "xWidthAvg": 1004
   },
-  {
+  "cormorantUnicase": {
     "familyName": "Cormorant Unicase",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "cormorantInfant": {
     "familyName": "Cormorant Infant",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 924,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 386,
-    "xWidthAvg": 395,
-    "category": "serif"
+    "xWidthAvg": 395
   },
-  {
+  "craftyGirls": {
     "familyName": "Crafty Girls",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1001,
     "descent": -461,
     "lineGap": 21,
     "unitsPerEm": 1024,
     "xHeight": 548,
-    "xWidthAvg": 529,
-    "category": "handwriting"
+    "xWidthAvg": 529
   },
-  {
+  "cousine": {
     "familyName": "Cousine",
+    "category": "monospace",
     "capHeight": 1349,
     "ascent": 1705,
     "descent": -615,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 1229,
-    "category": "monospace"
+    "xWidthAvg": 1229
   },
-  {
+  "creepster": {
     "familyName": "Creepster",
+    "category": "display",
     "capHeight": 751,
     "ascent": 974,
     "descent": -223,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 751,
-    "xWidthAvg": 413,
-    "category": "display"
+    "xWidthAvg": 413
   },
-  {
+  "croissantOne": {
     "familyName": "Croissant One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1071,
     "descent": -344,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 546,
-    "category": "display"
+    "xWidthAvg": 546
   },
-  {
+  "crimsonPro": {
     "familyName": "Crimson Pro",
+    "category": "serif",
     "capHeight": 587,
     "ascent": 918,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 430,
-    "xWidthAvg": 406,
-    "category": "serif"
+    "xWidthAvg": 406
   },
-  {
+  "crimsonText": {
     "familyName": "Crimson Text",
+    "category": "serif",
     "capHeight": 656,
     "ascent": 972,
     "descent": -359,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 430,
-    "xWidthAvg": 399,
-    "category": "serif"
+    "xWidthAvg": 399
   },
-  {
+  "crushed": {
     "familyName": "Crushed",
+    "category": "display",
     "capHeight": 1374,
     "ascent": 1820,
     "descent": -483,
     "lineGap": 51,
     "unitsPerEm": 2048,
     "xHeight": 958,
-    "xWidthAvg": 767,
-    "category": "display"
+    "xWidthAvg": 767
   },
-  {
+  "cuprum": {
     "familyName": "Cuprum",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 895,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 386,
-    "category": "sans-serif"
+    "xWidthAvg": 386
   },
-  {
+  "creteRound": {
     "familyName": "Crete Round",
+    "category": "serif",
     "capHeight": 679,
     "ascent": 990,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 444,
-    "category": "serif"
+    "xWidthAvg": 444
   },
-  {
+  "cuteFont": {
     "familyName": "Cute Font",
+    "category": "display",
     "capHeight": 429,
     "ascent": 710,
     "descent": -290,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 312,
-    "xWidthAvg": 363,
-    "category": "display"
+    "xWidthAvg": 363
   },
-  {
+  "dMSans": {
     "familyName": "DM Sans",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 992,
     "descent": -310,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 496,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "dMMono": {
     "familyName": "DM Mono",
+    "category": "monospace",
     "capHeight": 700,
     "ascent": 992,
     "descent": -310,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 496,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "dMSerifText": {
     "familyName": "DM Serif Text",
+    "category": "serif",
     "capHeight": 661,
     "ascent": 1036,
     "descent": -335,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 441,
-    "category": "serif"
+    "xWidthAvg": 441
   },
-  {
+  "dMSerifDisplay": {
     "familyName": "DM Serif Display",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 1036,
     "descent": -335,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 481,
-    "xWidthAvg": 443,
-    "category": "serif"
+    "xWidthAvg": 443
   },
-  {
+  "damion": {
     "familyName": "Damion",
+    "category": "handwriting",
     "capHeight": 432,
     "ascent": 2068,
     "descent": -746,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 299,
-    "xWidthAvg": 730,
-    "category": "handwriting"
+    "xWidthAvg": 730
   },
-  {
+  "dancingScript": {
     "familyName": "Dancing Script",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 920,
     "descent": -280,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 332,
-    "xWidthAvg": 356,
-    "category": "handwriting"
+    "xWidthAvg": 356
   },
-  {
+  "cutive": {
     "familyName": "Cutive",
+    "category": "serif",
     "capHeight": 1714,
     "ascent": 1473,
     "descent": -575,
     "lineGap": 200,
     "unitsPerEm": 2048,
     "xHeight": 1188,
-    "xWidthAvg": 1147,
-    "category": "serif"
+    "xWidthAvg": 1147
   },
-  {
+  "cutiveMono": {
     "familyName": "Cutive Mono",
+    "category": "monospace",
     "capHeight": 1171,
     "ascent": 1697,
     "descent": -558,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 774,
-    "xWidthAvg": 1240,
-    "category": "monospace"
+    "xWidthAvg": 1240
   },
-  {
+  "dangrek": {
     "familyName": "Dangrek",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 876,
-    "category": "display"
+    "xWidthAvg": 876
   },
-  {
+  "darkerGrotesque": {
     "familyName": "Darker Grotesque",
+    "category": "sans-serif",
     "capHeight": 563,
     "ascent": 1060,
     "descent": -296,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 406,
-    "xWidthAvg": 360,
-    "category": "sans-serif"
+    "xWidthAvg": 360
   },
-  {
+  "dawningOfANewDay": {
     "familyName": "Dawning of a New Day",
+    "category": "handwriting",
     "capHeight": 818,
     "ascent": 1151,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 218,
-    "xWidthAvg": 376,
-    "category": "handwriting"
+    "xWidthAvg": 376
   },
-  {
+  "davidLibre": {
     "familyName": "David Libre",
+    "category": "serif",
     "capHeight": 1360,
     "ascent": 1528,
     "descent": -449,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 989,
-    "xWidthAvg": 837,
-    "category": "serif"
+    "xWidthAvg": 837
   },
-  {
+  "daysOne": {
     "familyName": "Days One",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 2040,
     "descent": -567,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1096,
-    "xWidthAvg": 1122,
-    "category": "sans-serif"
+    "xWidthAvg": 1122
   },
-  {
+  "dekko": {
     "familyName": "Dekko",
+    "category": "handwriting",
     "capHeight": 1340,
     "ascent": 2231,
     "descent": -1112,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 995,
-    "xWidthAvg": 814,
-    "category": "handwriting"
+    "xWidthAvg": 814
   },
-  {
+  "delius": {
     "familyName": "Delius",
+    "category": "handwriting",
     "capHeight": 195,
     "ascent": 986,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 85,
-    "xWidthAvg": 448,
-    "category": "handwriting"
+    "xWidthAvg": 448
   },
-  {
+  "deliusUnicase": {
     "familyName": "Delius Unicase",
+    "category": "handwriting",
     "capHeight": 195,
     "ascent": 1016,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 641,
-    "category": "handwriting"
+    "xWidthAvg": 641
   },
-  {
+  "deliusSwashCaps": {
     "familyName": "Delius Swash Caps",
+    "category": "handwriting",
     "capHeight": 282,
     "ascent": 986,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 113,
-    "xWidthAvg": 448,
-    "category": "handwriting"
+    "xWidthAvg": 448
   },
-  {
+  "dellaRespira": {
     "familyName": "Della Respira",
+    "category": "serif",
     "ascent": 2196,
     "descent": -607,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 887,
-    "category": "serif"
+    "xWidthAvg": 887
   },
-  {
+  "denkOne": {
     "familyName": "Denk One",
+    "category": "sans-serif",
     "capHeight": 1690,
     "ascent": 2118,
     "descent": -442,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1202,
-    "xWidthAvg": 895,
-    "category": "sans-serif"
+    "xWidthAvg": 895
   },
-  {
+  "devonshire": {
     "familyName": "Devonshire",
+    "category": "handwriting",
     "capHeight": 664,
     "ascent": 981,
     "descent": -433,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 405,
-    "xWidthAvg": 305,
-    "category": "handwriting"
+    "xWidthAvg": 305
   },
-  {
+  "delaGothicOne": {
     "familyName": "Dela Gothic One",
+    "category": "display",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 574,
-    "category": "display"
+    "xWidthAvg": 574
   },
-  {
+  "diplomata": {
     "familyName": "Diplomata",
+    "category": "display",
     "capHeight": 650,
     "ascent": 930,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 558,
-    "xWidthAvg": 958,
-    "category": "display"
+    "xWidthAvg": 958
   },
-  {
+  "diplomataSC": {
     "familyName": "Diplomata SC",
+    "category": "display",
     "capHeight": 650,
     "ascent": 930,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 558,
-    "xWidthAvg": 1050,
-    "category": "display"
+    "xWidthAvg": 1050
   },
-  {
+  "dhurjati": {
     "familyName": "Dhurjati",
+    "category": "sans-serif",
     "capHeight": 419,
     "ascent": 1101,
     "descent": -509,
     "lineGap": 0,
     "unitsPerEm": 870,
     "xHeight": 314,
-    "xWidthAvg": 322,
-    "category": "sans-serif"
+    "xWidthAvg": 322
   },
-  {
+  "doHyeon": {
     "familyName": "Do Hyeon",
+    "category": "sans-serif",
     "capHeight": 851,
     "ascent": 800,
     "descent": -200,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 636,
-    "xWidthAvg": 505,
-    "category": "sans-serif"
+    "xWidthAvg": 505
   },
-  {
+  "domine": {
     "familyName": "Domine",
+    "category": "serif",
     "capHeight": 720,
     "ascent": 900,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 481,
-    "category": "serif"
+    "xWidthAvg": 481
   },
-  {
+  "didactGothic": {
     "familyName": "Didact Gothic",
+    "category": "sans-serif",
     "capHeight": 682,
     "ascent": 1046,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 421,
-    "category": "sans-serif"
+    "xWidthAvg": 421
   },
-  {
+  "donegalOne": {
     "familyName": "Donegal One",
+    "category": "serif",
     "capHeight": 1530,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1020,
-    "xWidthAvg": 1016,
-    "category": "serif"
+    "xWidthAvg": 1016
   },
-  {
+  "doppioOne": {
     "familyName": "Doppio One",
+    "category": "sans-serif",
     "capHeight": 1427,
     "ascent": 2060,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1055,
-    "xWidthAvg": 964,
-    "category": "sans-serif"
+    "xWidthAvg": 964
   },
-  {
+  "dorsa": {
     "familyName": "Dorsa",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 857,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 165,
-    "category": "sans-serif"
+    "xWidthAvg": 165
   },
-  {
+  "dosis": {
     "familyName": "Dosis",
+    "category": "sans-serif",
     "capHeight": 731,
     "ascent": 1027,
     "descent": -237,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 472,
-    "xWidthAvg": 376,
-    "category": "sans-serif"
+    "xWidthAvg": 376
   },
-  {
+  "drSugiyama": {
     "familyName": "Dr Sugiyama",
+    "category": "handwriting",
     "capHeight": 710,
     "ascent": 1009,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 235,
-    "xWidthAvg": 297,
-    "category": "handwriting"
+    "xWidthAvg": 297
   },
-  {
+  "dokdo": {
     "familyName": "Dokdo",
+    "category": "handwriting",
     "capHeight": 475,
     "ascent": 696,
     "descent": -304,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 272,
-    "xWidthAvg": 494,
-    "category": "handwriting"
+    "xWidthAvg": 494
   },
-  {
+  "duruSans": {
     "familyName": "Duru Sans",
+    "category": "sans-serif",
     "capHeight": 1554,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1157,
-    "xWidthAvg": 1065,
-    "category": "sans-serif"
+    "xWidthAvg": 1065
   },
-  {
+  "dynalight": {
     "familyName": "Dynalight",
+    "category": "display",
     "capHeight": 1441,
     "ascent": 1840,
     "descent": -645,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 723,
-    "xWidthAvg": 609,
-    "category": "display"
+    "xWidthAvg": 609
   },
-  {
+  "dynaPuff": {
     "familyName": "DynaPuff",
+    "category": "display",
     "capHeight": 730,
     "ascent": 965,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 620,
-    "xWidthAvg": 507,
-    "category": "display"
+    "xWidthAvg": 507
   },
-  {
+  "eagleLake": {
     "familyName": "Eagle Lake",
+    "category": "handwriting",
     "capHeight": 1518,
     "ascent": 2420,
     "descent": -925,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1094,
-    "xWidthAvg": 1160,
-    "category": "handwriting"
+    "xWidthAvg": 1160
   },
-  {
+  "economica": {
     "familyName": "Economica",
+    "category": "sans-serif",
     "capHeight": 720,
     "ascent": 949,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 307,
-    "category": "sans-serif"
+    "xWidthAvg": 307
   },
-  {
+  "eduNSWACTFoundation": {
     "familyName": "Edu NSW ACT Foundation",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1016,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 416,
-    "xWidthAvg": 344,
-    "category": "handwriting"
+    "xWidthAvg": 344
   },
-  {
+  "dotGothic16": {
     "familyName": "DotGothic16",
+    "category": "sans-serif",
     "capHeight": 787,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "eduQLDBeginner": {
     "familyName": "Edu QLD Beginner",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1016,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 416,
-    "xWidthAvg": 377,
-    "category": "handwriting"
+    "xWidthAvg": 377
   },
-  {
+  "eBGaramond": {
     "familyName": "EB Garamond",
+    "category": "serif",
     "capHeight": 650,
     "ascent": 1007,
     "descent": -298,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 377,
-    "category": "serif"
+    "xWidthAvg": 377
   },
-  {
+  "eater": {
     "familyName": "Eater",
+    "category": "display",
     "capHeight": 1729,
     "ascent": 2898,
     "descent": -919,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1706,
-    "xWidthAvg": 1267,
-    "category": "display"
+    "xWidthAvg": 1267
   },
-  {
+  "eduSABeginner": {
     "familyName": "Edu SA Beginner",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1016,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 416,
-    "xWidthAvg": 355,
-    "category": "handwriting"
+    "xWidthAvg": 355
   },
-  {
+  "eduVICWANTBeginner": {
     "familyName": "Edu VIC WA NT Beginner",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1016,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 416,
-    "xWidthAvg": 371,
-    "category": "handwriting"
+    "xWidthAvg": 371
   },
-  {
+  "dongle": {
     "familyName": "Dongle",
+    "category": "sans-serif",
     "capHeight": 395,
     "ascent": 850,
     "descent": -598,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 280,
-    "xWidthAvg": 291,
-    "category": "sans-serif"
+    "xWidthAvg": 291
   },
-  {
+  "eduTASBeginner": {
     "familyName": "Edu TAS Beginner",
+    "category": "handwriting",
     "capHeight": 772,
     "ascent": 1016,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 416,
-    "xWidthAvg": 378,
-    "category": "handwriting"
+    "xWidthAvg": 378
   },
-  {
+  "eczar": {
     "familyName": "Eczar",
+    "category": "serif",
     "capHeight": 650,
     "ascent": 1143,
     "descent": -634,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 435,
-    "category": "serif"
+    "xWidthAvg": 435
   },
-  {
+  "elsie": {
     "familyName": "Elsie",
+    "category": "display",
     "capHeight": 650,
     "ascent": 878,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 511,
-    "xWidthAvg": 440,
-    "category": "display"
+    "xWidthAvg": 440
   },
-  {
+  "elMessiri": {
     "familyName": "El Messiri",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 1019,
     "descent": -544,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 424,
-    "category": "sans-serif"
+    "xWidthAvg": 424
   },
-  {
+  "electrolize": {
     "familyName": "Electrolize",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 911,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 453,
-    "category": "sans-serif"
+    "xWidthAvg": 453
   },
-  {
+  "eastSeaDokdo": {
     "familyName": "East Sea Dokdo",
+    "category": "handwriting",
     "capHeight": 418,
     "ascent": 706,
     "descent": -294,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 239,
-    "xWidthAvg": 380,
-    "category": "handwriting"
+    "xWidthAvg": 380
   },
-  {
+  "emblemaOne": {
     "familyName": "Emblema One",
+    "category": "display",
     "capHeight": 1361,
     "ascent": 1898,
     "descent": -546,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1002,
-    "xWidthAvg": 1232,
-    "category": "display"
+    "xWidthAvg": 1232
   },
-  {
+  "elsieSwashCaps": {
     "familyName": "Elsie Swash Caps",
+    "category": "display",
     "capHeight": 650,
     "ascent": 878,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 511,
-    "xWidthAvg": 440,
-    "category": "display"
+    "xWidthAvg": 440
   },
-  {
+  "encodeSans": {
     "familyName": "Encode Sans",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1080,
-    "xWidthAvg": 881,
-    "category": "sans-serif"
+    "xWidthAvg": 881
   },
-  {
+  "encodeSansCondensed": {
     "familyName": "Encode Sans Condensed",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1085,
-    "xWidthAvg": 758,
-    "category": "sans-serif"
+    "xWidthAvg": 758
   },
-  {
+  "emilysCandy": {
     "familyName": "Emilys Candy",
+    "category": "display",
     "capHeight": 762,
     "ascent": 996,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 529,
-    "xWidthAvg": 432,
-    "category": "display"
+    "xWidthAvg": 432
   },
-  {
+  "encodeSansSC": {
     "familyName": "Encode Sans SC",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1080,
-    "xWidthAvg": 1005,
-    "category": "sans-serif"
+    "xWidthAvg": 1005
   },
-  {
+  "encodeSansSemiCondensed": {
     "familyName": "Encode Sans Semi Condensed",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1085,
-    "xWidthAvg": 820,
-    "category": "sans-serif"
+    "xWidthAvg": 820
   },
-  {
+  "englebert": {
     "familyName": "Englebert",
+    "category": "sans-serif",
     "capHeight": 1466,
     "ascent": 954,
     "descent": -311,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1077,
-    "xWidthAvg": 785,
-    "category": "sans-serif"
+    "xWidthAvg": 785
   },
-  {
+  "engagement": {
     "familyName": "Engagement",
+    "category": "handwriting",
     "capHeight": 1500,
     "ascent": 1843,
     "descent": -684,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 653,
-    "xWidthAvg": 494,
-    "category": "handwriting"
+    "xWidthAvg": 494
   },
-  {
+  "encodeSansSemiExpanded": {
     "familyName": "Encode Sans Semi Expanded",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1085,
-    "xWidthAvg": 941,
-    "category": "sans-serif"
+    "xWidthAvg": 941
   },
-  {
+  "ephesis": {
     "familyName": "Ephesis",
+    "category": "handwriting",
     "capHeight": 670,
     "ascent": 900,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 287,
-    "category": "handwriting"
+    "xWidthAvg": 287
   },
-  {
+  "epilogue": {
     "familyName": "Epilogue",
+    "category": "sans-serif",
     "capHeight": 1475,
     "ascent": 1580,
     "descent": -470,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1062,
-    "xWidthAvg": 993,
-    "category": "sans-serif"
+    "xWidthAvg": 993
   },
-  {
+  "ericaOne": {
     "familyName": "Erica One",
+    "category": "display",
     "capHeight": 691,
     "ascent": 1153,
     "descent": -339,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 591,
-    "xWidthAvg": 550,
-    "category": "display"
+    "xWidthAvg": 550
   },
-  {
+  "esteban": {
     "familyName": "Esteban",
+    "category": "serif",
     "capHeight": 137,
     "ascent": 984,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 127,
-    "xWidthAvg": 441,
-    "category": "serif"
+    "xWidthAvg": 441
   },
-  {
+  "encodeSansExpanded": {
     "familyName": "Encode Sans Expanded",
+    "category": "sans-serif",
     "capHeight": 1480,
     "ascent": 2060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1085,
-    "xWidthAvg": 1004,
-    "category": "sans-serif"
+    "xWidthAvg": 1004
   },
-  {
+  "enriqueta": {
     "familyName": "Enriqueta",
+    "category": "serif",
     "capHeight": 720,
     "ascent": 1077,
     "descent": -261,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 446,
-    "category": "serif"
+    "xWidthAvg": 446
   },
-  {
+  "ewert": {
     "familyName": "Ewert",
+    "category": "display",
     "capHeight": 700,
     "ascent": 944,
     "descent": -299,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 700,
-    "xWidthAvg": 661,
-    "category": "display"
+    "xWidthAvg": 661
   },
-  {
+  "exo": {
     "familyName": "Exo",
+    "category": "sans-serif",
     "capHeight": 732,
     "ascent": 1002,
     "descent": -327,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 531,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "expletusSans": {
     "familyName": "Expletus Sans",
+    "category": "display",
     "capHeight": 1454,
     "ascent": 2066,
     "descent": -612,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1034,
-    "xWidthAvg": 919,
-    "category": "display"
+    "xWidthAvg": 919
   },
-  {
+  "exo2": {
     "familyName": "Exo 2",
+    "category": "sans-serif",
     "capHeight": 690,
     "ascent": 999,
     "descent": -201,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 487,
-    "xWidthAvg": 454,
-    "category": "sans-serif"
+    "xWidthAvg": 454
   },
-  {
+  "euphoriaScript": {
     "familyName": "Euphoria Script",
+    "category": "handwriting",
     "capHeight": 274,
     "ascent": 1014,
     "descent": -442,
     "lineGap": 0,
     "unitsPerEm": 1250,
     "xHeight": 344,
-    "xWidthAvg": 378,
-    "category": "handwriting"
+    "xWidthAvg": 378
   },
-  {
+  "estonia": {
     "familyName": "Estonia",
+    "category": "handwriting",
     "capHeight": 447,
     "ascent": 900,
     "descent": -340,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 261,
-    "xWidthAvg": 233,
-    "category": "handwriting"
+    "xWidthAvg": 233
   },
-  {
+  "fahkwang": {
     "familyName": "Fahkwang",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1008,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 490,
-    "xWidthAvg": 501,
-    "category": "sans-serif"
+    "xWidthAvg": 501
   },
-  {
+  "explora": {
     "familyName": "Explora",
+    "category": "handwriting",
     "capHeight": 542,
     "ascent": 850,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 325,
-    "xWidthAvg": 232,
-    "category": "handwriting"
+    "xWidthAvg": 232
   },
-  {
+  "familjenGrotesk": {
     "familyName": "Familjen Grotesk",
+    "category": "sans-serif",
     "capHeight": 780,
     "ascent": 1230,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1200,
     "xHeight": 600,
-    "xWidthAvg": 501,
-    "category": "sans-serif"
+    "xWidthAvg": 501
   },
-  {
+  "fanwoodText": {
     "familyName": "Fanwood Text",
+    "category": "serif",
     "capHeight": 1282,
     "ascent": 3761,
     "descent": -1609,
     "lineGap": 0,
     "unitsPerEm": 4096,
     "xHeight": 1606,
-    "xWidthAvg": 1537,
-    "category": "serif"
+    "xWidthAvg": 1537
   },
-  {
+  "farro": {
     "familyName": "Farro",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 800,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 487,
-    "category": "sans-serif"
+    "xWidthAvg": 487
   },
-  {
+  "farsan": {
     "familyName": "Farsan",
+    "category": "display",
     "capHeight": 664,
     "ascent": 711,
     "descent": -289,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 441,
-    "xWidthAvg": 309,
-    "category": "display"
+    "xWidthAvg": 309
   },
-  {
+  "fascinateInline": {
     "familyName": "Fascinate Inline",
+    "category": "display",
     "capHeight": 1436,
     "ascent": 2125,
     "descent": -591,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 1119,
-    "category": "display"
+    "xWidthAvg": 1119
   },
-  {
+  "fasterOne": {
     "familyName": "Faster One",
+    "category": "display",
     "capHeight": 625,
     "ascent": 898,
     "descent": -165,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 529,
-    "xWidthAvg": 607,
-    "category": "display"
+    "xWidthAvg": 607
   },
-  {
+  "fascinate": {
     "familyName": "Fascinate",
+    "category": "display",
     "capHeight": 1436,
     "ascent": 2125,
     "descent": -591,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 1119,
-    "category": "display"
+    "xWidthAvg": 1119
   },
-  {
+  "faunaOne": {
     "familyName": "Fauna One",
+    "category": "serif",
     "capHeight": 730,
     "ascent": 987,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 572,
-    "xWidthAvg": 511,
-    "category": "serif"
+    "xWidthAvg": 511
   },
-  {
+  "fasthand": {
     "familyName": "Fasthand",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 754,
-    "category": "display"
+    "xWidthAvg": 754
   },
-  {
+  "federant": {
     "familyName": "Federant",
+    "category": "display",
     "capHeight": 714,
     "ascent": 942,
     "descent": -284,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 451,
-    "category": "display"
+    "xWidthAvg": 451
   },
-  {
+  "faustina": {
     "familyName": "Faustina",
+    "category": "serif",
     "capHeight": 648,
     "ascent": 1043,
     "descent": -217,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 494,
-    "xWidthAvg": 412,
-    "category": "serif"
+    "xWidthAvg": 412
   },
-  {
+  "federo": {
     "familyName": "Federo",
+    "category": "sans-serif",
     "capHeight": 1487,
     "ascent": 1883,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 942,
-    "xWidthAvg": 817,
-    "category": "sans-serif"
+    "xWidthAvg": 817
   },
-  {
+  "felipa": {
     "familyName": "Felipa",
+    "category": "handwriting",
     "capHeight": 752,
     "ascent": 966,
     "descent": -319,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 333,
-    "category": "handwriting"
+    "xWidthAvg": 333
   },
-  {
+  "fenix": {
     "familyName": "Fenix",
+    "category": "serif",
     "capHeight": 650,
     "ascent": 879,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 406,
-    "category": "serif"
+    "xWidthAvg": 406
   },
-  {
+  "figtree": {
     "familyName": "Figtree",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "fingerPaint": {
     "familyName": "Finger Paint",
+    "category": "display",
     "capHeight": 720,
     "ascent": 1097,
     "descent": -377,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 537,
-    "category": "display"
+    "xWidthAvg": 537
   },
-  {
+  "festive": {
     "familyName": "Festive",
+    "category": "handwriting",
     "capHeight": 800,
     "ascent": 1100,
     "descent": -590,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 360,
-    "xWidthAvg": 304,
-    "category": "handwriting"
+    "xWidthAvg": 304
   },
-  {
+  "fjallaOne": {
     "familyName": "Fjalla One",
+    "category": "sans-serif",
     "capHeight": 1708,
     "ascent": 2066,
     "descent": -508,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1377,
-    "xWidthAvg": 800,
-    "category": "sans-serif"
+    "xWidthAvg": 800
   },
-  {
+  "finlandica": {
     "familyName": "Finlandica",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 423,
-    "category": "sans-serif"
+    "xWidthAvg": 423
   },
-  {
+  "firaCode": {
     "familyName": "Fira Code",
+    "category": "monospace",
     "capHeight": 1377,
     "ascent": 1980,
     "descent": -644,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1053,
-    "xWidthAvg": 1200,
-    "category": "monospace"
+    "xWidthAvg": 1200
   },
-  {
+  "firaMono": {
     "familyName": "Fira Mono",
+    "category": "monospace",
     "capHeight": 689,
     "ascent": 935,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 527,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "firaSansExtraCondensed": {
     "familyName": "Fira Sans Extra Condensed",
+    "category": "sans-serif",
     "capHeight": 689,
     "ascent": 935,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 527,
-    "xWidthAvg": 379,
-    "category": "sans-serif"
+    "xWidthAvg": 379
   },
-  {
+  "firaSansCondensed": {
     "familyName": "Fira Sans Condensed",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 935,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 526,
-    "xWidthAvg": 412,
-    "category": "sans-serif"
+    "xWidthAvg": 412
   },
-  {
+  "firaSans": {
     "familyName": "Fira Sans",
+    "category": "sans-serif",
     "capHeight": 689,
     "ascent": 935,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 527,
-    "xWidthAvg": 458,
-    "category": "sans-serif"
+    "xWidthAvg": 458
   },
-  {
+  "fjord": {
     "familyName": "Fjord",
+    "category": "serif",
     "capHeight": 1448,
     "ascent": 1940,
     "descent": -620,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 950,
-    "xWidthAvg": 911,
-    "category": "serif"
+    "xWidthAvg": 911
   },
-  {
+  "flamenco": {
     "familyName": "Flamenco",
+    "category": "display",
     "capHeight": 608,
     "ascent": 800,
     "descent": -231,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 385,
-    "xWidthAvg": 391,
-    "category": "display"
+    "xWidthAvg": 391
   },
-  {
+  "flavors": {
     "familyName": "Flavors",
+    "category": "display",
     "capHeight": 801,
     "ascent": 1015,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 845,
-    "xWidthAvg": 431,
-    "category": "display"
+    "xWidthAvg": 431
   },
-  {
+  "flowRounded": {
     "familyName": "Flow Rounded",
+    "category": "display",
     "capHeight": 640,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 511,
-    "category": "display"
+    "xWidthAvg": 511
   },
-  {
+  "fontdinerSwanky": {
     "familyName": "Fontdiner Swanky",
+    "category": "display",
     "capHeight": 805,
     "ascent": 1047,
     "descent": -510,
     "lineGap": 20,
     "unitsPerEm": 1024,
     "xHeight": 579,
-    "xWidthAvg": 556,
-    "category": "display"
+    "xWidthAvg": 556
   },
-  {
+  "flowBlock": {
     "familyName": "Flow Block",
+    "category": "display",
     "capHeight": 640,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 511,
-    "category": "display"
+    "xWidthAvg": 511
   },
-  {
+  "fondamento": {
     "familyName": "Fondamento",
+    "category": "handwriting",
     "capHeight": 1439,
     "ascent": 2060,
     "descent": -774,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 953,
-    "xWidthAvg": 866,
-    "category": "handwriting"
+    "xWidthAvg": 866
   },
-  {
+  "flowCircular": {
     "familyName": "Flow Circular",
+    "category": "display",
     "capHeight": 640,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 505,
-    "category": "display"
+    "xWidthAvg": 505
   },
-  {
+  "fleurDeLeah": {
     "familyName": "Fleur De Leah",
+    "category": "handwriting",
     "capHeight": 620,
     "ascent": 920,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 324,
-    "xWidthAvg": 294,
-    "category": "handwriting"
+    "xWidthAvg": 294
   },
-  {
+  "fragmentMono": {
     "familyName": "Fragment Mono",
+    "category": "monospace",
     "capHeight": 699,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 524,
-    "xWidthAvg": 618,
-    "category": "monospace"
+    "xWidthAvg": 618
   },
-  {
+  "forum": {
     "familyName": "Forum",
+    "category": "display",
     "capHeight": 660,
     "ascent": 856,
     "descent": -248,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 420,
-    "xWidthAvg": 408,
-    "category": "display"
+    "xWidthAvg": 408
   },
-  {
+  "frankRuhlLibre": {
     "familyName": "Frank Ruhl Libre",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 957,
     "descent": -334,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 435,
-    "category": "serif"
+    "xWidthAvg": 435
   },
-  {
+  "fredokaOne": {
     "familyName": "Fredoka One",
+    "category": "display",
     "capHeight": 733,
     "ascent": 974,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 527,
-    "xWidthAvg": 485,
-    "category": "display"
+    "xWidthAvg": 485
   },
-  {
+  "freckleFace": {
     "familyName": "Freckle Face",
+    "category": "display",
     "capHeight": 1563,
     "ascent": 1946,
     "descent": -571,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1147,
-    "xWidthAvg": 866,
-    "category": "display"
+    "xWidthAvg": 866
   },
-  {
+  "fraunces": {
     "familyName": "Fraunces",
+    "category": "serif",
     "capHeight": 1400,
     "ascent": 1956,
     "descent": -510,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 964,
-    "xWidthAvg": 928,
-    "category": "serif"
+    "xWidthAvg": 928
   },
-  {
+  "fredoka": {
     "familyName": "Fredoka",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 974,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 451,
-    "category": "sans-serif"
+    "xWidthAvg": 451
   },
-  {
+  "freehand": {
     "familyName": "Freehand",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 754,
-    "category": "display"
+    "xWidthAvg": 754
   },
-  {
+  "fresca": {
     "familyName": "Fresca",
+    "category": "sans-serif",
     "capHeight": 648,
     "ascent": 869,
     "descent": -285,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 484,
-    "xWidthAvg": 408,
-    "category": "sans-serif"
+    "xWidthAvg": 408
   },
-  {
+  "frederickaTheGreat": {
     "familyName": "Fredericka the Great",
+    "category": "display",
     "capHeight": 772,
     "ascent": 1001,
     "descent": -254,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 519,
-    "xWidthAvg": 479,
-    "category": "display"
+    "xWidthAvg": 479
   },
-  {
+  "frijole": {
     "familyName": "Frijole",
+    "category": "display",
     "capHeight": 788,
     "ascent": 1075,
     "descent": -337,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 712,
-    "xWidthAvg": 765,
-    "category": "display"
+    "xWidthAvg": 765
   },
-  {
+  "francoisOne": {
     "familyName": "Francois One",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 1089,
     "descent": -329,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 563,
-    "xWidthAvg": 417,
-    "category": "sans-serif"
+    "xWidthAvg": 417
   },
-  {
+  "fruktur": {
     "familyName": "Fruktur",
+    "category": "display",
     "capHeight": 1529,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1182,
-    "xWidthAvg": 912,
-    "category": "display"
+    "xWidthAvg": 912
   },
-  {
+  "fugazOne": {
     "familyName": "Fugaz One",
+    "category": "display",
     "capHeight": 720,
     "ascent": 1046,
     "descent": -422,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 500,
-    "category": "display"
+    "xWidthAvg": 500
   },
-  {
+  "fuzzyBubbles": {
     "familyName": "Fuzzy Bubbles",
+    "category": "handwriting",
     "capHeight": 670,
     "ascent": 900,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 522,
-    "category": "handwriting"
+    "xWidthAvg": 522
   },
-  {
+  "gFSDidot": {
     "familyName": "GFS Didot",
+    "category": "serif",
     "capHeight": 689,
     "ascent": 947,
     "descent": -277,
     "lineGap": 25,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 458,
-    "category": "serif"
+    "xWidthAvg": 458
   },
-  {
+  "fuggles": {
     "familyName": "Fuggles",
+    "category": "handwriting",
     "capHeight": 667,
     "ascent": 850,
     "descent": -351,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 220,
-    "category": "handwriting"
+    "xWidthAvg": 220
   },
-  {
+  "gFSNeohellenic": {
     "familyName": "GFS Neohellenic",
+    "category": "sans-serif",
     "capHeight": 623,
     "ascent": 873,
     "descent": -245,
     "lineGap": 24,
     "unitsPerEm": 1000,
     "xHeight": 387,
-    "xWidthAvg": 386,
-    "category": "sans-serif"
+    "xWidthAvg": 386
   },
-  {
+  "gabriela": {
     "familyName": "Gabriela",
+    "category": "serif",
     "capHeight": 718,
     "ascent": 986,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 497,
-    "xWidthAvg": 481,
-    "category": "serif"
+    "xWidthAvg": 481
   },
-  {
+  "gafata": {
     "familyName": "Gafata",
+    "category": "sans-serif",
     "capHeight": 648,
     "ascent": 921,
     "descent": -202,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 405,
-    "category": "sans-serif"
+    "xWidthAvg": 405
   },
-  {
+  "galindo": {
     "familyName": "Galindo",
+    "category": "display",
     "capHeight": 1505,
     "ascent": 2014,
     "descent": -883,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1096,
-    "xWidthAvg": 1075,
-    "category": "display"
+    "xWidthAvg": 1075
   },
-  {
+  "gantari": {
     "familyName": "Gantari",
+    "category": "sans-serif",
     "capHeight": 668,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 458,
-    "category": "sans-serif"
+    "xWidthAvg": 458
   },
-  {
+  "galdeano": {
     "familyName": "Galdeano",
+    "category": "sans-serif",
     "capHeight": 605,
     "ascent": 820,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 166,
-    "xWidthAvg": 393,
-    "category": "sans-serif"
+    "xWidthAvg": 393
   },
-  {
+  "gelasio": {
     "familyName": "Gelasio",
+    "category": "serif",
     "capHeight": 1419,
     "ascent": 1900,
     "descent": -700,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 986,
-    "xWidthAvg": 899,
-    "category": "serif"
+    "xWidthAvg": 899
   },
-  {
+  "genos": {
     "familyName": "Genos",
+    "category": "sans-serif",
     "capHeight": 460,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 394,
-    "category": "sans-serif"
+    "xWidthAvg": 394
   },
-  {
+  "gayathri": {
     "familyName": "Gayathri",
+    "category": "sans-serif",
     "capHeight": 1385,
     "ascent": 1500,
     "descent": -1000,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1000,
-    "xWidthAvg": 898,
-    "category": "sans-serif"
+    "xWidthAvg": 898
   },
-  {
+  "gemunuLibre": {
     "familyName": "Gemunu Libre",
+    "category": "sans-serif",
     "capHeight": 0,
     "ascent": 884,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 0,
-    "xWidthAvg": 352,
-    "category": "sans-serif"
+    "xWidthAvg": 352
   },
-  {
+  "gaegu": {
     "familyName": "Gaegu",
+    "category": "handwriting",
     "capHeight": 525,
     "ascent": 760,
     "descent": -240,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 340,
-    "xWidthAvg": 501,
-    "category": "handwriting"
+    "xWidthAvg": 501
   },
-  {
+  "galada": {
     "familyName": "Galada",
+    "category": "display",
     "capHeight": 750,
     "ascent": 1035,
     "descent": -592,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 385,
-    "category": "display"
+    "xWidthAvg": 385
   },
-  {
+  "gentiumBookBasic": {
     "familyName": "Gentium Book Basic",
+    "category": "serif",
     "capHeight": 1260,
     "ascent": 1790,
     "descent": -580,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 863,
-    "category": "serif"
+    "xWidthAvg": 863
   },
-  {
+  "gentiumBookPlus": {
     "familyName": "Gentium Book Plus",
+    "category": "serif",
     "capHeight": 1260,
     "ascent": 2250,
     "descent": -750,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 859,
-    "category": "serif"
+    "xWidthAvg": 859
   },
-  {
+  "geostarFill": {
     "familyName": "Geostar Fill",
+    "category": "display",
     "capHeight": 695,
     "ascent": 922,
     "descent": -226,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 469,
-    "xWidthAvg": 644,
-    "category": "display"
+    "xWidthAvg": 644
   },
-  {
+  "geostar": {
     "familyName": "Geostar",
+    "category": "display",
     "capHeight": 695,
     "ascent": 922,
     "descent": -226,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 469,
-    "xWidthAvg": 644,
-    "category": "display"
+    "xWidthAvg": 644
   },
-  {
+  "geo": {
     "familyName": "Geo",
+    "category": "sans-serif",
     "capHeight": 573,
     "ascent": 821,
     "descent": -225,
     "lineGap": 92,
     "unitsPerEm": 1024,
     "xHeight": 451,
-    "xWidthAvg": 411,
-    "category": "sans-serif"
+    "xWidthAvg": 411
   },
-  {
+  "germaniaOne": {
     "familyName": "Germania One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 911,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 539,
-    "xWidthAvg": 393,
-    "category": "display"
+    "xWidthAvg": 393
   },
-  {
+  "gideonRoman": {
     "familyName": "Gideon Roman",
+    "category": "display",
     "capHeight": 660,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 465,
-    "category": "display"
+    "xWidthAvg": 465
   },
-  {
+  "gentiumPlus": {
     "familyName": "Gentium Plus",
+    "category": "serif",
     "capHeight": 1260,
     "ascent": 2250,
     "descent": -750,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 842,
-    "category": "serif"
+    "xWidthAvg": 842
   },
-  {
+  "georama": {
     "familyName": "Georama",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 968,
     "descent": -226,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 439,
-    "category": "sans-serif"
+    "xWidthAvg": 439
   },
-  {
+  "gildaDisplay": {
     "familyName": "Gilda Display",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 892,
     "descent": -285,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "gidugu": {
     "familyName": "Gidugu",
+    "category": "sans-serif",
     "ascent": 1294,
     "descent": -790,
     "lineGap": 0,
     "unitsPerEm": 1124,
-    "xWidthAvg": 323,
-    "category": "sans-serif"
+    "xWidthAvg": 323
   },
-  {
+  "girassol": {
     "familyName": "Girassol",
+    "category": "display",
     "capHeight": 750,
     "ascent": 944,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 416,
-    "category": "display"
+    "xWidthAvg": 416
   },
-  {
+  "giveYouGlory": {
     "familyName": "Give You Glory",
+    "category": "handwriting",
     "capHeight": 747,
     "ascent": 1020,
     "descent": -625,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 551,
-    "xWidthAvg": 460,
-    "category": "handwriting"
+    "xWidthAvg": 460
   },
-  {
+  "glassAntiqua": {
     "familyName": "Glass Antiqua",
+    "category": "display",
     "capHeight": 638,
     "ascent": 835,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 373,
-    "category": "display"
+    "xWidthAvg": 373
   },
-  {
+  "glory": {
     "familyName": "Glory",
+    "category": "sans-serif",
     "capHeight": 672,
     "ascent": 900,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 472,
-    "xWidthAvg": 389,
-    "category": "sans-serif"
+    "xWidthAvg": 389
   },
-  {
+  "gloriaHallelujah": {
     "familyName": "Gloria Hallelujah",
+    "category": "handwriting",
     "capHeight": 904,
     "ascent": 1439,
     "descent": -591,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 580,
-    "xWidthAvg": 519,
-    "category": "handwriting"
+    "xWidthAvg": 519
   },
-  {
+  "glegoo": {
     "familyName": "Glegoo",
+    "category": "serif",
     "ascent": 1267,
     "descent": -526,
     "lineGap": 0,
     "unitsPerEm": 1000,
-    "xWidthAvg": 509,
-    "category": "serif"
+    "xWidthAvg": 509
   },
-  {
+  "gluten": {
     "familyName": "Gluten",
+    "category": "display",
     "capHeight": 1167,
     "ascent": 1290,
     "descent": -475,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 833,
-    "xWidthAvg": 1024,
-    "category": "display"
+    "xWidthAvg": 1024
   },
-  {
+  "goblinOne": {
     "familyName": "Goblin One",
+    "category": "display",
     "capHeight": 1434,
     "ascent": 1920,
     "descent": -640,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1107,
-    "xWidthAvg": 1520,
-    "category": "display"
+    "xWidthAvg": 1520
   },
-  {
+  "gochiHand": {
     "familyName": "Gochi Hand",
+    "category": "handwriting",
     "capHeight": 975,
     "ascent": 1579,
     "descent": -835,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 765,
-    "xWidthAvg": 856,
-    "category": "handwriting"
+    "xWidthAvg": 856
   },
-  {
+  "goldman": {
     "familyName": "Goldman",
+    "category": "display",
     "capHeight": 588,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 448,
-    "xWidthAvg": 514,
-    "category": "display"
+    "xWidthAvg": 514
   },
-  {
+  "gorditas": {
     "familyName": "Gorditas",
+    "category": "display",
     "capHeight": 380,
     "ascent": 954,
     "descent": -259,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 274,
-    "xWidthAvg": 507,
-    "category": "display"
+    "xWidthAvg": 507
   },
-  {
+  "goudyBookletter1911": {
     "familyName": "Goudy Bookletter 1911",
+    "category": "serif",
     "capHeight": 691,
     "ascent": 983,
     "descent": -318,
     "lineGap": 92,
     "unitsPerEm": 1024,
     "xHeight": 458,
-    "xWidthAvg": 397,
-    "category": "serif"
+    "xWidthAvg": 397
   },
-  {
+  "graduate": {
     "familyName": "Graduate",
+    "category": "display",
     "capHeight": 750,
     "ascent": 953,
     "descent": -186,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 650,
-    "xWidthAvg": 601,
-    "category": "display"
+    "xWidthAvg": 601
   },
-  {
+  "grandHotel": {
     "familyName": "Grand Hotel",
+    "category": "handwriting",
     "capHeight": 1434,
     "ascent": 1938,
     "descent": -844,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 803,
-    "xWidthAvg": 611,
-    "category": "handwriting"
+    "xWidthAvg": 611
   },
-  {
+  "grandstander": {
     "familyName": "Grandstander",
+    "category": "display",
     "capHeight": 1291,
     "ascent": 1465,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1063,
-    "xWidthAvg": 1000,
-    "category": "display"
+    "xWidthAvg": 1000
   },
-  {
+  "gotu": {
     "familyName": "Gotu",
+    "category": "sans-serif",
     "capHeight": 713,
     "ascent": 1115,
     "descent": -545,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 493,
-    "category": "sans-serif"
+    "xWidthAvg": 493
   },
-  {
+  "grapeNuts": {
     "familyName": "Grape Nuts",
+    "category": "handwriting",
     "capHeight": 590,
     "ascent": 900,
     "descent": -325,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 365,
-    "xWidthAvg": 375,
-    "category": "handwriting"
+    "xWidthAvg": 375
   },
-  {
+  "gravitasOne": {
     "familyName": "Gravitas One",
+    "category": "display",
     "capHeight": 1417,
     "ascent": 1937,
     "descent": -668,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1113,
-    "xWidthAvg": 1480,
-    "category": "display"
+    "xWidthAvg": 1480
   },
-  {
+  "greatVibes": {
     "familyName": "Great Vibes",
+    "category": "handwriting",
     "capHeight": 800,
     "ascent": 851,
     "descent": -401,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 345,
-    "xWidthAvg": 288,
-    "category": "handwriting"
+    "xWidthAvg": 288
   },
-  {
+  "grechenFuemen": {
     "familyName": "Grechen Fuemen",
+    "category": "handwriting",
     "capHeight": 580,
     "ascent": 900,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 317,
-    "xWidthAvg": 421,
-    "category": "handwriting"
+    "xWidthAvg": 421
   },
-  {
+  "grenzeGotisch": {
     "familyName": "Grenze Gotisch",
+    "category": "display",
     "capHeight": 603,
     "ascent": 1100,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 448,
-    "xWidthAvg": 348,
-    "category": "display"
+    "xWidthAvg": 348
   },
-  {
+  "grenze": {
     "familyName": "Grenze",
+    "category": "serif",
     "capHeight": 603,
     "ascent": 1100,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 448,
-    "xWidthAvg": 352,
-    "category": "serif"
+    "xWidthAvg": 352
   },
-  {
+  "greyQo": {
     "familyName": "Grey Qo",
+    "category": "handwriting",
     "capHeight": 540,
     "ascent": 900,
     "descent": -360,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 265,
-    "xWidthAvg": 249,
-    "category": "handwriting"
+    "xWidthAvg": 249
   },
-  {
+  "gruppo": {
     "familyName": "Gruppo",
+    "category": "display",
     "capHeight": 1114,
     "ascent": 1639,
     "descent": -340,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 766,
-    "xWidthAvg": 933,
-    "category": "display"
+    "xWidthAvg": 933
   },
-  {
+  "griffy": {
     "familyName": "Griffy",
+    "category": "display",
     "capHeight": 0,
     "ascent": 984,
     "descent": -399,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 0,
-    "xWidthAvg": 428,
-    "category": "display"
+    "xWidthAvg": 428
   },
-  {
+  "gudea": {
     "familyName": "Gudea",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 972,
     "descent": -264,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 425,
-    "category": "sans-serif"
+    "xWidthAvg": 425
   },
-  {
+  "gothicA1": {
     "familyName": "Gothic A1",
+    "category": "sans-serif",
     "capHeight": 749,
     "ascent": 817,
     "descent": -207,
     "lineGap": 256,
     "unitsPerEm": 1024,
     "xHeight": 538,
-    "xWidthAvg": 459,
-    "category": "sans-serif"
+    "xWidthAvg": 459
   },
-  {
+  "habibi": {
     "familyName": "Habibi",
+    "category": "serif",
     "capHeight": 1508,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 989,
-    "xWidthAvg": 945,
-    "category": "serif"
+    "xWidthAvg": 945
   },
-  {
+  "gupter": {
     "familyName": "Gupter",
+    "category": "serif",
     "capHeight": 622,
     "ascent": 900,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 382,
-    "category": "serif"
+    "xWidthAvg": 382
   },
-  {
+  "gugi": {
     "familyName": "Gugi",
+    "category": "display",
     "capHeight": 794,
     "ascent": 858,
     "descent": -142,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 602,
-    "xWidthAvg": 603,
-    "category": "display"
+    "xWidthAvg": 603
   },
-  {
+  "gwendolyn": {
     "familyName": "Gwendolyn",
+    "category": "handwriting",
     "capHeight": 618,
     "ascent": 880,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 290,
-    "xWidthAvg": 306,
-    "category": "handwriting"
+    "xWidthAvg": 306
   },
-  {
+  "hanalei": {
     "familyName": "Hanalei",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2124,
     "descent": -541,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 936,
-    "category": "display"
+    "xWidthAvg": 936
   },
-  {
+  "gurajada": {
     "familyName": "Gurajada",
+    "category": "serif",
     "capHeight": 482,
     "ascent": 1294,
     "descent": -810,
     "lineGap": 0,
     "unitsPerEm": 1070,
     "xHeight": 358,
-    "xWidthAvg": 293,
-    "category": "serif"
+    "xWidthAvg": 293
   },
-  {
+  "halant": {
     "familyName": "Halant",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 1089,
     "descent": -486,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 504,
-    "xWidthAvg": 423,
-    "category": "serif"
+    "xWidthAvg": 423
   },
-  {
+  "hammersmithOne": {
     "familyName": "Hammersmith One",
+    "category": "sans-serif",
     "capHeight": 1330,
     "ascent": 1844,
     "descent": -716,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1045,
-    "xWidthAvg": 979,
-    "category": "sans-serif"
+    "xWidthAvg": 979
   },
-  {
+  "gulzar": {
     "familyName": "Gulzar",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 396,
-    "category": "serif"
+    "xWidthAvg": 396
   },
-  {
+  "handlee": {
     "familyName": "Handlee",
+    "category": "handwriting",
     "capHeight": 438,
     "ascent": 934,
     "descent": -401,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 331,
-    "xWidthAvg": 393,
-    "category": "handwriting"
+    "xWidthAvg": 393
   },
-  {
+  "hanaleiFill": {
     "familyName": "Hanalei Fill",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2124,
     "descent": -541,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 936,
-    "category": "display"
+    "xWidthAvg": 936
   },
-  {
+  "hankenGrotesk": {
     "familyName": "Hanken Grotesk",
+    "category": "sans-serif",
     "capHeight": 697,
     "ascent": 1000,
     "descent": -303,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 493,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "hahmlet": {
     "familyName": "Hahmlet",
+    "category": "serif",
     "capHeight": 742,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 486,
-    "category": "serif"
+    "xWidthAvg": 486
   },
-  {
+  "headlandOne": {
     "familyName": "HeadlandOne",
+    "category": "serif",
     "capHeight": 1530,
     "ascent": 2043,
     "descent": -522,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1189,
-    "xWidthAvg": 1093,
-    "category": "serif"
+    "xWidthAvg": 1093
   },
-  {
+  "hanuman": {
     "familyName": "Hanuman",
+    "category": "serif",
     "capHeight": 1462,
     "ascent": 2000,
     "descent": -1000,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1004,
-    "category": "serif"
+    "xWidthAvg": 1004
   },
-  {
+  "happyMonkey": {
     "familyName": "Happy Monkey",
+    "category": "display",
     "capHeight": 699,
     "ascent": 950,
     "descent": -255,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 504,
-    "category": "display"
+    "xWidthAvg": 504
   },
-  {
+  "harmattan": {
     "familyName": "Harmattan",
+    "category": "sans-serif",
     "capHeight": 1111,
     "ascent": 2166,
     "descent": -1323,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 778,
-    "xWidthAvg": 715,
-    "category": "sans-serif"
+    "xWidthAvg": 715
   },
-  {
+  "heebo": {
     "familyName": "Heebo",
+    "category": "sans-serif",
     "capHeight": 1456,
     "ascent": 2146,
     "descent": -862,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1178,
-    "xWidthAvg": 906,
-    "category": "sans-serif"
+    "xWidthAvg": 906
   },
-  {
+  "herrVonMuellerhoff": {
     "familyName": "Herr Von Muellerhoff",
+    "category": "handwriting",
     "capHeight": 644,
     "ascent": 925,
     "descent": -497,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 269,
-    "xWidthAvg": 250,
-    "category": "handwriting"
+    "xWidthAvg": 250
   },
-  {
+  "hennyPenny": {
     "familyName": "Henny Penny",
+    "category": "display",
     "capHeight": 1794,
     "ascent": 2324,
     "descent": -1305,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1264,
-    "xWidthAvg": 925,
-    "category": "display"
+    "xWidthAvg": 925
   },
-  {
+  "hachiMaruPop": {
     "familyName": "Hachi Maru Pop",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 659,
-    "category": "handwriting"
+    "xWidthAvg": 659
   },
-  {
+  "heptaSlab": {
     "familyName": "Hepta Slab",
+    "category": "serif",
     "capHeight": 1504,
     "ascent": 1976,
     "descent": -526,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1052,
-    "xWidthAvg": 1099,
-    "category": "serif"
+    "xWidthAvg": 1099
   },
-  {
+  "hind": {
     "familyName": "Hind",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 1055,
     "descent": -546,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "hindMadurai": {
     "familyName": "Hind Madurai",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 982,
     "descent": -398,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "gamjaFlower": {
     "familyName": "Gamja Flower",
+    "category": "handwriting",
     "capHeight": 526,
     "ascent": 800,
     "descent": -224,
     "lineGap": 256,
     "unitsPerEm": 1024,
     "xHeight": 311,
-    "xWidthAvg": 486,
-    "category": "handwriting"
+    "xWidthAvg": 486
   },
-  {
+  "hindGuntur": {
     "familyName": "Hind Guntur",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 1115,
     "descent": -773,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "holtwoodOneSC": {
     "familyName": "Holtwood One SC",
+    "category": "serif",
     "capHeight": 1536,
     "ascent": 2457,
     "descent": -876,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1408,
-    "xWidthAvg": 1451,
-    "category": "serif"
+    "xWidthAvg": 1451
   },
-  {
+  "gowunBatang": {
     "familyName": "Gowun Batang",
+    "category": "serif",
     "capHeight": 775,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 440,
-    "category": "serif"
+    "xWidthAvg": 440
   },
-  {
+  "hindVadodara": {
     "familyName": "Hind Vadodara",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 1125,
     "descent": -373,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "hindSiliguri": {
     "familyName": "Hind Siliguri",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 1116,
     "descent": -501,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 505,
-    "xWidthAvg": 427,
-    "category": "sans-serif"
+    "xWidthAvg": 427
   },
-  {
+  "homenaje": {
     "familyName": "Homenaje",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 892,
     "descent": -204,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 307,
-    "category": "sans-serif"
+    "xWidthAvg": 307
   },
-  {
+  "hubballi": {
     "familyName": "Hubballi",
+    "category": "display",
     "capHeight": 535,
     "ascent": 765,
     "descent": -191,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 392,
-    "xWidthAvg": 411,
-    "category": "display"
+    "xWidthAvg": 411
   },
-  {
+  "iBMPlexMono": {
     "familyName": "IBM Plex Mono",
+    "category": "monospace",
     "capHeight": 698,
     "ascent": 1025,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "iBMPlexSans": {
     "familyName": "IBM Plex Sans",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1025,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "hurricane": {
     "familyName": "Hurricane",
+    "category": "handwriting",
     "capHeight": 610,
     "ascent": 950,
     "descent": -430,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 326,
-    "xWidthAvg": 271,
-    "category": "handwriting"
+    "xWidthAvg": 271
   },
-  {
+  "iBMPlexSansArabic": {
     "familyName": "IBM Plex Sans Arabic",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1085,
     "descent": -415,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "iBMPlexSansCondensed": {
     "familyName": "IBM Plex Sans Condensed",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1025,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 403,
-    "category": "sans-serif"
+    "xWidthAvg": 403
   },
-  {
+  "iBMPlexSansHebrew": {
     "familyName": "IBM Plex Sans Hebrew",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1025,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "iBMPlexSansThai": {
     "familyName": "IBM Plex Sans Thai",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1116,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "homemadeApple": {
     "familyName": "Homemade Apple",
+    "category": "handwriting",
     "capHeight": 1022,
     "ascent": 1327,
     "descent": -866,
     "lineGap": 18,
     "unitsPerEm": 1024,
     "xHeight": 600,
-    "xWidthAvg": 565,
-    "category": "handwriting"
+    "xWidthAvg": 565
   },
-  {
+  "iBMPlexSansThaiLooped": {
     "familyName": "IBM Plex Sans Thai Looped",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1116,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "iMFELLDoublePica": {
     "familyName": "IM FELL Double Pica",
+    "category": "serif",
     "capHeight": 1509,
     "ascent": 1924,
     "descent": -643,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 926,
-    "xWidthAvg": 789,
-    "category": "serif"
+    "xWidthAvg": 789
   },
-  {
+  "iMFELLDWPicaSC": {
     "familyName": "IM FELL DW Pica SC",
+    "category": "serif",
     "capHeight": 1438,
     "ascent": 1868,
     "descent": -692,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 903,
-    "xWidthAvg": 859,
-    "category": "serif"
+    "xWidthAvg": 859
   },
-  {
+  "iBMPlexSerif": {
     "familyName": "IBM Plex Serif",
+    "category": "serif",
     "capHeight": 698,
     "ascent": 1025,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 468,
-    "category": "serif"
+    "xWidthAvg": 468
   },
-  {
+  "iMFELLDWPica": {
     "familyName": "IM FELL DW Pica",
+    "category": "serif",
     "capHeight": 1438,
     "ascent": 1868,
     "descent": -692,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 903,
-    "xWidthAvg": 794,
-    "category": "serif"
+    "xWidthAvg": 794
   },
-  {
+  "iMFELLDoublePicaSC": {
     "familyName": "IM FELL Double Pica SC",
+    "category": "serif",
     "capHeight": 1509,
     "ascent": 1924,
     "descent": -643,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 946,
-    "xWidthAvg": 874,
-    "category": "serif"
+    "xWidthAvg": 874
   },
-  {
+  "iBMPlexSansDevanagari": {
     "familyName": "IBM Plex Sans Devanagari",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1070,
     "descent": -460,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "iMFELLEnglishSC": {
     "familyName": "IM FELL English SC",
+    "category": "serif",
     "capHeight": 1417,
     "ascent": 1854,
     "descent": -744,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 901,
-    "xWidthAvg": 883,
-    "category": "serif"
+    "xWidthAvg": 883
   },
-  {
+  "iMFELLEnglish": {
     "familyName": "IM FELL English",
+    "category": "serif",
     "capHeight": 1417,
     "ascent": 1854,
     "descent": -744,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 962,
-    "xWidthAvg": 832,
-    "category": "serif"
+    "xWidthAvg": 832
   },
-  {
+  "iMFELLFrenchCanonSC": {
     "familyName": "IM FELL French Canon SC",
+    "category": "serif",
     "capHeight": 1465,
     "ascent": 1868,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 984,
-    "xWidthAvg": 926,
-    "category": "serif"
+    "xWidthAvg": 926
   },
-  {
+  "iMFELLGreatPrimer": {
     "familyName": "IM FELL Great Primer",
+    "category": "serif",
     "capHeight": 1488,
     "ascent": 1942,
     "descent": -562,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 962,
-    "xWidthAvg": 818,
-    "category": "serif"
+    "xWidthAvg": 818
   },
-  {
+  "iMFELLFrenchCanon": {
     "familyName": "IM FELL French Canon",
+    "category": "serif",
     "capHeight": 1465,
     "ascent": 1868,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 981,
-    "xWidthAvg": 870,
-    "category": "serif"
+    "xWidthAvg": 870
   },
-  {
+  "iBMPlexSansKR": {
     "familyName": "IBM Plex Sans KR",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1085,
     "descent": -415,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 516,
-    "xWidthAvg": 446,
-    "category": "sans-serif"
+    "xWidthAvg": 446
   },
-  {
+  "iceberg": {
     "familyName": "Iceberg",
+    "category": "display",
     "capHeight": 691,
     "ascent": 936,
     "descent": -284,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 519,
-    "xWidthAvg": 408,
-    "category": "display"
+    "xWidthAvg": 408
   },
-  {
+  "ibarraRealNova": {
     "familyName": "Ibarra Real Nova",
+    "category": "serif",
     "capHeight": 673,
     "ascent": 950,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 426,
-    "xWidthAvg": 413,
-    "category": "serif"
+    "xWidthAvg": 413
   },
-  {
+  "iMFELLGreatPrimerSC": {
     "familyName": "IM FELL Great Primer SC",
+    "category": "serif",
     "capHeight": 1488,
     "ascent": 1942,
     "descent": -562,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 957,
-    "xWidthAvg": 933,
-    "category": "serif"
+    "xWidthAvg": 933
   },
-  {
+  "iceland": {
     "familyName": "Iceland",
+    "category": "display",
     "capHeight": 490,
     "ascent": 750,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 389,
-    "category": "display"
+    "xWidthAvg": 389
   },
-  {
+  "imbue10pt": {
     "familyName": "Imbue 10pt",
+    "category": "serif",
     "capHeight": 1400,
     "ascent": 1900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1046,
-    "xWidthAvg": 580,
-    "category": "serif"
+    "xWidthAvg": 580
   },
-  {
+  "imperialScript": {
     "familyName": "Imperial Script",
+    "category": "handwriting",
     "capHeight": 620,
     "ascent": 880,
     "descent": -330,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 325,
-    "xWidthAvg": 272,
-    "category": "handwriting"
+    "xWidthAvg": 272
   },
-  {
+  "imprima": {
     "familyName": "Imprima",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 919,
     "descent": -239,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 434,
-    "category": "sans-serif"
+    "xWidthAvg": 434
   },
-  {
+  "inder": {
     "familyName": "Inder",
+    "category": "sans-serif",
     "capHeight": 1392,
     "ascent": 2040,
     "descent": -520,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1032,
-    "xWidthAvg": 981,
-    "category": "sans-serif"
+    "xWidthAvg": 981
   },
-  {
+  "inconsolata": {
     "familyName": "Inconsolata",
+    "category": "monospace",
     "capHeight": 623,
     "ascent": 859,
     "descent": -190,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 457,
-    "xWidthAvg": 500,
-    "category": "monospace"
+    "xWidthAvg": 500
   },
-  {
+  "indieFlower": {
     "familyName": "Indie Flower",
+    "category": "handwriting",
     "capHeight": 587,
     "ascent": 994,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 374,
-    "xWidthAvg": 434,
-    "category": "handwriting"
+    "xWidthAvg": 434
   },
-  {
+  "ingridDarling": {
     "familyName": "Ingrid Darling",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 860,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 236,
-    "category": "handwriting"
+    "xWidthAvg": 236
   },
-  {
+  "inika": {
     "familyName": "Inika",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1006,
     "descent": -297,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 509,
-    "xWidthAvg": 463,
-    "category": "serif"
+    "xWidthAvg": 463
   },
-  {
+  "inriaSans": {
     "familyName": "Inria Sans",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 976,
     "descent": -223,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "inriaSerif": {
     "familyName": "Inria Serif",
+    "category": "serif",
     "capHeight": 680,
     "ascent": 976,
     "descent": -223,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 495,
-    "xWidthAvg": 460,
-    "category": "serif"
+    "xWidthAvg": 460
   },
-  {
+  "iBMPlexSansJP": {
     "familyName": "IBM Plex Sans JP",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1060,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 541,
-    "xWidthAvg": 468,
-    "category": "sans-serif"
+    "xWidthAvg": 468
   },
-  {
+  "inknutAntiqua": {
     "familyName": "Inknut Antiqua",
+    "category": "serif",
     "capHeight": 786,
     "ascent": 1703,
     "descent": -876,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 531,
-    "xWidthAvg": 550,
-    "category": "serif"
+    "xWidthAvg": 550
   },
-  {
+  "inspiration": {
     "familyName": "Inspiration",
+    "category": "handwriting",
     "capHeight": 680,
     "ascent": 870,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 340,
-    "xWidthAvg": 236,
-    "category": "handwriting"
+    "xWidthAvg": 236
   },
-  {
+  "inter": {
     "familyName": "Inter",
+    "category": "sans-serif",
     "capHeight": 2048,
     "ascent": 2728,
     "descent": -680,
     "lineGap": 0,
     "unitsPerEm": 2816,
     "xHeight": 1536,
-    "xWidthAvg": 1335,
-    "category": "sans-serif"
+    "xWidthAvg": 1335
   },
-  {
+  "interTight": {
     "familyName": "Inter Tight",
+    "category": "sans-serif",
     "capHeight": 1490,
     "ascent": 1984,
     "descent": -494,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1118,
-    "xWidthAvg": 874,
-    "category": "sans-serif"
+    "xWidthAvg": 874
   },
-  {
+  "irishGrover": {
     "familyName": "Irish Grover",
+    "category": "display",
     "capHeight": 731,
     "ascent": 965,
     "descent": -246,
     "lineGap": 27,
     "unitsPerEm": 1024,
     "xHeight": 573,
-    "xWidthAvg": 474,
-    "category": "display"
+    "xWidthAvg": 474
   },
-  {
+  "italiana": {
     "familyName": "Italiana",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 928,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 436,
-    "category": "serif"
+    "xWidthAvg": 436
   },
-  {
+  "hinaMincho": {
     "familyName": "Hina Mincho",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 380,
-    "xWidthAvg": 367,
-    "category": "serif"
+    "xWidthAvg": 367
   },
-  {
+  "islandMoments": {
     "familyName": "Island Moments",
+    "category": "handwriting",
     "capHeight": 480,
     "ascent": 750,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 270,
-    "xWidthAvg": 273,
-    "category": "handwriting"
+    "xWidthAvg": 273
   },
-  {
+  "istokWeb": {
     "familyName": "Istok Web",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 2061,
     "descent": -887,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1050,
-    "xWidthAvg": 924,
-    "category": "sans-serif"
+    "xWidthAvg": 924
   },
-  {
+  "italianno": {
     "familyName": "Italianno",
+    "category": "handwriting",
     "capHeight": 577,
     "ascent": 800,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 273,
-    "xWidthAvg": 253,
-    "category": "handwriting"
+    "xWidthAvg": 253
   },
-  {
+  "jacquesFrancoisShadow": {
     "familyName": "Jacques Francois Shadow",
+    "category": "display",
     "capHeight": 1513,
     "ascent": 2095,
     "descent": -606,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 1017,
-    "category": "display"
+    "xWidthAvg": 1017
   },
-  {
+  "itim": {
     "familyName": "Itim",
+    "category": "handwriting",
     "capHeight": 635,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 474,
-    "xWidthAvg": 427,
-    "category": "handwriting"
+    "xWidthAvg": 427
   },
-  {
+  "jacquesFrancois": {
     "familyName": "Jacques Francois",
+    "category": "serif",
     "capHeight": 1464,
     "ascent": 2095,
     "descent": -606,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 879,
-    "xWidthAvg": 930,
-    "category": "serif"
+    "xWidthAvg": 930
   },
-  {
+  "jaldi": {
     "familyName": "Jaldi",
+    "category": "sans-serif",
     "capHeight": 1243,
     "ascent": 2350,
     "descent": -1111,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 785,
-    "category": "sans-serif"
+    "xWidthAvg": 785
   },
-  {
+  "jetBrainsMono": {
     "familyName": "JetBrains Mono",
+    "category": "monospace",
     "capHeight": 730,
     "ascent": 1020,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "jockeyOne": {
     "familyName": "Jockey One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1079,
     "descent": -319,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 511,
-    "xWidthAvg": 369,
-    "category": "sans-serif"
+    "xWidthAvg": 369
   },
-  {
+  "jimNightshade": {
     "familyName": "Jim Nightshade",
+    "category": "handwriting",
     "capHeight": 1234,
     "ascent": 1852,
     "descent": -1050,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 930,
-    "xWidthAvg": 613,
-    "category": "handwriting"
+    "xWidthAvg": 613
   },
-  {
+  "jollyLodger": {
     "familyName": "Jolly Lodger",
+    "category": "display",
     "capHeight": 757,
     "ascent": 988,
     "descent": -257,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 642,
-    "xWidthAvg": 291,
-    "category": "display"
+    "xWidthAvg": 291
   },
-  {
+  "joan": {
     "familyName": "Joan",
+    "category": "serif",
     "capHeight": 707,
     "ascent": 1000,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 406,
-    "category": "serif"
+    "xWidthAvg": 406
   },
-  {
+  "jomhuria": {
     "familyName": "Jomhuria",
+    "category": "display",
     "capHeight": 1172,
     "ascent": 1840,
     "descent": -1160,
     "lineGap": 0,
     "unitsPerEm": 3000,
     "xHeight": 850,
-    "xWidthAvg": 737,
-    "category": "display"
+    "xWidthAvg": 737
   },
-  {
+  "josefinSlab": {
     "familyName": "Josefin Slab",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 375,
-    "xWidthAvg": 424,
-    "category": "serif"
+    "xWidthAvg": 424
   },
-  {
+  "jost": {
     "familyName": "Jost",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1070,
     "descent": -375,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 423,
-    "category": "sans-serif"
+    "xWidthAvg": 423
   },
-  {
+  "jotiOne": {
     "familyName": "Joti One",
+    "category": "display",
     "capHeight": 665,
     "ascent": 1003,
     "descent": -331,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 503,
-    "category": "display"
+    "xWidthAvg": 503
   },
-  {
+  "hiMelody": {
     "familyName": "Hi Melody",
+    "category": "handwriting",
     "capHeight": 512,
     "ascent": 679,
     "descent": -345,
     "lineGap": 256,
     "unitsPerEm": 1024,
     "xHeight": 321,
-    "xWidthAvg": 447,
-    "category": "handwriting"
+    "xWidthAvg": 447
   },
-  {
+  "judson": {
     "familyName": "Judson",
+    "category": "serif",
     "capHeight": 585,
     "ascent": 902,
     "descent": -248,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 440,
-    "xWidthAvg": 426,
-    "category": "serif"
+    "xWidthAvg": 426
   },
-  {
+  "juliusSansOne": {
     "familyName": "Julius Sans One",
+    "category": "sans-serif",
     "capHeight": 715,
     "ascent": 863,
     "descent": -228,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 649,
-    "xWidthAvg": 564,
-    "category": "sans-serif"
+    "xWidthAvg": 564
   },
-  {
+  "julee": {
     "familyName": "Julee",
+    "category": "handwriting",
     "capHeight": 207,
     "ascent": 894,
     "descent": -284,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 153,
-    "xWidthAvg": 392,
-    "category": "handwriting"
+    "xWidthAvg": 392
   },
-  {
+  "josefinSans": {
     "familyName": "Josefin Sans",
+    "category": "sans-serif",
     "capHeight": 702,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 378,
-    "xWidthAvg": 454,
-    "category": "sans-serif"
+    "xWidthAvg": 454
   },
-  {
+  "junge": {
     "familyName": "Junge",
+    "category": "serif",
     "capHeight": 1444,
     "ascent": 1901,
     "descent": -588,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1010,
-    "xWidthAvg": 958,
-    "category": "serif"
+    "xWidthAvg": 958
   },
-  {
+  "jura": {
     "familyName": "Jura",
+    "category": "sans-serif",
     "capHeight": 1266,
     "ascent": 1930,
     "descent": -436,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 922,
-    "xWidthAvg": 953,
-    "category": "sans-serif"
+    "xWidthAvg": 953
   },
-  {
+  "justAnotherHand": {
     "familyName": "Just Another Hand",
+    "category": "handwriting",
     "capHeight": 1436,
     "ascent": 1440,
     "descent": -608,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 880,
-    "xWidthAvg": 439,
-    "category": "handwriting"
+    "xWidthAvg": 439
   },
-  {
+  "jua": {
     "familyName": "Jua",
+    "category": "sans-serif",
     "capHeight": 711,
     "ascent": 800,
     "descent": -200,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 432,
-    "xWidthAvg": 572,
-    "category": "sans-serif"
+    "xWidthAvg": 572
   },
-  {
+  "justMeAgainDownHere": {
     "familyName": "Just Me Again Down Here",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 1069,
     "descent": -429,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 289,
-    "xWidthAvg": 314,
-    "category": "handwriting"
+    "xWidthAvg": 314
   },
-  {
+  "k2D": {
     "familyName": "K2D",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1048,
     "descent": -252,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 453,
-    "category": "sans-serif"
+    "xWidthAvg": 453
   },
-  {
+  "kadwa": {
     "familyName": "Kadwa",
+    "category": "serif",
     "capHeight": 1434,
     "ascent": 2691,
     "descent": -1421,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1085,
-    "xWidthAvg": 986,
-    "category": "serif"
+    "xWidthAvg": 986
   },
-  {
+  "kameron": {
     "familyName": "Kameron",
+    "category": "serif",
     "capHeight": 1290,
     "ascent": 1823,
     "descent": -608,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 894,
-    "xWidthAvg": 918,
-    "category": "serif"
+    "xWidthAvg": 918
   },
-  {
+  "kanit": {
     "familyName": "Kanit",
+    "category": "sans-serif",
     "capHeight": 644,
     "ascent": 1100,
     "descent": -395,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 474,
-    "xWidthAvg": 451,
-    "category": "sans-serif"
+    "xWidthAvg": 451
   },
-  {
+  "kalam": {
     "familyName": "Kalam",
+    "category": "handwriting",
     "capHeight": 739,
     "ascent": 1063,
     "descent": -531,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 526,
-    "xWidthAvg": 435,
-    "category": "handwriting"
+    "xWidthAvg": 435
   },
-  {
+  "kantumruyPro": {
     "familyName": "Kantumruy Pro",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 920,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 479,
-    "category": "sans-serif"
+    "xWidthAvg": 479
   },
-  {
+  "karantina": {
     "familyName": "Karantina",
+    "category": "display",
     "capHeight": 700,
     "ascent": 859,
     "descent": -153,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 259,
-    "category": "display"
+    "xWidthAvg": 259
   },
-  {
+  "karla": {
     "familyName": "Karla",
+    "category": "sans-serif",
     "capHeight": 1256,
     "ascent": 1834,
     "descent": -504,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 956,
-    "xWidthAvg": 913,
-    "category": "sans-serif"
+    "xWidthAvg": 913
   },
-  {
+  "kantumruy": {
     "familyName": "Kantumruy",
+    "category": "sans-serif",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1773,
-    "category": "sans-serif"
+    "xWidthAvg": 1773
   },
-  {
+  "gowunDodum": {
     "familyName": "Gowun Dodum",
+    "category": "sans-serif",
     "capHeight": 775,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 426,
-    "category": "sans-serif"
+    "xWidthAvg": 426
   },
-  {
+  "karma": {
     "familyName": "Karma",
+    "category": "serif",
     "capHeight": 677,
     "ascent": 945,
     "descent": -508,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 489,
-    "xWidthAvg": 440,
-    "category": "serif"
+    "xWidthAvg": 440
   },
-  {
+  "kavivanar": {
     "familyName": "Kavivanar",
+    "category": "handwriting",
     "ascent": 1065,
     "descent": -417,
     "lineGap": 0,
     "unitsPerEm": 1000,
-    "xWidthAvg": 416,
-    "category": "handwriting"
+    "xWidthAvg": 416
   },
-  {
+  "katibeh": {
     "familyName": "Katibeh",
+    "category": "display",
     "capHeight": 700,
     "ascent": 490,
     "descent": -510,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 319,
-    "category": "display"
+    "xWidthAvg": 319
   },
-  {
+  "kaushanScript": {
     "familyName": "Kaushan Script",
+    "category": "handwriting",
     "capHeight": 714,
     "ascent": 1084,
     "descent": -367,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 452,
-    "xWidthAvg": 391,
-    "category": "handwriting"
+    "xWidthAvg": 391
   },
-  {
+  "kavoon": {
     "familyName": "Kavoon",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1185,
-    "xWidthAvg": 991,
-    "category": "display"
+    "xWidthAvg": 991
   },
-  {
+  "kdamThmorPro": {
     "familyName": "Kdam Thmor Pro",
+    "category": "sans-serif",
     "capHeight": 793,
     "ascent": 1146,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 612,
-    "xWidthAvg": 450,
-    "category": "sans-serif"
+    "xWidthAvg": 450
   },
-  {
+  "kaiseiOpti": {
     "familyName": "Kaisei Opti",
+    "category": "serif",
     "capHeight": 738,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "keaniaOne": {
     "familyName": "Keania One",
+    "category": "display",
     "capHeight": 723,
     "ascent": 989,
     "descent": -228,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 432,
-    "category": "display"
+    "xWidthAvg": 432
   },
-  {
+  "kellySlab": {
     "familyName": "Kelly Slab",
+    "category": "display",
     "capHeight": 750,
     "ascent": 962,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 446,
-    "category": "display"
+    "xWidthAvg": 446
   },
-  {
+  "kenia": {
     "familyName": "Kenia",
+    "category": "display",
     "capHeight": 727,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 512,
-    "xWidthAvg": 373,
-    "category": "display"
+    "xWidthAvg": 373
   },
-  {
+  "khand": {
     "familyName": "Khand",
+    "category": "sans-serif",
     "capHeight": 672,
     "ascent": 1050,
     "descent": -479,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 569,
-    "xWidthAvg": 353,
-    "category": "sans-serif"
+    "xWidthAvg": 353
   },
-  {
+  "khmer": {
     "familyName": "Khmer",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2300,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1773,
-    "category": "display"
+    "xWidthAvg": 1773
   },
-  {
+  "khula": {
     "familyName": "Khula",
+    "category": "sans-serif",
     "capHeight": 1316,
     "ascent": 1978,
     "descent": -1198,
     "lineGap": 0,
     "unitsPerEm": 1978,
     "xHeight": 986,
-    "xWidthAvg": 870,
-    "category": "sans-serif"
+    "xWidthAvg": 870
   },
-  {
+  "kiteOne": {
     "familyName": "Kite One",
+    "category": "sans-serif",
     "capHeight": 860,
     "ascent": 1094,
     "descent": -351,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 493,
-    "xWidthAvg": 427,
-    "category": "sans-serif"
+    "xWidthAvg": 427
   },
-  {
+  "kings": {
     "familyName": "Kings",
+    "category": "handwriting",
     "capHeight": 630,
     "ascent": 950,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 359,
-    "category": "handwriting"
+    "xWidthAvg": 359
   },
-  {
+  "knewave": {
     "familyName": "Knewave",
+    "category": "display",
     "capHeight": 780,
     "ascent": 1169,
     "descent": -385,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 497,
-    "xWidthAvg": 468,
-    "category": "display"
+    "xWidthAvg": 468
   },
-  {
+  "koHo": {
     "familyName": "KoHo",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1045,
     "descent": -255,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "kodchasan": {
     "familyName": "Kodchasan",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1024,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 490,
-    "xWidthAvg": 499,
-    "category": "sans-serif"
+    "xWidthAvg": 499
   },
-  {
+  "kohSantepheap": {
     "familyName": "Koh Santepheap",
+    "category": "display",
     "capHeight": 700,
     "ascent": 2050,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 500,
-    "xWidthAvg": 980,
-    "category": "display"
+    "xWidthAvg": 980
   },
-  {
+  "kaiseiTokumin": {
     "familyName": "Kaisei Tokumin",
+    "category": "serif",
     "capHeight": 738,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "kolkerBrush": {
     "familyName": "Kolker Brush",
+    "category": "handwriting",
     "capHeight": 480,
     "ascent": 750,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 205,
-    "xWidthAvg": 209,
-    "category": "handwriting"
+    "xWidthAvg": 209
   },
-  {
+  "kosugi": {
     "familyName": "Kosugi",
+    "category": "sans-serif",
     "capHeight": 774,
     "ascent": 901,
     "descent": -123,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 539,
-    "xWidthAvg": 512,
-    "category": "sans-serif"
+    "xWidthAvg": 512
   },
-  {
+  "kottaOne": {
     "familyName": "Kotta One",
+    "category": "serif",
     "capHeight": 212,
     "ascent": 915,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 76,
-    "xWidthAvg": 431,
-    "category": "serif"
+    "xWidthAvg": 431
   },
-  {
+  "kirangHaerang": {
     "familyName": "Kirang Haerang",
+    "category": "display",
     "capHeight": 558,
     "ascent": 750,
     "descent": -250,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 337,
-    "xWidthAvg": 463,
-    "category": "display"
+    "xWidthAvg": 463
   },
-  {
+  "koulen": {
     "familyName": "Koulen",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 819,
-    "category": "display"
+    "xWidthAvg": 819
   },
-  {
+  "kristi": {
     "familyName": "Kristi",
+    "category": "handwriting",
     "ascent": 1836,
     "descent": -724,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 541,
-    "category": "handwriting"
+    "xWidthAvg": 541
   },
-  {
+  "kreon": {
     "familyName": "Kreon",
+    "category": "serif",
     "capHeight": 691,
     "ascent": 974,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 481,
-    "xWidthAvg": 408,
-    "category": "serif"
+    "xWidthAvg": 408
   },
-  {
+  "kronaOne": {
     "familyName": "Krona One",
+    "category": "sans-serif",
     "capHeight": 1563,
     "ascent": 2030,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1180,
-    "xWidthAvg": 1340,
-    "category": "sans-serif"
+    "xWidthAvg": 1340
   },
-  {
+  "kosugiMaru": {
     "familyName": "Kosugi Maru",
+    "category": "sans-serif",
     "capHeight": 781,
     "ascent": 901,
     "descent": -123,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 546,
-    "xWidthAvg": 512,
-    "category": "sans-serif"
+    "xWidthAvg": 512
   },
-  {
+  "kranky": {
     "familyName": "Kranky",
+    "category": "display",
     "capHeight": 777,
     "ascent": 977,
     "descent": -294,
     "lineGap": 28,
     "unitsPerEm": 1024,
     "xHeight": 432,
-    "xWidthAvg": 460,
-    "category": "display"
+    "xWidthAvg": 460
   },
-  {
+  "jomolhari": {
     "familyName": "Jomolhari",
+    "category": "serif",
     "capHeight": 756,
     "ascent": 1248,
     "descent": -392,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 360,
-    "xWidthAvg": 459,
-    "category": "serif"
+    "xWidthAvg": 459
   },
-  {
+  "krub": {
     "familyName": "Krub",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1007,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 468,
-    "category": "sans-serif"
+    "xWidthAvg": 468
   },
-  {
+  "kulimPark": {
     "familyName": "Kulim Park",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 931,
     "descent": -204,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 457,
-    "category": "sans-serif"
+    "xWidthAvg": 457
   },
-  {
+  "kufam": {
     "familyName": "Kufam",
+    "category": "sans-serif",
     "capHeight": 720,
     "ascent": 900,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 544,
-    "xWidthAvg": 485,
-    "category": "sans-serif"
+    "xWidthAvg": 485
   },
-  {
+  "kumarOne": {
     "familyName": "Kumar One",
+    "category": "display",
     "capHeight": 800,
     "ascent": 1137,
     "descent": -642,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 594,
-    "category": "display"
+    "xWidthAvg": 594
   },
-  {
+  "kumbhSans": {
     "familyName": "Kumbh Sans",
+    "category": "sans-serif",
     "capHeight": 1500,
     "ascent": 2020,
     "descent": -520,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1000,
-    "xWidthAvg": 949,
-    "category": "sans-serif"
+    "xWidthAvg": 949
   },
-  {
+  "lacquer": {
     "familyName": "Lacquer",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 490,
-    "category": "display"
+    "xWidthAvg": 490
   },
-  {
+  "kurale": {
     "familyName": "Kurale",
+    "category": "serif",
     "capHeight": 650,
     "ascent": 1095,
     "descent": -383,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 446,
-    "category": "serif"
+    "xWidthAvg": 446
   },
-  {
+  "kumarOneOutline": {
     "familyName": "Kumar One Outline",
+    "category": "display",
     "capHeight": 800,
     "ascent": 1137,
     "descent": -642,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 593,
-    "category": "display"
+    "xWidthAvg": 593
   },
-  {
+  "laila": {
     "familyName": "Laila",
+    "category": "sans-serif",
     "capHeight": 717,
     "ascent": 1098,
     "descent": -452,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 517,
-    "xWidthAvg": 460,
-    "category": "sans-serif"
+    "xWidthAvg": 460
   },
-  {
+  "lakkiReddy": {
     "familyName": "Lakki Reddy",
+    "category": "handwriting",
     "capHeight": 718,
     "ascent": 938,
     "descent": -765,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 529,
-    "xWidthAvg": 460,
-    "category": "handwriting"
+    "xWidthAvg": 460
   },
-  {
+  "laBelleAurore": {
     "familyName": "La Belle Aurore",
+    "category": "handwriting",
     "capHeight": 688,
     "ascent": 1103,
     "descent": -794,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 377,
-    "xWidthAvg": 421,
-    "category": "handwriting"
+    "xWidthAvg": 421
   },
-  {
+  "lancelot": {
     "familyName": "Lancelot",
+    "category": "display",
     "capHeight": 1190,
     "ascent": 1595,
     "descent": -668,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 804,
-    "xWidthAvg": 721,
-    "category": "display"
+    "xWidthAvg": 721
   },
-  {
+  "lalezar": {
     "familyName": "Lalezar",
+    "category": "display",
     "capHeight": 570,
     "ascent": 979,
     "descent": -588,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 186,
-    "xWidthAvg": 412,
-    "category": "display"
+    "xWidthAvg": 412
   },
-  {
+  "langar": {
     "familyName": "Langar",
+    "category": "display",
     "capHeight": 700,
     "ascent": 739,
     "descent": -200,
     "lineGap": 455,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 444,
-    "category": "display"
+    "xWidthAvg": 444
   },
-  {
+  "lato": {
     "familyName": "Lato",
+    "category": "sans-serif",
     "capHeight": 1433,
     "ascent": 1974,
     "descent": -426,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1013,
-    "xWidthAvg": 860,
-    "category": "sans-serif"
+    "xWidthAvg": 860
   },
-  {
+  "leagueGothic": {
     "familyName": "League Gothic",
+    "category": "sans-serif",
     "capHeight": 1470,
     "ascent": 1935,
     "descent": -465,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1094,
-    "xWidthAvg": 523,
-    "category": "sans-serif"
+    "xWidthAvg": 523
   },
-  {
+  "lavishlyYours": {
     "familyName": "Lavishly Yours",
+    "category": "handwriting",
     "capHeight": 780,
     "ascent": 1100,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 244,
-    "xWidthAvg": 279,
-    "category": "handwriting"
+    "xWidthAvg": 279
   },
-  {
+  "leagueScript": {
     "familyName": "League Script",
+    "category": "handwriting",
     "capHeight": 936,
     "ascent": 1100,
     "descent": -600,
     "lineGap": 0,
     "unitsPerEm": 1536,
     "xHeight": 542,
-    "xWidthAvg": 676,
-    "category": "handwriting"
+    "xWidthAvg": 676
   },
-  {
+  "lateef": {
     "familyName": "Lateef",
+    "category": "serif",
     "capHeight": 1022,
     "ascent": 1937,
     "descent": -1024,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 690,
-    "xWidthAvg": 664,
-    "category": "serif"
+    "xWidthAvg": 664
   },
-  {
+  "leagueSpartan": {
     "familyName": "League Spartan",
+    "category": "sans-serif",
     "capHeight": 1320,
     "ascent": 1400,
     "descent": -440,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 821,
-    "xWidthAvg": 820,
-    "category": "sans-serif"
+    "xWidthAvg": 820
   },
-  {
+  "leckerliOne": {
     "familyName": "Leckerli One",
+    "category": "handwriting",
     "capHeight": 521,
     "ascent": 1032,
     "descent": -313,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 461,
-    "category": "handwriting"
+    "xWidthAvg": 461
   },
-  {
+  "ledger": {
     "familyName": "Ledger",
+    "category": "serif",
     "capHeight": 750,
     "ascent": 1062,
     "descent": -329,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 487,
-    "xWidthAvg": 497,
-    "category": "serif"
+    "xWidthAvg": 497
   },
-  {
+  "lemon": {
     "familyName": "Lemon",
+    "category": "display",
     "capHeight": 111,
     "ascent": 1019,
     "descent": -287,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 127,
-    "xWidthAvg": 589,
-    "category": "display"
+    "xWidthAvg": 589
   },
-  {
+  "lekton": {
     "familyName": "Lekton",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "lemonada": {
     "familyName": "Lemonada",
+    "category": "display",
     "capHeight": 710,
     "ascent": 1345,
     "descent": -653,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 575,
-    "xWidthAvg": 582,
-    "category": "display"
+    "xWidthAvg": 582
   },
-  {
+  "lexend": {
     "familyName": "Lexend",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 488,
-    "category": "sans-serif"
+    "xWidthAvg": 488
   },
-  {
+  "lexendDeca": {
     "familyName": "Lexend Deca",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 488,
-    "category": "sans-serif"
+    "xWidthAvg": 488
   },
-  {
+  "lexendGiga": {
     "familyName": "Lexend Giga",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 670,
-    "category": "sans-serif"
+    "xWidthAvg": 670
   },
-  {
+  "kaiseiHarunoUmi": {
     "familyName": "Kaisei HarunoUmi",
+    "category": "serif",
     "capHeight": 738,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "lexendMega": {
     "familyName": "Lexend Mega",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 696,
-    "category": "sans-serif"
+    "xWidthAvg": 696
   },
-  {
+  "kaiseiDecol": {
     "familyName": "Kaisei Decol",
+    "category": "serif",
     "capHeight": 738,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "lexendTera": {
     "familyName": "Lexend Tera",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 747,
-    "category": "sans-serif"
+    "xWidthAvg": 747
   },
-  {
+  "lexendPeta": {
     "familyName": "Lexend Peta",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 721,
-    "category": "sans-serif"
+    "xWidthAvg": 721
   },
-  {
+  "lexendZetta": {
     "familyName": "Lexend Zetta",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 812,
-    "category": "sans-serif"
+    "xWidthAvg": 812
   },
-  {
+  "lexendExa": {
     "familyName": "Lexend Exa",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 618,
-    "category": "sans-serif"
+    "xWidthAvg": 618
   },
-  {
+  "libreBarcode128": {
     "familyName": "Libre Barcode 128",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 330,
-    "category": "display"
+    "xWidthAvg": 330
   },
-  {
+  "libreBarcode128Text": {
     "familyName": "Libre Barcode 128 Text",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 330,
-    "category": "display"
+    "xWidthAvg": 330
   },
-  {
+  "libreBarcode39": {
     "familyName": "Libre Barcode 39",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 480,
-    "category": "display"
+    "xWidthAvg": 480
   },
-  {
+  "libreBarcode39Extended": {
     "familyName": "Libre Barcode 39 Extended",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 873,
-    "category": "display"
+    "xWidthAvg": 873
   },
-  {
+  "libreBarcode39Text": {
     "familyName": "Libre Barcode 39 Text",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 480,
-    "category": "display"
+    "xWidthAvg": 480
   },
-  {
+  "libreBarcode39ExtendedText": {
     "familyName": "Libre Barcode 39 Extended Text",
+    "category": "display",
     "capHeight": 590,
     "ascent": 600,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 873,
-    "category": "display"
+    "xWidthAvg": 873
   },
-  {
+  "libreBarcodeEAN13Text": {
     "familyName": "Libre Barcode EAN13 Text",
+    "category": "display",
     "capHeight": 840,
     "ascent": 840,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 420,
-    "xWidthAvg": 117,
-    "category": "display"
+    "xWidthAvg": 117
   },
-  {
+  "libreBaskerville": {
     "familyName": "Libre Baskerville",
+    "category": "serif",
     "capHeight": 770,
     "ascent": 970,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 512,
-    "category": "serif"
+    "xWidthAvg": 512
   },
-  {
+  "libreBodoni": {
     "familyName": "Libre Bodoni",
+    "category": "serif",
     "capHeight": 754,
     "ascent": 924,
     "descent": -326,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 442,
-    "category": "serif"
+    "xWidthAvg": 442
   },
-  {
+  "libreCaslonDisplay": {
     "familyName": "Libre Caslon Display",
+    "category": "serif",
     "capHeight": 690,
     "ascent": 970,
     "descent": -266,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 424,
-    "xWidthAvg": 365,
-    "category": "serif"
+    "xWidthAvg": 365
   },
-  {
+  "libreCaslonText": {
     "familyName": "Libre Caslon Text",
+    "category": "serif",
     "capHeight": 770,
     "ascent": 970,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 473,
-    "category": "serif"
+    "xWidthAvg": 473
   },
-  {
+  "kiwiMaru": {
     "familyName": "Kiwi Maru",
+    "category": "serif",
     "capHeight": 727,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 514,
-    "category": "serif"
+    "xWidthAvg": 514
   },
-  {
+  "libreFranklin": {
     "familyName": "Libre Franklin",
+    "category": "sans-serif",
     "capHeight": 742,
     "ascent": 966,
     "descent": -246,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 461,
-    "category": "sans-serif"
+    "xWidthAvg": 461
   },
-  {
+  "licorice": {
     "familyName": "Licorice",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 850,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 267,
-    "category": "handwriting"
+    "xWidthAvg": 267
   },
-  {
+  "lilitaOne": {
     "familyName": "Lilita One",
+    "category": "display",
     "capHeight": 704,
     "ascent": 923,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 421,
-    "category": "display"
+    "xWidthAvg": 421
   },
-  {
+  "lifeSavers": {
     "familyName": "Life Savers",
+    "category": "display",
     "capHeight": 821,
     "ascent": 972,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 436,
-    "xWidthAvg": 417,
-    "category": "display"
+    "xWidthAvg": 417
   },
-  {
+  "lilyScriptOne": {
     "familyName": "Lily Script One",
+    "category": "display",
     "capHeight": 762,
     "ascent": 1017,
     "descent": -359,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 762,
-    "xWidthAvg": 424,
-    "category": "display"
+    "xWidthAvg": 424
   },
-  {
+  "lindenHill": {
     "familyName": "Linden Hill",
+    "category": "serif",
     "capHeight": 2732,
     "ascent": 3633,
     "descent": -1888,
     "lineGap": 0,
     "unitsPerEm": 4096,
     "xHeight": 1606,
-    "xWidthAvg": 1512,
-    "category": "serif"
+    "xWidthAvg": 1512
   },
-  {
+  "kleeOne": {
     "familyName": "Klee One",
+    "category": "handwriting",
     "capHeight": 695,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 477,
-    "category": "handwriting"
+    "xWidthAvg": 477
   },
-  {
+  "livvic": {
     "familyName": "Livvic",
+    "category": "sans-serif",
     "capHeight": 710,
     "ascent": 1005,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 497,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "limelight": {
     "familyName": "Limelight",
+    "category": "display",
     "capHeight": 1415,
     "ascent": 1864,
     "descent": -629,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1068,
-    "xWidthAvg": 1092,
-    "category": "display"
+    "xWidthAvg": 1092
   },
-  {
+  "lobsterTwo": {
     "familyName": "Lobster Two",
+    "category": "display",
     "capHeight": 754,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 356,
-    "category": "display"
+    "xWidthAvg": 356
   },
-  {
+  "londrinaShadow": {
     "familyName": "Londrina Shadow",
+    "category": "display",
     "capHeight": 722,
     "ascent": 945,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 383,
-    "category": "display"
+    "xWidthAvg": 383
   },
-  {
+  "londrinaOutline": {
     "familyName": "Londrina Outline",
+    "category": "display",
     "capHeight": 722,
     "ascent": 945,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 383,
-    "category": "display"
+    "xWidthAvg": 383
   },
-  {
+  "literata": {
     "familyName": "Literata",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1177,
     "descent": -308,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 507,
-    "xWidthAvg": 474,
-    "category": "serif"
+    "xWidthAvg": 474
   },
-  {
+  "lobster": {
     "familyName": "Lobster",
+    "category": "display",
     "capHeight": 748,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 385,
-    "category": "display"
+    "xWidthAvg": 385
   },
-  {
+  "londrinaSolid": {
     "familyName": "Londrina Solid",
+    "category": "display",
     "capHeight": 722,
     "ascent": 945,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 383,
-    "category": "display"
+    "xWidthAvg": 383
   },
-  {
+  "londrinaSketch": {
     "familyName": "Londrina Sketch",
+    "category": "display",
     "capHeight": 722,
     "ascent": 945,
     "descent": -238,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 383,
-    "category": "display"
+    "xWidthAvg": 383
   },
-  {
+  "lovedByTheKing": {
     "familyName": "Loved by the King",
+    "category": "handwriting",
     "capHeight": 1774,
     "ascent": 2398,
     "descent": -1137,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1111,
-    "xWidthAvg": 668,
-    "category": "handwriting"
+    "xWidthAvg": 668
   },
-  {
+  "loveYaLikeASister": {
     "familyName": "Love Ya Like A Sister",
+    "category": "display",
     "capHeight": 674,
     "ascent": 942,
     "descent": -333,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 510,
-    "xWidthAvg": 474,
-    "category": "display"
+    "xWidthAvg": 474
   },
-  {
+  "lora": {
     "familyName": "Lora",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1006,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 466,
-    "category": "serif"
+    "xWidthAvg": 466
   },
-  {
+  "loversQuarrel": {
     "familyName": "Lovers Quarrel",
+    "category": "handwriting",
     "capHeight": 609,
     "ascent": 726,
     "descent": -401,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 274,
-    "xWidthAvg": 218,
-    "category": "handwriting"
+    "xWidthAvg": 218
   },
-  {
+  "liuJianMaoCao": {
     "familyName": "Liu Jian Mao Cao",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 420,
-    "xWidthAvg": 379,
-    "category": "handwriting"
+    "xWidthAvg": 379
   },
-  {
+  "lustria": {
     "familyName": "Lustria",
+    "category": "serif",
     "capHeight": 704,
     "ascent": 955,
     "descent": -327,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 504,
-    "xWidthAvg": 465,
-    "category": "serif"
+    "xWidthAvg": 465
   },
-  {
+  "lusitana": {
     "familyName": "Lusitana",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 956,
     "descent": -341,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 139,
-    "xWidthAvg": 414,
-    "category": "serif"
+    "xWidthAvg": 414
   },
-  {
+  "loveLight": {
     "familyName": "Love Light",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 273,
-    "category": "handwriting"
+    "xWidthAvg": 273
   },
-  {
+  "luxuriousRoman": {
     "familyName": "Luxurious Roman",
+    "category": "display",
     "capHeight": 665,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 465,
-    "category": "display"
+    "xWidthAvg": 465
   },
-  {
+  "mPLUSCodeLatin": {
     "familyName": "M PLUS Code Latin",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 1000,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "luckiestGuy": {
     "familyName": "Luckiest Guy",
+    "category": "display",
     "capHeight": 1424,
     "ascent": 1440,
     "descent": -608,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1400,
-    "xWidthAvg": 1046,
-    "category": "display"
+    "xWidthAvg": 1046
   },
-  {
+  "luxuriousScript": {
     "familyName": "Luxurious Script",
+    "category": "handwriting",
     "capHeight": 565,
     "ascent": 850,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 330,
-    "xWidthAvg": 241,
-    "category": "handwriting"
+    "xWidthAvg": 241
   },
-  {
+  "macondo": {
     "familyName": "Macondo",
+    "category": "display",
     "capHeight": 53,
     "ascent": 888,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 24,
-    "xWidthAvg": 414,
-    "category": "display"
+    "xWidthAvg": 414
   },
-  {
+  "macondoSwashCaps": {
     "familyName": "Macondo Swash Caps",
+    "category": "display",
     "capHeight": 696,
     "ascent": 888,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 24,
-    "xWidthAvg": 414,
-    "category": "display"
+    "xWidthAvg": 414
   },
-  {
+  "mPLUS1": {
     "familyName": "M PLUS 1",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 485,
-    "category": "sans-serif"
+    "xWidthAvg": 485
   },
-  {
+  "mPLUS1Code": {
     "familyName": "M PLUS 1 Code",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 1000,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "mada": {
     "familyName": "Mada",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 900,
     "descent": -300,
     "lineGap": 96,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 416,
-    "category": "sans-serif"
+    "xWidthAvg": 416
   },
-  {
+  "magra": {
     "familyName": "Magra",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 968,
     "descent": -247,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 411,
-    "category": "sans-serif"
+    "xWidthAvg": 411
   },
-  {
+  "maitree": {
     "familyName": "Maitree",
+    "category": "serif",
     "capHeight": 695,
     "ascent": 1150,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 489,
-    "xWidthAvg": 470,
-    "category": "serif"
+    "xWidthAvg": 470
   },
-  {
+  "mPLUS2": {
     "familyName": "M PLUS 2",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 486,
-    "category": "sans-serif"
+    "xWidthAvg": 486
   },
-  {
+  "mako": {
     "familyName": "Mako",
+    "category": "sans-serif",
     "capHeight": 1437,
     "ascent": 2141,
     "descent": -538,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1031,
-    "xWidthAvg": 888,
-    "category": "sans-serif"
+    "xWidthAvg": 888
   },
-  {
+  "maidenOrange": {
     "familyName": "Maiden Orange",
+    "category": "display",
     "capHeight": 1406,
     "ascent": 1440,
     "descent": -608,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1056,
-    "xWidthAvg": 659,
-    "category": "display"
+    "xWidthAvg": 659
   },
-  {
+  "mali": {
     "familyName": "Mali",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1050,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 498,
-    "category": "handwriting"
+    "xWidthAvg": 498
   },
-  {
+  "majorMonoDisplay": {
     "familyName": "Major Mono Display",
+    "category": "monospace",
     "capHeight": 696,
     "ascent": 900,
     "descent": -100,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 696,
-    "xWidthAvg": 740,
-    "category": "monospace"
+    "xWidthAvg": 740
   },
-  {
+  "manrope": {
     "familyName": "Manrope",
+    "category": "sans-serif",
     "capHeight": 1440,
     "ascent": 2132,
     "descent": -600,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1080,
-    "xWidthAvg": 914,
-    "category": "sans-serif"
+    "xWidthAvg": 914
   },
-  {
+  "manjari": {
     "familyName": "Manjari",
+    "category": "sans-serif",
     "capHeight": 1385,
     "ascent": 1500,
     "descent": -750,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 923,
-    "category": "sans-serif"
+    "xWidthAvg": 923
   },
-  {
+  "longCang": {
     "familyName": "Long Cang",
+    "category": "handwriting",
     "capHeight": 684,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 512,
-    "xWidthAvg": 412,
-    "category": "handwriting"
+    "xWidthAvg": 412
   },
-  {
+  "mPLUS1p": {
     "familyName": "M PLUS 1p",
+    "category": "sans-serif",
     "ascent": 1075,
     "descent": -320,
     "lineGap": 90,
     "unitsPerEm": 1000,
-    "xWidthAvg": 485,
-    "category": "sans-serif"
+    "xWidthAvg": 485
   },
-  {
+  "mandali": {
     "familyName": "Mandali",
+    "category": "sans-serif",
     "capHeight": 550,
     "ascent": 1087,
     "descent": -475,
     "lineGap": 0,
     "unitsPerEm": 790,
     "xHeight": 382,
-    "xWidthAvg": 355,
-    "category": "sans-serif"
+    "xWidthAvg": 355
   },
-  {
+  "manuale": {
     "familyName": "Manuale",
+    "category": "serif",
     "capHeight": 611,
     "ascent": 980,
     "descent": -236,
     "lineGap": 221,
     "unitsPerEm": 1000,
     "xHeight": 491,
-    "xWidthAvg": 439,
-    "category": "serif"
+    "xWidthAvg": 439
   },
-  {
+  "mallanna": {
     "familyName": "Mallanna",
+    "category": "sans-serif",
     "capHeight": 546,
     "ascent": 1105,
     "descent": -504,
     "lineGap": 0,
     "unitsPerEm": 870,
     "xHeight": 379,
-    "xWidthAvg": 349,
-    "category": "sans-serif"
+    "xWidthAvg": 349
   },
-  {
+  "mansalva": {
     "familyName": "Mansalva",
+    "category": "handwriting",
     "capHeight": 702,
     "ascent": 1112,
     "descent": -466,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 384,
-    "xWidthAvg": 432,
-    "category": "handwriting"
+    "xWidthAvg": 432
   },
-  {
+  "marcellus": {
     "familyName": "Marcellus",
+    "category": "serif",
     "capHeight": 1434,
     "ascent": 1995,
     "descent": -573,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 933,
-    "category": "serif"
+    "xWidthAvg": 933
   },
-  {
+  "marcellusSC": {
     "familyName": "Marcellus SC",
+    "category": "serif",
     "capHeight": 1434,
     "ascent": 1995,
     "descent": -573,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1075,
-    "xWidthAvg": 960,
-    "category": "serif"
+    "xWidthAvg": 960
   },
-  {
+  "marhey": {
     "familyName": "Marhey",
+    "category": "display",
     "capHeight": 750,
     "ascent": 1100,
     "descent": -640,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 480,
-    "category": "display"
+    "xWidthAvg": 480
   },
-  {
+  "markaziText": {
     "familyName": "Markazi Text",
+    "category": "serif",
     "capHeight": 990,
     "ascent": 1718,
     "descent": -740,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 746,
-    "xWidthAvg": 682,
-    "category": "serif"
+    "xWidthAvg": 682
   },
-  {
+  "margarine": {
     "familyName": "Margarine",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2075,
     "descent": -678,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 928,
-    "category": "display"
+    "xWidthAvg": 928
   },
-  {
+  "markoOne": {
     "familyName": "Marko One",
+    "category": "serif",
     "capHeight": 1475,
     "ascent": 2019,
     "descent": -727,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 713,
-    "xWidthAvg": 1083,
-    "category": "serif"
+    "xWidthAvg": 1083
   },
-  {
+  "marmelad": {
     "familyName": "Marmelad",
+    "category": "sans-serif",
     "capHeight": 709,
     "ascent": 972,
     "descent": -221,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 502,
-    "xWidthAvg": 465,
-    "category": "sans-serif"
+    "xWidthAvg": 465
   },
-  {
+  "marckScript": {
     "familyName": "Marck Script",
+    "category": "handwriting",
     "capHeight": 638,
     "ascent": 864,
     "descent": -385,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 263,
-    "xWidthAvg": 414,
-    "category": "handwriting"
+    "xWidthAvg": 414
   },
-  {
+  "martel": {
     "familyName": "Martel",
+    "category": "serif",
     "capHeight": 758,
     "ascent": 1125,
     "descent": -562,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 546,
-    "xWidthAvg": 495,
-    "category": "serif"
+    "xWidthAvg": 495
   },
-  {
+  "martelSans": {
     "familyName": "Martel Sans",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 1150,
     "descent": -674,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 476,
-    "category": "sans-serif"
+    "xWidthAvg": 476
   },
-  {
+  "roundedMplus1c": {
     "familyName": "Rounded Mplus 1c",
+    "category": "sans-serif",
     "ascent": 1075,
     "descent": -320,
     "lineGap": 90,
     "unitsPerEm": 1000,
-    "xWidthAvg": 473,
-    "category": "sans-serif"
+    "xWidthAvg": 473
   },
-  {
+  "martianMono": {
     "familyName": "Martian Mono",
+    "category": "monospace",
     "capHeight": 800,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 700,
-    "category": "monospace"
+    "xWidthAvg": 700
   },
-  {
+  "marvel": {
     "familyName": "Marvel",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 951,
     "descent": -259,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 342,
-    "category": "sans-serif"
+    "xWidthAvg": 342
   },
-  {
+  "mate": {
     "familyName": "Mate",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 958,
     "descent": -262,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 423,
-    "category": "serif"
+    "xWidthAvg": 423
   },
-  {
+  "mateSC": {
     "familyName": "Mate SC",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 958,
     "descent": -262,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 461,
-    "category": "serif"
+    "xWidthAvg": 461
   },
-  {
+  "mavenPro": {
     "familyName": "Maven Pro",
+    "category": "sans-serif",
     "capHeight": 667,
     "ascent": 965,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 499,
-    "xWidthAvg": 459,
-    "category": "sans-serif"
+    "xWidthAvg": 459
   },
-  {
+  "mcLaren": {
     "familyName": "McLaren",
+    "category": "display",
     "capHeight": 1445,
     "ascent": 2216,
     "descent": -722,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1042,
-    "xWidthAvg": 1036,
-    "category": "display"
+    "xWidthAvg": 1036
   },
-  {
+  "meddon": {
     "familyName": "Meddon",
+    "category": "handwriting",
     "capHeight": 2177,
     "ascent": 2860,
     "descent": -1457,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 756,
-    "xWidthAvg": 1210,
-    "category": "handwriting"
+    "xWidthAvg": 1210
   },
-  {
+  "meaCulpa": {
     "familyName": "Mea Culpa",
+    "category": "handwriting",
     "capHeight": 800,
     "ascent": 1000,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 265,
-    "category": "handwriting"
+    "xWidthAvg": 265
   },
-  {
+  "medulaOne": {
     "familyName": "Medula One",
+    "category": "display",
     "capHeight": 650,
     "ascent": 846,
     "descent": -162,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 490,
-    "xWidthAvg": 255,
-    "category": "display"
+    "xWidthAvg": 255
   },
-  {
+  "medievalSharp": {
     "familyName": "MedievalSharp",
+    "category": "display",
     "capHeight": 201,
     "ascent": 1771,
     "descent": -543,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 224,
-    "xWidthAvg": 942,
-    "category": "display"
+    "xWidthAvg": 942
   },
-  {
+  "meeraInimai": {
     "familyName": "Meera Inimai",
+    "category": "sans-serif",
     "capHeight": 1460,
     "ascent": 1986,
     "descent": -1200,
     "lineGap": 184,
     "unitsPerEm": 2048,
     "xHeight": 1056,
-    "xWidthAvg": 896,
-    "category": "sans-serif"
+    "xWidthAvg": 896
   },
-  {
+  "megrim": {
     "familyName": "Megrim",
+    "category": "display",
     "capHeight": 700,
     "ascent": 880,
     "descent": -200,
     "lineGap": 90,
     "unitsPerEm": 1000,
     "xHeight": 580,
-    "xWidthAvg": 486,
-    "category": "display"
+    "xWidthAvg": 486
   },
-  {
+  "meieScript": {
     "familyName": "Meie Script",
+    "category": "handwriting",
     "capHeight": 862,
     "ascent": 1814,
     "descent": -780,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 354,
-    "xWidthAvg": 793,
-    "category": "handwriting"
+    "xWidthAvg": 793
   },
-  {
+  "maShanZheng": {
     "familyName": "Ma Shan Zheng",
+    "category": "handwriting",
     "capHeight": 760,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 305,
-    "category": "handwriting"
+    "xWidthAvg": 305
   },
-  {
+  "merienda": {
     "familyName": "Merienda",
+    "category": "handwriting",
     "capHeight": 847,
     "ascent": 1102,
     "descent": -342,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 599,
-    "xWidthAvg": 501,
-    "category": "handwriting"
+    "xWidthAvg": 501
   },
-  {
+  "meriendaOne": {
     "familyName": "Merienda One",
+    "category": "handwriting",
     "capHeight": 439,
     "ascent": 1102,
     "descent": -342,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 379,
-    "xWidthAvg": 503,
-    "category": "handwriting"
+    "xWidthAvg": 503
   },
-  {
+  "merriweather": {
     "familyName": "Merriweather",
+    "category": "serif",
     "capHeight": 743,
     "ascent": 984,
     "descent": -273,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 555,
-    "xWidthAvg": 490,
-    "category": "serif"
+    "xWidthAvg": 490
   },
-  {
+  "meowScript": {
     "familyName": "Meow Script",
+    "category": "handwriting",
     "capHeight": 560,
     "ascent": 830,
     "descent": -370,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 320,
-    "xWidthAvg": 297,
-    "category": "handwriting"
+    "xWidthAvg": 297
   },
-  {
+  "merriweatherSans": {
     "familyName": "Merriweather Sans",
+    "category": "sans-serif",
     "capHeight": 1486,
     "ascent": 1968,
     "descent": -546,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1114,
-    "xWidthAvg": 936,
-    "category": "sans-serif"
+    "xWidthAvg": 936
   },
-  {
+  "metal": {
     "familyName": "Metal",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2600,
     "descent": -1600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 738,
-    "category": "display"
+    "xWidthAvg": 738
   },
-  {
+  "metamorphous": {
     "familyName": "Metamorphous",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 1972,
     "descent": -588,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1208,
-    "xWidthAvg": 1138,
-    "category": "display"
+    "xWidthAvg": 1138
   },
-  {
+  "metrophobic": {
     "familyName": "Metrophobic",
+    "category": "sans-serif",
     "capHeight": 1441,
     "ascent": 2065,
     "descent": -460,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1011,
-    "xWidthAvg": 927,
-    "category": "sans-serif"
+    "xWidthAvg": 927
   },
-  {
+  "metalMania": {
     "familyName": "Metal Mania",
+    "category": "display",
     "capHeight": 820,
     "ascent": 965,
     "descent": -303,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 620,
-    "xWidthAvg": 401,
-    "category": "display"
+    "xWidthAvg": 401
   },
-  {
+  "michroma": {
     "familyName": "Michroma",
+    "category": "sans-serif",
     "capHeight": 1536,
     "ascent": 2368,
     "descent": -544,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1152,
-    "xWidthAvg": 1282,
-    "category": "sans-serif"
+    "xWidthAvg": 1282
   },
-  {
+  "milonga": {
     "familyName": "Milonga",
+    "category": "display",
     "capHeight": 809,
     "ascent": 990,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 458,
-    "xWidthAvg": 444,
-    "category": "display"
+    "xWidthAvg": 444
   },
-  {
+  "miltonian": {
     "familyName": "Miltonian",
+    "category": "display",
     "capHeight": 689,
     "ascent": 918,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 454,
-    "xWidthAvg": 498,
-    "category": "display"
+    "xWidthAvg": 498
   },
-  {
+  "miltonianTattoo": {
     "familyName": "Miltonian Tattoo",
+    "category": "display",
     "capHeight": 689,
     "ascent": 918,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 454,
-    "xWidthAvg": 498,
-    "category": "display"
+    "xWidthAvg": 498
   },
-  {
+  "mina": {
     "familyName": "Mina",
+    "category": "sans-serif",
     "ascent": 1075,
     "descent": -515,
     "lineGap": 0,
     "unitsPerEm": 1000,
-    "xWidthAvg": 463,
-    "category": "sans-serif"
+    "xWidthAvg": 463
   },
-  {
+  "miniver": {
     "familyName": "Miniver",
+    "category": "display",
     "capHeight": 782,
     "ascent": 1019,
     "descent": -474,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 501,
-    "xWidthAvg": 437,
-    "category": "display"
+    "xWidthAvg": 437
   },
-  {
+  "mingzat": {
     "familyName": "Mingzat",
+    "category": "sans-serif",
     "capHeight": 1100,
     "ascent": 1427,
     "descent": -670,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 705,
-    "xWidthAvg": 513,
-    "category": "sans-serif"
+    "xWidthAvg": 513
   },
-  {
+  "missFajardose": {
     "familyName": "Miss Fajardose",
+    "category": "handwriting",
     "capHeight": 658,
     "ascent": 859,
     "descent": -389,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 158,
-    "xWidthAvg": 187,
-    "category": "handwriting"
+    "xWidthAvg": 187
   },
-  {
+  "miriamLibre": {
     "familyName": "Miriam Libre",
+    "category": "sans-serif",
     "capHeight": 695,
     "ascent": 969,
     "descent": -344,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 566,
-    "xWidthAvg": 487,
-    "category": "sans-serif"
+    "xWidthAvg": 487
   },
-  {
+  "mirza": {
     "familyName": "Mirza",
+    "category": "display",
     "capHeight": 700,
     "ascent": 547,
     "descent": -453,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 397,
-    "category": "display"
+    "xWidthAvg": 397
   },
-  {
+  "mitr": {
     "familyName": "Mitr",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1150,
     "descent": -420,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 513,
-    "category": "sans-serif"
+    "xWidthAvg": 513
   },
-  {
+  "mohave": {
     "familyName": "Mohave",
+    "category": "sans-serif",
     "capHeight": 1500,
     "ascent": 1980,
     "descent": -806,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1080,
-    "xWidthAvg": 751,
-    "category": "sans-serif"
+    "xWidthAvg": 751
   },
-  {
+  "modernAntiqua": {
     "familyName": "Modern Antiqua",
+    "category": "display",
     "capHeight": 1511,
     "ascent": 1815,
     "descent": -508,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1089,
-    "xWidthAvg": 1016,
-    "category": "display"
+    "xWidthAvg": 1016
   },
-  {
+  "modak": {
     "familyName": "Modak",
+    "category": "display",
     "capHeight": 1290,
     "ascent": 2035,
     "descent": -1049,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1099,
-    "xWidthAvg": 951,
-    "category": "display"
+    "xWidthAvg": 951
   },
-  {
+  "molle": {
     "familyName": "Molle",
+    "category": "handwriting",
     "capHeight": 1588,
     "ascent": 1852,
     "descent": -701,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 910,
-    "xWidthAvg": 978,
-    "category": "handwriting"
+    "xWidthAvg": 978
   },
-  {
+  "molengo": {
     "familyName": "Molengo",
+    "category": "sans-serif",
     "capHeight": 1391,
     "ascent": 1928,
     "descent": -522,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 938,
-    "xWidthAvg": 860,
-    "category": "sans-serif"
+    "xWidthAvg": 860
   },
-  {
+  "monda": {
     "familyName": "Monda",
+    "category": "sans-serif",
     "capHeight": 1446,
     "ascent": 2461,
     "descent": -875,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1060,
-    "xWidthAvg": 967,
-    "category": "sans-serif"
+    "xWidthAvg": 967
   },
-  {
+  "mogra": {
     "familyName": "Mogra",
+    "category": "display",
     "capHeight": 705,
     "ascent": 750,
     "descent": -250,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 565,
-    "xWidthAvg": 506,
-    "category": "display"
+    "xWidthAvg": 506
   },
-  {
+  "monofett": {
     "familyName": "Monofett",
+    "category": "display",
     "capHeight": 1370,
     "ascent": 2001,
     "descent": -315,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1370,
-    "xWidthAvg": 1022,
-    "category": "display"
+    "xWidthAvg": 1022
   },
-  {
+  "monoton": {
     "familyName": "Monoton",
+    "category": "display",
     "capHeight": 1656,
     "ascent": 2366,
     "descent": -822,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1440,
-    "xWidthAvg": 1270,
-    "category": "display"
+    "xWidthAvg": 1270
   },
-  {
+  "monsieurLaDoulaise": {
     "familyName": "Monsieur La Doulaise",
+    "category": "handwriting",
     "capHeight": 729,
     "ascent": 1048,
     "descent": -513,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 164,
-    "xWidthAvg": 272,
-    "category": "handwriting"
+    "xWidthAvg": 272
   },
-  {
+  "montaga": {
     "familyName": "Montaga",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 978,
     "descent": -254,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 466,
-    "xWidthAvg": 436,
-    "category": "serif"
+    "xWidthAvg": 436
   },
-  {
+  "montaguSlab144pt": {
     "familyName": "Montagu Slab 144pt",
+    "category": "serif",
     "capHeight": 682,
     "ascent": 982,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 518,
-    "xWidthAvg": 488,
-    "category": "serif"
+    "xWidthAvg": 488
   },
-  {
+  "montez": {
     "familyName": "Montez",
+    "category": "handwriting",
     "capHeight": 1456,
     "ascent": 1831,
     "descent": -848,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 766,
-    "xWidthAvg": 649,
-    "category": "handwriting"
+    "xWidthAvg": 649
   },
-  {
+  "monteCarlo": {
     "familyName": "MonteCarlo",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 1200,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 315,
-    "xWidthAvg": 277,
-    "category": "handwriting"
+    "xWidthAvg": 277
   },
-  {
+  "montserrat": {
     "familyName": "Montserrat",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 968,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 517,
-    "xWidthAvg": 503,
-    "category": "sans-serif"
+    "xWidthAvg": 503
   },
-  {
+  "montserratSubrayada": {
     "familyName": "Montserrat Subrayada",
+    "category": "sans-serif",
     "capHeight": 699,
     "ascent": 968,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 699,
-    "xWidthAvg": 620,
-    "category": "sans-serif"
+    "xWidthAvg": 620
   },
-  {
+  "montserratAlternates": {
     "familyName": "Montserrat Alternates",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 968,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 514,
-    "category": "sans-serif"
+    "xWidthAvg": 514
   },
-  {
+  "mooLahLah": {
     "familyName": "Moo Lah Lah",
+    "category": "display",
     "capHeight": 650,
     "ascent": 920,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 565,
-    "xWidthAvg": 408,
-    "category": "display"
+    "xWidthAvg": 408
   },
-  {
+  "moulpali": {
     "familyName": "Moulpali",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2900,
     "descent": -1600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 830,
-    "category": "display"
+    "xWidthAvg": 830
   },
-  {
+  "moul": {
     "familyName": "Moul",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1174,
-    "category": "display"
+    "xWidthAvg": 1174
   },
-  {
+  "mountainsOfChristmas": {
     "familyName": "Mountains of Christmas",
+    "category": "display",
     "capHeight": 743,
     "ascent": 1066,
     "descent": -354,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 515,
-    "xWidthAvg": 362,
-    "category": "display"
+    "xWidthAvg": 362
   },
-  {
+  "mouseMemoirs": {
     "familyName": "Mouse Memoirs",
+    "category": "sans-serif",
     "capHeight": 1448,
     "ascent": 1917,
     "descent": -428,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1044,
-    "xWidthAvg": 597,
-    "category": "sans-serif"
+    "xWidthAvg": 597
   },
-  {
+  "mochiyPopPOne": {
     "familyName": "Mochiy Pop P One",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 560,
-    "category": "sans-serif"
+    "xWidthAvg": 560
   },
-  {
+  "moonDance": {
     "familyName": "Moon Dance",
+    "category": "handwriting",
     "capHeight": 605,
     "ascent": 970,
     "descent": -370,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 294,
-    "category": "handwriting"
+    "xWidthAvg": 294
   },
-  {
+  "mrBedfort": {
     "familyName": "Mr Bedfort",
+    "category": "handwriting",
     "capHeight": 770,
     "ascent": 1015,
     "descent": -661,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 245,
-    "xWidthAvg": 373,
-    "category": "handwriting"
+    "xWidthAvg": 373
   },
-  {
+  "mrDeHaviland": {
     "familyName": "Mr De Haviland",
+    "category": "handwriting",
     "capHeight": 557,
     "ascent": 875,
     "descent": -442,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 217,
-    "xWidthAvg": 239,
-    "category": "handwriting"
+    "xWidthAvg": 239
   },
-  {
+  "mrDafoe": {
     "familyName": "Mr Dafoe",
+    "category": "handwriting",
     "capHeight": 622,
     "ascent": 981,
     "descent": -416,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 313,
-    "xWidthAvg": 352,
-    "category": "handwriting"
+    "xWidthAvg": 352
   },
-  {
+  "mrsSheppards": {
     "familyName": "Mrs Sheppards",
+    "category": "handwriting",
     "capHeight": 662,
     "ascent": 959,
     "descent": -378,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 285,
-    "xWidthAvg": 344,
-    "category": "handwriting"
+    "xWidthAvg": 344
   },
-  {
+  "mrsSaintDelafield": {
     "familyName": "Mrs Saint Delafield",
+    "category": "handwriting",
     "capHeight": 708,
     "ascent": 906,
     "descent": -619,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 224,
-    "xWidthAvg": 255,
-    "category": "handwriting"
+    "xWidthAvg": 255
   },
-  {
+  "muktaMahee": {
     "familyName": "Mukta Mahee",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1130,
     "descent": -532,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "msMadi": {
     "familyName": "Ms Madi",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 900,
     "descent": -420,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 335,
-    "xWidthAvg": 301,
-    "category": "handwriting"
+    "xWidthAvg": 301
   },
-  {
+  "muktaMalar": {
     "familyName": "Mukta Malar",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1130,
     "descent": -532,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 430,
-    "category": "sans-serif"
+    "xWidthAvg": 430
   },
-  {
+  "mukta": {
     "familyName": "Mukta",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1130,
     "descent": -532,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "mulish": {
     "familyName": "Mulish",
+    "category": "sans-serif",
     "capHeight": 705,
     "ascent": 1005,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 462,
-    "category": "sans-serif"
+    "xWidthAvg": 462
   },
-  {
+  "mochiyPopOne": {
     "familyName": "Mochiy Pop One",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 560,
-    "category": "sans-serif"
+    "xWidthAvg": 560
   },
-  {
+  "museoModerno": {
     "familyName": "MuseoModerno",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1145,
     "descent": -445,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 490,
-    "category": "display"
+    "xWidthAvg": 490
   },
-  {
+  "mysteryQuest": {
     "familyName": "Mystery Quest",
+    "category": "display",
     "capHeight": 769,
     "ascent": 989,
     "descent": -409,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 626,
-    "xWidthAvg": 434,
-    "category": "display"
+    "xWidthAvg": 434
   },
-  {
+  "murecho": {
     "familyName": "Murecho",
+    "category": "sans-serif",
     "capHeight": 728,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 435,
-    "category": "sans-serif"
+    "xWidthAvg": 435
   },
-  {
+  "mySoul": {
     "familyName": "My Soul",
+    "category": "handwriting",
     "capHeight": 760,
     "ascent": 975,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 360,
-    "xWidthAvg": 339,
-    "category": "handwriting"
+    "xWidthAvg": 339
   },
-  {
+  "muktaVaani": {
     "familyName": "Mukta Vaani",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1130,
     "descent": -532,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "nTR": {
     "familyName": "NTR",
+    "category": "sans-serif",
     "capHeight": 572,
     "ascent": 1294,
     "descent": -877,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 422,
-    "xWidthAvg": 392,
-    "category": "sans-serif"
+    "xWidthAvg": 392
   },
-  {
+  "nerkoOne": {
     "familyName": "Nerko One",
+    "category": "handwriting",
     "capHeight": 586,
     "ascent": 894,
     "descent": -317,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 426,
-    "xWidthAvg": 412,
-    "category": "handwriting"
+    "xWidthAvg": 412
   },
-  {
+  "neucha": {
     "familyName": "Neucha",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 787,
     "descent": -292,
     "lineGap": 49,
     "unitsPerEm": 1024,
     "xHeight": 523,
-    "xWidthAvg": 380,
-    "category": "handwriting"
+    "xWidthAvg": 380
   },
-  {
+  "neuton": {
     "familyName": "Neuton",
+    "category": "serif",
     "capHeight": 0,
     "ascent": 2106,
     "descent": -485,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 745,
-    "category": "serif"
+    "xWidthAvg": 745
   },
-  {
+  "nabla": {
     "familyName": "Nabla",
+    "category": "display",
     "capHeight": 600,
     "ascent": 1263,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 468,
-    "category": "display"
+    "xWidthAvg": 468
   },
-  {
+  "neonderthaw": {
     "familyName": "Neonderthaw",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 1050,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 368,
-    "category": "handwriting"
+    "xWidthAvg": 368
   },
-  {
+  "newRocker": {
     "familyName": "New Rocker",
+    "category": "display",
     "capHeight": 733,
     "ascent": 946,
     "descent": -283,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 465,
-    "xWidthAvg": 419,
-    "category": "display"
+    "xWidthAvg": 419
   },
-  {
+  "niconne": {
     "familyName": "Niconne",
+    "category": "handwriting",
     "capHeight": 1442,
     "ascent": 1898,
     "descent": -585,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 218,
-    "xWidthAvg": 664,
-    "category": "handwriting"
+    "xWidthAvg": 664
   },
-  {
+  "newsreader16pt": {
     "familyName": "Newsreader 16pt",
+    "category": "serif",
     "capHeight": 1340,
     "ascent": 1470,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 852,
-    "xWidthAvg": 843,
-    "category": "serif"
+    "xWidthAvg": 843
   },
-  {
+  "nanumGothicCoding": {
     "familyName": "NanumGothicCoding",
+    "category": "monospace",
     "capHeight": 699,
     "ascent": 800,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 500,
-    "category": "monospace"
+    "xWidthAvg": 500
   },
-  {
+  "newsCycle": {
     "familyName": "News Cycle",
+    "category": "sans-serif",
     "ascent": 2574,
     "descent": -794,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 792,
-    "category": "sans-serif"
+    "xWidthAvg": 792
   },
-  {
+  "niramit": {
     "familyName": "Niramit",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1105,
     "descent": -195,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 485,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "nanumGothic": {
     "familyName": "NanumGothic",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 920,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 463,
-    "category": "sans-serif"
+    "xWidthAvg": 463
   },
-  {
+  "nobile": {
     "familyName": "Nobile",
+    "category": "sans-serif",
     "capHeight": 1579,
     "ascent": 1731,
     "descent": -578,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1169,
-    "xWidthAvg": 980,
-    "category": "sans-serif"
+    "xWidthAvg": 980
   },
-  {
+  "nixieOne": {
     "familyName": "Nixie One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 926,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 502,
-    "category": "display"
+    "xWidthAvg": 502
   },
-  {
+  "nokora": {
     "familyName": "Nokora",
+    "category": "sans-serif",
     "capHeight": 1462,
     "ascent": 1907,
     "descent": -800,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 965,
-    "category": "sans-serif"
+    "xWidthAvg": 965
   },
-  {
+  "norican": {
     "familyName": "Norican",
+    "category": "handwriting",
     "capHeight": 1530,
     "ascent": 2095,
     "descent": -791,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 807,
-    "xWidthAvg": 701,
-    "category": "handwriting"
+    "xWidthAvg": 701
   },
-  {
+  "nosifer": {
     "familyName": "Nosifer",
+    "category": "display",
     "capHeight": 854,
     "ascent": 2236,
     "descent": -1328,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 925,
-    "xWidthAvg": 1590,
-    "category": "display"
+    "xWidthAvg": 1590
   },
-  {
+  "notable": {
     "familyName": "Notable",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1143,
     "descent": -157,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 356,
-    "xWidthAvg": 765,
-    "category": "sans-serif"
+    "xWidthAvg": 765
   },
-  {
+  "nothingYouCouldDo": {
     "familyName": "Nothing You Could Do",
+    "category": "handwriting",
     "capHeight": 758,
     "ascent": 959,
     "descent": -407,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 462,
-    "xWidthAvg": 500,
-    "category": "handwriting"
+    "xWidthAvg": 500
   },
-  {
+  "noticiaText": {
     "familyName": "Noticia Text",
+    "category": "serif",
     "capHeight": 1353,
     "ascent": 2202,
     "descent": -593,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1085,
-    "xWidthAvg": 967,
-    "category": "serif"
+    "xWidthAvg": 967
   },
-  {
+  "nanumBrushScript": {
     "familyName": "Nanum Brush Script",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 920,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 331,
-    "category": "handwriting"
+    "xWidthAvg": 331
   },
-  {
+  "notoMusic": {
     "familyName": "Noto Music",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1389,
     "descent": -398,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoEmoji": {
     "familyName": "Noto Emoji",
+    "category": "sans-serif",
     "capHeight": 1900,
     "ascent": 1900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 1291,
-    "category": "sans-serif"
+    "xWidthAvg": 1291
   },
-  {
+  "notoRashiHebrew": {
     "familyName": "Noto Rashi Hebrew",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 896,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoKufiArabic": {
     "familyName": "Noto Kufi Arabic",
+    "category": "sans-serif",
     "capHeight": 1272,
     "ascent": 1282,
     "descent": -615,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 890,
-    "xWidthAvg": 553,
-    "category": "sans-serif"
+    "xWidthAvg": 553
   },
-  {
+  "notoNastaliqUrdu": {
     "familyName": "Noto Nastaliq Urdu",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1904,
     "descent": -596,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 455,
-    "category": "serif"
+    "xWidthAvg": 455
   },
-  {
+  "newTegomin": {
     "familyName": "New Tegomin",
+    "category": "serif",
     "capHeight": 635,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 438,
-    "xWidthAvg": 497,
-    "category": "serif"
+    "xWidthAvg": 497
   },
-  {
+  "notoSansAdlamUnjoined": {
     "familyName": "Noto Sans Adlam Unjoined",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 575,
-    "xWidthAvg": 470,
-    "category": "sans-serif"
+    "xWidthAvg": 470
   },
-  {
+  "notoNaskhArabic": {
     "familyName": "Noto Naskh Arabic",
+    "category": "serif",
     "capHeight": 0,
     "ascent": 1069,
     "descent": -634,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 0,
-    "xWidthAvg": 471,
-    "category": "serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansAdlam": {
     "familyName": "Noto Sans Adlam",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 575,
-    "xWidthAvg": 470,
-    "category": "sans-serif"
+    "xWidthAvg": 470
   },
-  {
+  "notoSansBalinese": {
     "familyName": "Noto Sans Balinese",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1363,
     "descent": -838,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansArabic": {
     "familyName": "Noto Sans Arabic",
+    "category": "sans-serif",
     "capHeight": 416,
     "ascent": 1374,
     "descent": -738,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 374,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansBamum": {
     "familyName": "Noto Sans Bamum",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansArmenian": {
     "familyName": "Noto Sans Armenian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSans": {
     "familyName": "Noto Sans",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansAvestan": {
     "familyName": "Noto Sans Avestan",
+    "category": "sans-serif",
     "capHeight": 652,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansAnatoHiero": {
     "familyName": "Noto Sans AnatoHiero",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1153,
     "descent": -253,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansBassaVah": {
     "familyName": "Noto Sans Bassa Vah",
+    "category": "sans-serif",
     "capHeight": 674,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 486,
-    "category": "sans-serif"
+    "xWidthAvg": 486
   },
-  {
+  "notoSansBatak": {
     "familyName": "Noto Sans Batak",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansBengali": {
     "familyName": "Noto Sans Bengali",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 917,
     "descent": -408,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "nanumPen": {
     "familyName": "Nanum Pen",
+    "category": "handwriting",
     "capHeight": 674,
     "ascent": 920,
     "descent": -230,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 476,
-    "xWidthAvg": 356,
-    "category": "handwriting"
+    "xWidthAvg": 356
   },
-  {
+  "notoSansBhaiksuki": {
     "familyName": "Noto Sans Bhaiksuki",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 960,
     "descent": -460,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 531,
-    "category": "sans-serif"
+    "xWidthAvg": 531
   },
-  {
+  "notoSansBrahmi": {
     "familyName": "Noto Sans Brahmi",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -306,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansBuginese": {
     "familyName": "Noto Sans Buginese",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansCarian": {
     "familyName": "Noto Sans Carian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansBuhid": {
     "familyName": "Noto Sans Buhid",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansCanadianAboriginal": {
     "familyName": "Noto Sans Canadian Aboriginal",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 477,
-    "category": "sans-serif"
+    "xWidthAvg": 477
   },
-  {
+  "notoSansCaucAlban": {
     "familyName": "Noto Sans CaucAlban",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 976,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 410,
-    "xWidthAvg": 546,
-    "category": "sans-serif"
+    "xWidthAvg": 546
   },
-  {
+  "notoSansCham": {
     "familyName": "Noto Sans Cham",
+    "category": "sans-serif",
     "capHeight": 594,
     "ascent": 1117,
     "descent": -351,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansChakma": {
     "familyName": "Noto Sans Chakma",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1140,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansCoptic": {
     "familyName": "Noto Sans Coptic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansCypriot": {
     "familyName": "Noto Sans Cypriot",
+    "category": "sans-serif",
     "capHeight": 736,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansDeseret": {
     "familyName": "Noto Sans Deseret",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansCherokee": {
     "familyName": "Noto Sans Cherokee",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 535,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansDevanagari": {
     "familyName": "Noto Sans Devanagari",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 896,
     "descent": -408,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansDuployan": {
     "familyName": "Noto Sans Duployan",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansElbasan": {
     "familyName": "Noto Sans Elbasan",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 847,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 560,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansElymaic": {
     "familyName": "Noto Sans Elymaic",
+    "category": "sans-serif",
     "capHeight": 570,
     "ascent": 920,
     "descent": -280,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 570,
-    "xWidthAvg": 564,
-    "category": "sans-serif"
+    "xWidthAvg": 564
   },
-  {
+  "notoSansDisplay": {
     "familyName": "Noto Sans Display",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 445,
-    "category": "sans-serif"
+    "xWidthAvg": 445
   },
-  {
+  "notoSansGeorgian": {
     "familyName": "Noto Sans Georgian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansGlagolitic": {
     "familyName": "Noto Sans Glagolitic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansGothic": {
     "familyName": "Noto Sans Gothic",
+    "category": "sans-serif",
     "capHeight": 646,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "nanumMyeongjo": {
     "familyName": "NanumMyeongjo",
+    "category": "serif",
     "capHeight": 755,
     "ascent": 942,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 480,
-    "xWidthAvg": 448,
-    "category": "serif"
+    "xWidthAvg": 448
   },
-  {
+  "notoSansGrantha": {
     "familyName": "Noto Sans Grantha",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1290,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 566,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansGujarati": {
     "familyName": "Noto Sans Gujarati",
+    "category": "sans-serif",
     "capHeight": 592,
     "ascent": 896,
     "descent": -408,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "sans-serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSansGunjalaGondi": {
     "familyName": "Noto Sans Gunjala Gondi",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 1014,
     "descent": -252,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 561,
-    "xWidthAvg": 3777,
-    "category": "sans-serif"
+    "xWidthAvg": 3777
   },
-  {
+  "notoSansEthiopic": {
     "familyName": "Noto Sans Ethiopic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansHanifiRohingya": {
     "familyName": "Noto Sans Hanifi Rohingya",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansEgyptHiero": {
     "familyName": "Noto Sans EgyptHiero",
+    "category": "sans-serif",
     "capHeight": 900,
     "ascent": 1324,
     "descent": -326,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 535,
-    "category": "sans-serif"
+    "xWidthAvg": 535
   },
-  {
+  "notoSansHatran": {
     "familyName": "Noto Sans Hatran",
+    "category": "sans-serif",
     "capHeight": 763,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 560,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansCuneiform": {
     "familyName": "Noto Sans Cuneiform",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1596,
     "descent": -690,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansGurmukhi": {
     "familyName": "Noto Sans Gurmukhi",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 896,
     "descent": -408,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 622,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansHanunoo": {
     "familyName": "Noto Sans Hanunoo",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansHebrew": {
     "familyName": "Noto Sans Hebrew",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansImpAramaic": {
     "familyName": "Noto Sans ImpAramaic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansInsPahlavi": {
     "familyName": "Noto Sans InsPahlavi",
+    "category": "sans-serif",
     "capHeight": 760,
     "ascent": 1069,
     "descent": -352,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansIndicSiyaqNumbers": {
     "familyName": "Noto Sans Indic Siyaq Numbers",
+    "category": "sans-serif",
     "capHeight": 964,
     "ascent": 1215,
     "descent": -347,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 553,
-    "xWidthAvg": 515,
-    "category": "sans-serif"
+    "xWidthAvg": 515
   },
-  {
+  "notoSansInsParthi": {
     "familyName": "Noto Sans InsParthi",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -301,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansKannada": {
     "familyName": "Noto Sans Kannada",
+    "category": "sans-serif",
     "capHeight": 690,
     "ascent": 809,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 551,
-    "xWidthAvg": 476,
-    "category": "sans-serif"
+    "xWidthAvg": 476
   },
-  {
+  "notoSansKharoshthi": {
     "familyName": "Noto Sans Kharoshthi",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -301,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansKayahLi": {
     "familyName": "Noto Sans Kayah Li",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansKaithi": {
     "familyName": "Noto Sans Kaithi",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 1077,
     "descent": -425,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 540,
-    "category": "sans-serif"
+    "xWidthAvg": 540
   },
-  {
+  "notoSansJavanese": {
     "familyName": "Noto Sans Javanese",
+    "category": "sans-serif",
     "capHeight": 750,
     "ascent": 1120,
     "descent": -916,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansKhmer": {
     "familyName": "Noto Sans Khmer",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansKhudawadi": {
     "familyName": "Noto Sans Khudawadi",
+    "category": "sans-serif",
     "capHeight": 620,
     "ascent": 944,
     "descent": -373,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansKhojki": {
     "familyName": "Noto Sans Khojki",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1409,
     "descent": -447,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 545,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansLao": {
     "familyName": "Noto Sans Lao",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1183,
     "descent": -462,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansLepcha": {
     "familyName": "Noto Sans Lepcha",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansLimbu": {
     "familyName": "Noto Sans Limbu",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansLaoLooped": {
     "familyName": "Noto Sans Lao Looped",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1250,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansLinearA": {
     "familyName": "Noto Sans Linear A",
+    "category": "sans-serif",
     "capHeight": 800,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 588,
-    "category": "sans-serif"
+    "xWidthAvg": 588
   },
-  {
+  "notoSansLinearB": {
     "familyName": "Noto Sans Linear B",
+    "category": "sans-serif",
     "capHeight": 800,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansLycian": {
     "familyName": "Noto Sans Lycian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansMahajani": {
     "familyName": "Noto Sans Mahajani",
+    "category": "sans-serif",
     "capHeight": 600,
     "ascent": 757,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansMalayalam": {
     "familyName": "Noto Sans Malayalam",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 864,
     "descent": -383,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 480,
-    "category": "sans-serif"
+    "xWidthAvg": 480
   },
-  {
+  "notoSansHK": {
     "familyName": "Noto Sans HK",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "notoSansLydian": {
     "familyName": "Noto Sans Lydian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansMandaic": {
     "familyName": "Noto Sans Mandaic",
+    "category": "sans-serif",
     "capHeight": 694,
     "ascent": 724,
     "descent": -423,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansLisu": {
     "familyName": "Noto Sans Lisu",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansManichaean": {
     "familyName": "Noto Sans Manichaean",
+    "category": "sans-serif",
     "capHeight": 625,
     "ascent": 790,
     "descent": -340,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 439,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansMasaramGondi": {
     "familyName": "Noto Sans Masaram Gondi",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 357,
-    "xWidthAvg": 493,
-    "category": "sans-serif"
+    "xWidthAvg": 493
   },
-  {
+  "notoSansMarchen": {
     "familyName": "Noto Sans Marchen",
+    "category": "sans-serif",
     "capHeight": 678,
     "ascent": 1107,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 678,
-    "xWidthAvg": 531,
-    "category": "sans-serif"
+    "xWidthAvg": 531
   },
-  {
+  "notoSansJP": {
     "familyName": "Noto Sans JP",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "notoSansMayanNumerals": {
     "familyName": "Noto Sans Mayan Numerals",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansMedefaidrin": {
     "familyName": "Noto Sans Medefaidrin",
+    "category": "sans-serif",
     "capHeight": 713,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMeeteiMayek": {
     "familyName": "Noto Sans Meetei Mayek",
+    "category": "sans-serif",
     "capHeight": 659,
     "ascent": 1069,
     "descent": -321,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 475,
-    "category": "sans-serif"
+    "xWidthAvg": 475
   },
-  {
+  "notoSansMendeKikakui": {
     "familyName": "Noto Sans Mende Kikakui",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1030,
     "descent": -237,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMath": {
     "familyName": "Noto Sans Math",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -423,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMeroitic": {
     "familyName": "Noto Sans Meroitic",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 928,
     "descent": -415,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansMiao": {
     "familyName": "Noto Sans Miao",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1142,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 341,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansKR": {
     "familyName": "Noto Sans KR",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "notoSansModi": {
     "familyName": "Noto Sans Modi",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 891,
     "descent": -463,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMongolian": {
     "familyName": "Noto Sans Mongolian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1457,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 444,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMro": {
     "familyName": "Noto Sans Mro",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMono": {
     "familyName": "Noto Sans Mono",
+    "category": "monospace",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "notoSansMultani": {
     "familyName": "Noto Sans Multani",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansMyanmar": {
     "familyName": "Noto Sans Myanmar",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1324,
     "descent": -860,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansNabataean": {
     "familyName": "Noto Sans Nabataean",
+    "category": "sans-serif",
     "capHeight": 640,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansNKo": {
     "familyName": "Noto Sans NKo",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 513,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansNewTaiLue": {
     "familyName": "Noto Sans New Tai Lue",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansNewa": {
     "familyName": "Noto Sans Newa",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 1036,
     "descent": -396,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansNushu": {
     "familyName": "Noto Sans Nushu",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -321,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOldItalic": {
     "familyName": "Noto Sans Old Italic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOldPermic": {
     "familyName": "Noto Sans Old Permic",
+    "category": "sans-serif",
     "capHeight": 638,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 535,
-    "category": "sans-serif"
+    "xWidthAvg": 535
   },
-  {
+  "notoSansOldNorArab": {
     "familyName": "Noto Sans OldNorArab",
+    "category": "sans-serif",
     "capHeight": 665,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOldSogdian": {
     "familyName": "Noto Sans OldSogdian",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 518,
-    "category": "sans-serif"
+    "xWidthAvg": 518
   },
-  {
+  "notoSansOldHung": {
     "familyName": "Noto Sans OldHung",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 859,
     "descent": -177,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 600,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOldSouArab": {
     "familyName": "Noto Sans OldSouArab",
+    "category": "sans-serif",
     "capHeight": 859,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 508,
-    "category": "sans-serif"
+    "xWidthAvg": 508
   },
-  {
+  "notoSansOldTurkic": {
     "familyName": "Noto Sans Old Turkic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOlChiki": {
     "familyName": "Noto Sans Ol Chiki",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansOgham": {
     "familyName": "Noto Sans Ogham",
+    "category": "sans-serif",
     "capHeight": 695,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansOsage": {
     "familyName": "Noto Sans Osage",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansOriya": {
     "familyName": "Noto Sans Oriya",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 658,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansPahawhHmong": {
     "familyName": "Noto Sans Pahawh Hmong",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansOsmanya": {
     "familyName": "Noto Sans Osmanya",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 477,
-    "category": "sans-serif"
+    "xWidthAvg": 477
   },
-  {
+  "notoSansPalmyrene": {
     "familyName": "Noto Sans Palmyrene",
+    "category": "sans-serif",
     "capHeight": 778,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 640,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansPhoenician": {
     "familyName": "Noto Sans Phoenician",
+    "category": "sans-serif",
     "capHeight": 719,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansPauCinHau": {
     "familyName": "Noto Sans Pau Cin Hau",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 475,
-    "category": "sans-serif"
+    "xWidthAvg": 475
   },
-  {
+  "notoSansPsaPahlavi": {
     "familyName": "Noto Sans PsaPahlavi",
+    "category": "sans-serif",
     "capHeight": 625,
     "ascent": 737,
     "descent": -554,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 469,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansRejang": {
     "familyName": "Noto Sans Rejang",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansPhagsPa": {
     "familyName": "Noto Sans PhagsPa",
+    "category": "sans-serif",
     "capHeight": 670,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansRunic": {
     "familyName": "Noto Sans Runic",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansSamaritan": {
     "familyName": "Noto Sans Samaritan",
+    "category": "sans-serif",
     "capHeight": 659,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansOldPersian": {
     "familyName": "Noto Sans OldPersian",
+    "category": "sans-serif",
     "capHeight": 724,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansSaurashtra": {
     "familyName": "Noto Sans Saurashtra",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 476,
-    "category": "sans-serif"
+    "xWidthAvg": 476
   },
-  {
+  "notoSansShavian": {
     "familyName": "Noto Sans Shavian",
+    "category": "sans-serif",
     "capHeight": 771,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 456,
-    "category": "sans-serif"
+    "xWidthAvg": 456
   },
-  {
+  "notoSansSharada": {
     "familyName": "Noto Sans Sharada",
+    "category": "sans-serif",
     "capHeight": 625,
     "ascent": 925,
     "descent": -455,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSoraSompeng": {
     "familyName": "Noto Sans Sora Sompeng",
+    "category": "sans-serif",
     "capHeight": 800,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 433,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSogdian": {
     "familyName": "Noto Sans Sogdian",
+    "category": "sans-serif",
     "capHeight": 674,
     "ascent": 1069,
     "descent": -313,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 382,
-    "xWidthAvg": 518,
-    "category": "sans-serif"
+    "xWidthAvg": 518
   },
-  {
+  "notoSansSinhala": {
     "familyName": "Noto Sans Sinhala",
+    "category": "sans-serif",
     "capHeight": 612,
     "ascent": 1011,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 515,
-    "category": "sans-serif"
+    "xWidthAvg": 515
   },
-  {
+  "notoSansSiddham": {
     "familyName": "Noto Sans Siddham",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1000,
     "descent": -1030,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 683,
-    "xWidthAvg": 460,
-    "category": "sans-serif"
+    "xWidthAvg": 460
   },
-  {
+  "notoSansSundanese": {
     "familyName": "Noto Sans Sundanese",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -368,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSylotiNagri": {
     "familyName": "Noto Sans Syloti Nagri",
+    "category": "sans-serif",
     "capHeight": 679,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSymbols": {
     "familyName": "Noto Sans Symbols",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1480,
     "descent": -570,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSoyombo": {
     "familyName": "Noto Sans Soyombo",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1239,
     "descent": -357,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansSyriac": {
     "familyName": "Noto Sans Syriac",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 926,
     "descent": -486,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 553,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansTagalog": {
     "familyName": "Noto Sans Tagalog",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansSymbols2": {
     "familyName": "Noto Sans Symbols 2",
+    "category": "sans-serif",
     "capHeight": 945,
     "ascent": 1069,
     "descent": -630,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 437,
-    "category": "sans-serif"
+    "xWidthAvg": 437
   },
-  {
+  "notoSansTagbanwa": {
     "familyName": "Noto Sans Tagbanwa",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTaiTham": {
     "familyName": "Noto Sans Tai Tham",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1069,
     "descent": -520,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 495,
-    "category": "sans-serif"
+    "xWidthAvg": 495
   },
-  {
+  "notoSansTaiLe": {
     "familyName": "Noto Sans Tai Le",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTakri": {
     "familyName": "Noto Sans Takri",
+    "category": "sans-serif",
     "capHeight": 625,
     "ascent": 955,
     "descent": -307,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 575,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTamilSupplement": {
     "familyName": "Noto Sans Tamil Supplement",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 870,
     "descent": -370,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 600,
-    "category": "sans-serif"
+    "xWidthAvg": 600
   },
-  {
+  "notoSansTaiViet": {
     "familyName": "Noto Sans Tai Viet",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTangsa": {
     "familyName": "Noto Sans Tangsa",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansThaana": {
     "familyName": "Noto Sans Thaana",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -424,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTamil": {
     "familyName": "Noto Sans Tamil",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 870,
     "descent": -370,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansThai": {
     "familyName": "Noto Sans Thai",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1061,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 556,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansTelugu": {
     "familyName": "Noto Sans Telugu",
+    "category": "sans-serif",
     "capHeight": 620,
     "ascent": 869,
     "descent": -483,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 476,
-    "category": "sans-serif"
+    "xWidthAvg": 476
   },
-  {
+  "notoSansThaiLoopedRegular": {
     "familyName": "Noto Sans Thai Looped Regular",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1250,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansUgaritic": {
     "familyName": "Noto Sans Ugaritic",
+    "category": "sans-serif",
     "capHeight": 723,
     "ascent": 743,
     "descent": -381,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansTirhuta": {
     "familyName": "Noto Sans Tirhuta",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 1026,
     "descent": -519,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "sans-serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSansTifinagh": {
     "familyName": "Noto Sans Tifinagh",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansWancho": {
     "familyName": "Noto Sans Wancho",
+    "category": "sans-serif",
     "capHeight": 710,
     "ascent": 1096,
     "descent": -161,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 497,
-    "category": "sans-serif"
+    "xWidthAvg": 497
   },
-  {
+  "notoSansWarangCiti": {
     "familyName": "Noto Sans Warang Citi",
+    "category": "sans-serif",
     "capHeight": 710,
     "ascent": 1042,
     "descent": -100,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 561,
-    "xWidthAvg": 479,
-    "category": "sans-serif"
+    "xWidthAvg": 479
   },
-  {
+  "notoColorEmoji": {
     "familyName": "Noto Color Emoji",
+    "category": "sans-serif",
     "capHeight": 717,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 512,
-    "xWidthAvg": 1275,
-    "category": "sans-serif"
+    "xWidthAvg": 1275
   },
-  {
+  "notoSansVai": {
     "familyName": "Noto Sans Vai",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSerif": {
     "familyName": "Noto Serif",
+    "category": "serif",
     "capHeight": 1462,
     "ascent": 2189,
     "descent": -600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 980,
-    "category": "serif"
+    "xWidthAvg": 980
   },
-  {
+  "notoSerifArmenian": {
     "familyName": "Noto Serif Armenian",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifAhom": {
     "familyName": "Noto Serif Ahom",
+    "category": "serif",
     "capHeight": 680,
     "ascent": 980,
     "descent": -675,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 471,
-    "category": "serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansZanabazarSquare": {
     "familyName": "Noto Sans Zanabazar Square",
+    "category": "sans-serif",
     "capHeight": 678,
     "ascent": 1621,
     "descent": -821,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 471,
-    "category": "sans-serif"
+    "xWidthAvg": 471
   },
-  {
+  "notoSansYi": {
     "familyName": "Noto Sans Yi",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 468,
-    "category": "sans-serif"
+    "xWidthAvg": 468
   },
-  {
+  "notoSansSC": {
     "familyName": "Noto Sans SC",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "notoSerifBalinese": {
     "familyName": "Noto Serif Balinese",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -726,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifDogra": {
     "familyName": "Noto Serif Dogra",
+    "category": "serif",
     "capHeight": 625,
     "ascent": 1130,
     "descent": -364,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 535,
-    "category": "serif"
+    "xWidthAvg": 535
   },
-  {
+  "notoSerifBengali": {
     "familyName": "Noto Serif Bengali",
+    "category": "serif",
     "capHeight": 622,
     "ascent": 1092,
     "descent": -502,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifDevanagari": {
     "familyName": "Noto Serif Devanagari",
+    "category": "serif",
     "capHeight": 715,
     "ascent": 930,
     "descent": -625,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 623,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSansTC": {
     "familyName": "Noto Sans TC",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 543,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "notoSerifGeorgian": {
     "familyName": "Noto Serif Georgian",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifEthiopic": {
     "familyName": "Noto Serif Ethiopic",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifDisplay": {
     "familyName": "Noto Serif Display",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 472,
-    "category": "serif"
+    "xWidthAvg": 472
   },
-  {
+  "notoSerifGujarati": {
     "familyName": "Noto Serif Gujarati",
+    "category": "serif",
     "capHeight": 592,
     "ascent": 997,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 486,
-    "category": "serif"
+    "xWidthAvg": 486
   },
-  {
+  "notoSerifGrantha": {
     "familyName": "Noto Serif Grantha",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1290,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 566,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifGurmukhi": {
     "familyName": "Noto Serif Gurmukhi",
+    "category": "serif",
     "capHeight": 622,
     "ascent": 1006,
     "descent": -428,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifHebrew": {
     "familyName": "Noto Serif Hebrew",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 896,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifKannada": {
     "familyName": "Noto Serif Kannada",
+    "category": "serif",
     "capHeight": 690,
     "ascent": 910,
     "descent": -710,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 547,
-    "xWidthAvg": 473,
-    "category": "serif"
+    "xWidthAvg": 473
   },
-  {
+  "notoSerifLao": {
     "familyName": "Noto Serif Lao",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1174,
     "descent": -482,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifKhojki": {
     "familyName": "Noto Serif Khojki",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1409,
     "descent": -447,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifKhmer": {
     "familyName": "Noto Serif Khmer",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1069,
     "descent": -293,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifMalayalam": {
     "familyName": "Noto Serif Malayalam",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 864,
     "descent": -383,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 487,
-    "category": "serif"
+    "xWidthAvg": 487
   },
-  {
+  "notoSerifMyanmar": {
     "familyName": "Noto Serif Myanmar",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1239,
     "descent": -1260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 550,
-    "category": "serif"
+    "xWidthAvg": 550
   },
-  {
+  "notoSansSignWriting": {
     "familyName": "Noto Sans SignWriting",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 802,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 606,
-    "category": "sans-serif"
+    "xWidthAvg": 606
   },
-  {
+  "notoSerifNPHmong": {
     "familyName": "Noto Serif NP Hmong",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifNyiakengPuachueHmong": {
     "familyName": "Noto Serif Nyiakeng Puachue Hmong",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSerifTamil": {
     "familyName": "Noto Serif Tamil",
+    "category": "serif",
     "capHeight": 829,
     "ascent": 1069,
     "descent": -492,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 554,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifOriya": {
     "familyName": "Noto Serif Oriya",
+    "category": "serif",
     "capHeight": 657,
     "ascent": 917,
     "descent": -492,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 657,
-    "xWidthAvg": 504,
-    "category": "serif"
+    "xWidthAvg": 504
   },
-  {
+  "notoSerifSinhala": {
     "familyName": "Noto Serif Sinhala",
+    "category": "serif",
     "capHeight": 612,
     "ascent": 997,
     "descent": -307,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 522,
-    "category": "serif"
+    "xWidthAvg": 522
   },
-  {
+  "notoSerifThai": {
     "familyName": "Noto Serif Thai",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1064,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoSerifTelugu": {
     "familyName": "Noto Serif Telugu",
+    "category": "serif",
     "capHeight": 620,
     "ascent": 869,
     "descent": -483,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 483,
-    "category": "serif"
+    "xWidthAvg": 483
   },
-  {
+  "notoSerifYezidi": {
     "familyName": "Noto Serif Yezidi",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1068,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "serif"
+    "xWidthAvg": 538
   },
-  {
+  "notoSerifTibetan": {
     "familyName": "Noto Serif Tibetan",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1466,
     "descent": -1349,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 678,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "novaFlat": {
     "familyName": "Nova Flat",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 993,
-    "category": "display"
+    "xWidthAvg": 993
   },
-  {
+  "notoSerifToto": {
     "familyName": "Noto Serif Toto",
+    "category": "serif",
     "capHeight": 720,
     "ascent": 925,
     "descent": -378,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 622,
-    "xWidthAvg": 478,
-    "category": "serif"
+    "xWidthAvg": 478
   },
-  {
+  "notoTraditionalNushu": {
     "familyName": "Noto Traditional Nushu",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1080,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 543,
-    "xWidthAvg": 517,
-    "category": "sans-serif"
+    "xWidthAvg": 517
   },
-  {
+  "novaCut": {
     "familyName": "Nova Cut",
+    "category": "display",
     "capHeight": 1550,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1140,
-    "xWidthAvg": 1008,
-    "category": "display"
+    "xWidthAvg": 1008
   },
-  {
+  "notoSerifTC": {
     "familyName": "Noto Serif TC",
+    "category": "serif",
     "capHeight": 729,
     "ascent": 1151,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 484,
-    "category": "serif"
+    "xWidthAvg": 484
   },
-  {
+  "novaRound": {
     "familyName": "Nova Round",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 993,
-    "category": "display"
+    "xWidthAvg": 993
   },
-  {
+  "novaMono": {
     "familyName": "NovaMono",
+    "category": "monospace",
     "capHeight": 1509,
     "ascent": 2215,
     "descent": -639,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 1150,
-    "category": "monospace"
+    "xWidthAvg": 1150
   },
-  {
+  "novaScript": {
     "familyName": "Nova Script",
+    "category": "display",
     "capHeight": 1550,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 1000,
-    "category": "display"
+    "xWidthAvg": 1000
   },
-  {
+  "notoSerifTangut": {
     "familyName": "Noto Serif Tangut",
+    "category": "serif",
     "capHeight": 743,
     "ascent": 856,
     "descent": -150,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 538,
-    "category": "serif"
+    "xWidthAvg": 538
   },
-  {
+  "novaSlim": {
     "familyName": "Nova Slim",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 993,
-    "category": "display"
+    "xWidthAvg": 993
   },
-  {
+  "numans": {
     "familyName": "Numans",
+    "category": "sans-serif",
     "capHeight": 1434,
     "ascent": 1853,
     "descent": -553,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1096,
-    "xWidthAvg": 1095,
-    "category": "sans-serif"
+    "xWidthAvg": 1095
   },
-  {
+  "novaSquare": {
     "familyName": "Nova Square",
+    "category": "display",
     "capHeight": 1510,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1100,
-    "xWidthAvg": 993,
-    "category": "display"
+    "xWidthAvg": 993
   },
-  {
+  "novaOval": {
     "familyName": "Nova Oval",
+    "category": "display",
     "capHeight": 1550,
     "ascent": 1966,
     "descent": -506,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1120,
-    "xWidthAvg": 992,
-    "category": "display"
+    "xWidthAvg": 992
   },
-  {
+  "nunito": {
     "familyName": "Nunito",
+    "category": "sans-serif",
     "capHeight": 705,
     "ascent": 1011,
     "descent": -353,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 484,
-    "xWidthAvg": 449,
-    "category": "sans-serif"
+    "xWidthAvg": 449
   },
-  {
+  "nunitoSans": {
     "familyName": "Nunito Sans",
+    "category": "sans-serif",
     "capHeight": 705,
     "ascent": 1011,
     "descent": -353,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 449,
-    "category": "sans-serif"
+    "xWidthAvg": 449
   },
-  {
+  "nuosuSIL": {
     "familyName": "Nuosu SIL",
+    "category": "serif",
     "capHeight": 1800,
     "ascent": 2200,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1000,
-    "xWidthAvg": 851,
-    "category": "serif"
+    "xWidthAvg": 851
   },
-  {
+  "offside": {
     "familyName": "Offside",
+    "category": "display",
     "capHeight": 740,
     "ascent": 996,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 605,
-    "xWidthAvg": 537,
-    "category": "display"
+    "xWidthAvg": 537
   },
-  {
+  "odibeeSans": {
     "familyName": "Odibee Sans",
+    "category": "display",
     "capHeight": 700,
     "ascent": 858,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 307,
-    "category": "display"
+    "xWidthAvg": 307
   },
-  {
+  "odorMeanChey": {
     "familyName": "Odor Mean Chey",
+    "category": "serif",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 917,
-    "category": "serif"
+    "xWidthAvg": 917
   },
-  {
+  "oi": {
     "familyName": "Oi",
+    "category": "display",
     "capHeight": 760,
     "ascent": 1070,
     "descent": -510,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 696,
-    "xWidthAvg": 802,
-    "category": "display"
+    "xWidthAvg": 802
   },
-  {
+  "oldenburg": {
     "familyName": "Oldenburg",
+    "category": "display",
     "capHeight": 1555,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 9,
     "unitsPerEm": 2048,
     "xHeight": 482,
-    "xWidthAvg": 1094,
-    "category": "display"
+    "xWidthAvg": 1094
   },
-  {
+  "oleoScript": {
     "familyName": "Oleo Script",
+    "category": "display",
     "capHeight": 710,
     "ascent": 1004,
     "descent": -379,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 443,
-    "xWidthAvg": 376,
-    "category": "display"
+    "xWidthAvg": 376
   },
-  {
+  "oleoScriptSwashCaps": {
     "familyName": "Oleo Script Swash Caps",
+    "category": "display",
     "capHeight": 747,
     "ascent": 1004,
     "descent": -379,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 443,
-    "xWidthAvg": 376,
-    "category": "display"
+    "xWidthAvg": 376
   },
-  {
+  "ole": {
     "familyName": "Ole",
+    "category": "handwriting",
     "capHeight": 510,
     "ascent": 880,
     "descent": -380,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 270,
-    "xWidthAvg": 264,
-    "category": "handwriting"
+    "xWidthAvg": 264
   },
-  {
+  "orbitron": {
     "familyName": "Orbitron",
+    "category": "sans-serif",
     "capHeight": 720,
     "ascent": 1011,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 580,
-    "xWidthAvg": 550,
-    "category": "sans-serif"
+    "xWidthAvg": 550
   },
-  {
+  "openSans": {
     "familyName": "Open Sans",
+    "category": "sans-serif",
     "capHeight": 1462,
     "ascent": 2189,
     "descent": -600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1096,
-    "xWidthAvg": 955,
-    "category": "sans-serif"
+    "xWidthAvg": 955
   },
-  {
+  "oranienbaum": {
     "familyName": "Oranienbaum",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 895,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 401,
-    "category": "serif"
+    "xWidthAvg": 401
   },
-  {
+  "oldStandardTT": {
     "familyName": "Old Standard TT",
+    "category": "serif",
     "capHeight": 712,
     "ascent": 762,
     "descent": -238,
     "lineGap": 236,
     "unitsPerEm": 1000,
     "xHeight": 456,
-    "xWidthAvg": 430,
-    "category": "serif"
+    "xWidthAvg": 430
   },
-  {
+  "ooohBaby": {
     "familyName": "Oooh Baby",
+    "category": "handwriting",
     "capHeight": 695,
     "ascent": 900,
     "descent": -325,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 365,
-    "xWidthAvg": 352,
-    "category": "handwriting"
+    "xWidthAvg": 352
   },
-  {
+  "notoSerifSC": {
     "familyName": "Noto Serif SC",
+    "category": "serif",
     "capHeight": 729,
     "ascent": 1151,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 484,
-    "category": "serif"
+    "xWidthAvg": 484
   },
-  {
+  "oregano": {
     "familyName": "Oregano",
+    "category": "display",
     "capHeight": 1460,
     "ascent": 1975,
     "descent": -669,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 864,
-    "xWidthAvg": 660,
-    "category": "display"
+    "xWidthAvg": 660
   },
-  {
+  "notoSerifJP": {
     "familyName": "Noto Serif JP",
+    "category": "serif",
     "capHeight": 729,
     "ascent": 1151,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 484,
-    "category": "serif"
+    "xWidthAvg": 484
   },
-  {
+  "orelegaOne": {
     "familyName": "Orelega One",
+    "category": "display",
     "capHeight": 2480,
     "ascent": 3296,
     "descent": -801,
     "lineGap": 369,
     "unitsPerEm": 4096,
     "xHeight": 1840,
-    "xWidthAvg": 1837,
-    "category": "display"
+    "xWidthAvg": 1837
   },
-  {
+  "overTheRainbow": {
     "familyName": "Over the Rainbow",
+    "category": "handwriting",
     "capHeight": 812,
     "ascent": 1412,
     "descent": -677,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 636,
-    "xWidthAvg": 467,
-    "category": "handwriting"
+    "xWidthAvg": 467
   },
-  {
+  "originalSurfer": {
     "familyName": "Original Surfer",
+    "category": "display",
     "capHeight": 1497,
     "ascent": 2036,
     "descent": -526,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 987,
-    "xWidthAvg": 944,
-    "category": "display"
+    "xWidthAvg": 944
   },
-  {
+  "orienta": {
     "familyName": "Orienta",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 960,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 484,
-    "category": "sans-serif"
+    "xWidthAvg": 484
   },
-  {
+  "overlock": {
     "familyName": "Overlock",
+    "category": "display",
     "capHeight": 154,
     "ascent": 966,
     "descent": -254,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 125,
-    "xWidthAvg": 402,
-    "category": "display"
+    "xWidthAvg": 402
   },
-  {
+  "outfit": {
     "familyName": "Outfit",
+    "category": "sans-serif",
     "capHeight": 676,
     "ascent": 1000,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 439,
-    "category": "sans-serif"
+    "xWidthAvg": 439
   },
-  {
+  "oswald": {
     "familyName": "Oswald",
+    "category": "sans-serif",
     "capHeight": 810,
     "ascent": 1193,
     "descent": -289,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 578,
-    "xWidthAvg": 363,
-    "category": "sans-serif"
+    "xWidthAvg": 363
   },
-  {
+  "overlockSC": {
     "familyName": "Overlock SC",
+    "category": "display",
     "capHeight": 154,
     "ascent": 966,
     "descent": -254,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 159,
-    "xWidthAvg": 443,
-    "category": "display"
+    "xWidthAvg": 443
   },
-  {
+  "oxanium": {
     "familyName": "Oxanium",
+    "category": "display",
     "capHeight": 690,
     "ascent": 790,
     "descent": -210,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 461,
-    "category": "display"
+    "xWidthAvg": 461
   },
-  {
+  "ovo": {
     "familyName": "Ovo",
+    "category": "serif",
     "capHeight": 210,
     "ascent": 1770,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 356,
-    "xWidthAvg": 895,
-    "category": "serif"
+    "xWidthAvg": 895
   },
-  {
+  "overpassMono": {
     "familyName": "Overpass Mono",
+    "category": "monospace",
     "capHeight": 1400,
     "ascent": 1766,
     "descent": -766,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1022,
-    "xWidthAvg": 1232,
-    "category": "monospace"
+    "xWidthAvg": 1232
   },
-  {
-    "familyName": "Oxygen",
-    "ascent": 2103,
-    "descent": -483,
-    "lineGap": 0,
-    "unitsPerEm": 2048,
-    "xWidthAvg": 918,
-    "category": "sans-serif"
-  },
-  {
+  "oxygenMono": {
     "familyName": "Oxygen Mono",
+    "category": "monospace",
     "capHeight": 1491,
     "ascent": 2015,
     "descent": -672,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1097,
-    "xWidthAvg": 1229,
-    "category": "monospace"
+    "xWidthAvg": 1229
   },
-  {
+  "pTMono": {
     "familyName": "PT Mono",
+    "category": "monospace",
     "capHeight": 700,
     "ascent": 885,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "notoSerifKR": {
     "familyName": "Noto Serif KR",
+    "category": "serif",
     "capHeight": 729,
     "ascent": 1151,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 484,
-    "category": "serif"
+    "xWidthAvg": 484
   },
-  {
+  "pTSans": {
     "familyName": "PT Sans",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 431,
-    "category": "sans-serif"
+    "xWidthAvg": 431
   },
-  {
+  "pTSansCaption": {
     "familyName": "PT Sans Caption",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "overpass": {
     "familyName": "Overpass",
+    "category": "sans-serif",
     "capHeight": 1400,
     "ascent": 1766,
     "descent": -766,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1022,
-    "xWidthAvg": 889,
-    "category": "sans-serif"
+    "xWidthAvg": 889
   },
-  {
+  "pTSerif": {
     "familyName": "PT Serif",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1039,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 444,
-    "category": "serif"
+    "xWidthAvg": 444
   },
-  {
+  "pTSerifCaption": {
     "familyName": "PT Serif Caption",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1039,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 500,
-    "category": "serif"
+    "xWidthAvg": 500
   },
-  {
+  "padauk": {
     "familyName": "Padauk",
+    "category": "sans-serif",
     "capHeight": 903,
     "ascent": 1010,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 459,
-    "xWidthAvg": 434,
-    "category": "sans-serif"
+    "xWidthAvg": 434
   },
-  {
+  "pacifico": {
     "familyName": "Pacifico",
+    "category": "handwriting",
     "capHeight": 840,
     "ascent": 1303,
     "descent": -453,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 408,
-    "category": "handwriting"
+    "xWidthAvg": 408
   },
-  {
+  "padyakkeExpandedOne": {
     "familyName": "Padyakke Expanded One",
+    "category": "display",
     "capHeight": 520,
     "ascent": 813,
     "descent": -628,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 357,
-    "xWidthAvg": 672,
-    "category": "display"
+    "xWidthAvg": 672
   },
-  {
+  "pTSansNarrow": {
     "familyName": "PT Sans Narrow",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -276,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 346,
-    "category": "sans-serif"
+    "xWidthAvg": 346
   },
-  {
+  "palanquin": {
     "familyName": "Palanquin",
+    "category": "sans-serif",
     "capHeight": 680,
     "ascent": 1320,
     "descent": -491,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 485,
-    "xWidthAvg": 428,
-    "category": "sans-serif"
+    "xWidthAvg": 428
   },
-  {
+  "passeroOne": {
     "familyName": "Passero One",
+    "category": "display",
     "capHeight": 1323,
     "ascent": 1820,
     "descent": -618,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 983,
-    "xWidthAvg": 812,
-    "category": "display"
+    "xWidthAvg": 812
   },
-  {
+  "parisienne": {
     "familyName": "Parisienne",
+    "category": "handwriting",
     "capHeight": 1558,
     "ascent": 1875,
     "descent": -915,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 723,
-    "xWidthAvg": 718,
-    "category": "handwriting"
+    "xWidthAvg": 718
   },
-  {
+  "paprika": {
     "familyName": "Paprika",
+    "category": "display",
     "capHeight": 889,
     "ascent": 1145,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 689,
-    "xWidthAvg": 533,
-    "category": "display"
+    "xWidthAvg": 533
   },
-  {
+  "passionOne": {
     "familyName": "Passion One",
+    "category": "display",
     "capHeight": 621,
     "ascent": 835,
     "descent": -266,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 479,
-    "xWidthAvg": 369,
-    "category": "display"
+    "xWidthAvg": 369
   },
-  {
+  "palanquinDark": {
     "familyName": "Palanquin Dark",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1320,
     "descent": -491,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 449,
-    "category": "sans-serif"
+    "xWidthAvg": 449
   },
-  {
+  "pangolin": {
     "familyName": "Pangolin",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 937,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 555,
-    "xWidthAvg": 412,
-    "category": "handwriting"
+    "xWidthAvg": 412
   },
-  {
+  "pathwayGothicOne": {
     "familyName": "Pathway Gothic One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 954,
     "descent": -198,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 308,
-    "category": "sans-serif"
+    "xWidthAvg": 308
   },
-  {
+  "passionsConflict": {
     "familyName": "Passions Conflict",
+    "category": "handwriting",
     "capHeight": 475,
     "ascent": 750,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 170,
-    "xWidthAvg": 247,
-    "category": "handwriting"
+    "xWidthAvg": 247
   },
-  {
+  "patuaOne": {
     "familyName": "Patua One",
+    "category": "display",
     "capHeight": 690,
     "ascent": 972,
     "descent": -247,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 442,
-    "category": "display"
+    "xWidthAvg": 442
   },
-  {
+  "pavanam": {
     "familyName": "Pavanam",
+    "category": "sans-serif",
     "ascent": 952,
     "descent": -339,
     "lineGap": 0,
     "unitsPerEm": 1000,
-    "xWidthAvg": 388,
-    "category": "sans-serif"
+    "xWidthAvg": 388
   },
-  {
+  "patrickHand": {
     "familyName": "Patrick Hand",
+    "category": "handwriting",
     "capHeight": 661,
     "ascent": 1042,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 467,
-    "xWidthAvg": 359,
-    "category": "handwriting"
+    "xWidthAvg": 359
   },
-  {
+  "patrickHandSC": {
     "familyName": "Patrick Hand SC",
+    "category": "handwriting",
     "capHeight": 661,
     "ascent": 1042,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 464,
-    "xWidthAvg": 365,
-    "category": "handwriting"
+    "xWidthAvg": 365
   },
-  {
+  "pattaya": {
     "familyName": "Pattaya",
+    "category": "sans-serif",
     "capHeight": 1532,
     "ascent": 2065,
     "descent": -777,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 787,
-    "category": "sans-serif"
+    "xWidthAvg": 787
   },
-  {
+  "paytoneOne": {
     "familyName": "Paytone One",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1113,
     "descent": -283,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 501,
-    "xWidthAvg": 506,
-    "category": "sans-serif"
+    "xWidthAvg": 506
   },
-  {
+  "peralta": {
     "familyName": "Peralta",
+    "category": "display",
     "capHeight": 1479,
     "ascent": 2004,
     "descent": -647,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1036,
-    "xWidthAvg": 1161,
-    "category": "display"
+    "xWidthAvg": 1161
   },
-  {
+  "peddana": {
     "familyName": "Peddana",
+    "category": "serif",
     "capHeight": 329,
     "ascent": 703,
     "descent": -518,
     "lineGap": 0,
     "unitsPerEm": 750,
     "xHeight": 241,
-    "xWidthAvg": 236,
-    "category": "serif"
+    "xWidthAvg": 236
   },
-  {
+  "permanentMarker": {
     "familyName": "Permanent Marker",
+    "category": "handwriting",
     "capHeight": 758,
     "ascent": 1136,
     "descent": -325,
     "lineGap": 31,
     "unitsPerEm": 1024,
     "xHeight": 625,
-    "xWidthAvg": 518,
-    "category": "handwriting"
+    "xWidthAvg": 518
   },
-  {
+  "petemoss": {
     "familyName": "Petemoss",
+    "category": "handwriting",
     "capHeight": 480,
     "ascent": 800,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 305,
-    "xWidthAvg": 208,
-    "category": "handwriting"
+    "xWidthAvg": 208
   },
-  {
+  "philosopher": {
     "familyName": "Philosopher",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 900,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 424,
-    "category": "sans-serif"
+    "xWidthAvg": 424
   },
-  {
+  "petitFormalScript": {
     "familyName": "Petit Formal Script",
+    "category": "handwriting",
     "capHeight": 1609,
     "ascent": 2033,
     "descent": -527,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1185,
-    "xWidthAvg": 1095,
-    "category": "handwriting"
+    "xWidthAvg": 1095
   },
-  {
+  "petrona": {
     "familyName": "Petrona",
+    "category": "serif",
     "capHeight": 641,
     "ascent": 858,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 443,
-    "xWidthAvg": 430,
-    "category": "serif"
+    "xWidthAvg": 430
   },
-  {
+  "piedra": {
     "familyName": "Piedra",
+    "category": "display",
     "capHeight": 655,
     "ascent": 973,
     "descent": -328,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 437,
-    "xWidthAvg": 398,
-    "category": "display"
+    "xWidthAvg": 398
   },
-  {
+  "pinyonScript": {
     "familyName": "Pinyon Script",
+    "category": "handwriting",
     "capHeight": 1388,
     "ascent": 1768,
     "descent": -787,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 760,
-    "xWidthAvg": 701,
-    "category": "handwriting"
+    "xWidthAvg": 701
   },
-  {
+  "piazzolla": {
     "familyName": "Piazzolla",
+    "category": "serif",
     "capHeight": 644,
     "ascent": 1110,
     "descent": -310,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 435,
-    "category": "serif"
+    "xWidthAvg": 435
   },
-  {
+  "pirataOne": {
     "familyName": "Pirata One",
+    "category": "display",
     "capHeight": 793,
     "ascent": 1006,
     "descent": -279,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 594,
-    "xWidthAvg": 352,
-    "category": "display"
+    "xWidthAvg": 352
   },
-  {
+  "plaster": {
     "familyName": "Plaster",
+    "category": "display",
     "capHeight": 1361,
     "ascent": 2000,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1020,
-    "xWidthAvg": 1413,
-    "category": "display"
+    "xWidthAvg": 1413
   },
-  {
+  "play": {
     "familyName": "Play",
+    "category": "sans-serif",
     "capHeight": 649,
     "ascent": 937,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 484,
-    "xWidthAvg": 447,
-    "category": "sans-serif"
+    "xWidthAvg": 447
   },
-  {
+  "playball": {
     "familyName": "Playball",
+    "category": "display",
     "capHeight": 706,
     "ascent": 950,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 403,
-    "xWidthAvg": 372,
-    "category": "display"
+    "xWidthAvg": 372
   },
-  {
+  "plusJakartaSans": {
     "familyName": "Plus Jakarta Sans",
+    "category": "sans-serif",
     "capHeight": 745,
     "ascent": 1038,
     "descent": -222,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 464,
-    "category": "sans-serif"
+    "xWidthAvg": 464
   },
-  {
+  "playfairDisplaySC": {
     "familyName": "Playfair Display SC",
+    "category": "serif",
     "capHeight": 708,
     "ascent": 1082,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 555,
-    "category": "serif"
+    "xWidthAvg": 555
   },
-  {
+  "poiretOne": {
     "familyName": "Poiret One",
+    "category": "display",
     "capHeight": 750,
     "ascent": 962,
     "descent": -208,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 428,
-    "category": "display"
+    "xWidthAvg": 428
   },
-  {
+  "playfairDisplay": {
     "familyName": "Playfair Display",
+    "category": "serif",
     "capHeight": 708,
     "ascent": 1082,
     "descent": -251,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 449,
-    "category": "serif"
+    "xWidthAvg": 449
   },
-  {
+  "pollerOne": {
     "familyName": "Poller One",
+    "category": "display",
     "capHeight": 1486,
     "ascent": 1920,
     "descent": -514,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 991,
-    "xWidthAvg": 1258,
-    "category": "display"
+    "xWidthAvg": 1258
   },
-  {
+  "pompiere": {
     "familyName": "Pompiere ",
+    "category": "display",
     "capHeight": 1315,
     "ascent": 1918,
     "descent": -543,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 616,
-    "xWidthAvg": 606,
-    "category": "display"
+    "xWidthAvg": 606
   },
-  {
+  "podkova": {
     "familyName": "Podkova",
+    "category": "serif",
     "capHeight": 589,
     "ascent": 859,
     "descent": -249,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 429,
-    "xWidthAvg": 450,
-    "category": "serif"
+    "xWidthAvg": 450
   },
-  {
+  "pontanoSans": {
     "familyName": "Pontano Sans",
+    "category": "sans-serif",
     "ascent": 2025,
     "descent": -599,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 837,
-    "category": "sans-serif"
+    "xWidthAvg": 837
   },
-  {
+  "portLligatSans": {
     "familyName": "Port Lligat Sans",
+    "category": "sans-serif",
     "capHeight": 125,
     "ascent": 860,
     "descent": -211,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 178,
-    "xWidthAvg": 398,
-    "category": "sans-serif"
+    "xWidthAvg": 398
   },
-  {
+  "portLligatSlab": {
     "familyName": "Port Lligat Slab",
+    "category": "serif",
     "capHeight": 99,
     "ascent": 860,
     "descent": -211,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 155,
-    "xWidthAvg": 397,
-    "category": "serif"
+    "xWidthAvg": 397
   },
-  {
+  "poppins": {
     "familyName": "Poppins",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1050,
     "descent": -350,
     "lineGap": 100,
     "unitsPerEm": 1000,
     "xHeight": 548,
-    "xWidthAvg": 502,
-    "category": "sans-serif"
+    "xWidthAvg": 502
   },
-  {
+  "poly": {
     "familyName": "Poly",
+    "category": "serif",
     "capHeight": 693,
     "ascent": 964,
     "descent": -224,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 444,
-    "category": "serif"
+    "xWidthAvg": 444
   },
-  {
+  "prata": {
     "familyName": "Prata",
+    "category": "serif",
     "capHeight": 800,
     "ascent": 993,
     "descent": -362,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 518,
-    "xWidthAvg": 476,
-    "category": "serif"
+    "xWidthAvg": 476
   },
-  {
+  "preahvihear": {
     "familyName": "Preahvihear",
+    "category": "sans-serif",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1065,
-    "category": "sans-serif"
+    "xWidthAvg": 1065
   },
-  {
+  "pragatiNarrow": {
     "familyName": "Pragati Narrow",
+    "category": "sans-serif",
     "capHeight": 630,
     "ascent": 1158,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 484,
-    "xWidthAvg": 332,
-    "category": "sans-serif"
+    "xWidthAvg": 332
   },
-  {
+  "pressStart2P": {
     "familyName": "Press Start 2P",
+    "category": "display",
     "capHeight": 1000,
     "ascent": 1000,
     "descent": 0,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 750,
-    "xWidthAvg": 1000,
-    "category": "display"
+    "xWidthAvg": 1000
   },
-  {
+  "princessSofia": {
     "familyName": "Princess Sofia",
+    "category": "handwriting",
     "capHeight": 858,
     "ascent": 1010,
     "descent": -574,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 670,
-    "xWidthAvg": 353,
-    "category": "handwriting"
+    "xWidthAvg": 353
   },
-  {
+  "prociono": {
     "familyName": "Prociono",
+    "category": "serif",
     "capHeight": 738,
     "ascent": 1008,
     "descent": -212,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 203,
-    "xWidthAvg": 425,
-    "category": "serif"
+    "xWidthAvg": 425
   },
-  {
+  "pridi": {
     "familyName": "Pridi",
+    "category": "serif",
     "capHeight": 714,
     "ascent": 1100,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 483,
-    "category": "serif"
+    "xWidthAvg": 483
   },
-  {
+  "prostoOne": {
     "familyName": "Prosto One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 940,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 561,
-    "category": "display"
+    "xWidthAvg": 561
   },
-  {
+  "prompt": {
     "familyName": "Prompt",
+    "category": "sans-serif",
     "capHeight": 714,
     "ascent": 1090,
     "descent": -422,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 536,
-    "xWidthAvg": 502,
-    "category": "sans-serif"
+    "xWidthAvg": 502
   },
-  {
+  "publicSans": {
     "familyName": "Public Sans",
+    "category": "sans-serif",
     "capHeight": 1446,
     "ascent": 1900,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1034,
-    "xWidthAvg": 928,
-    "category": "sans-serif"
+    "xWidthAvg": 928
   },
-  {
+  "puritan": {
     "familyName": "Puritan",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 881,
     "descent": -256,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 507,
-    "xWidthAvg": 431,
-    "category": "sans-serif"
+    "xWidthAvg": 431
   },
-  {
+  "purplePurse": {
     "familyName": "Purple Purse",
+    "category": "display",
     "capHeight": 1419,
     "ascent": 1870,
     "descent": -690,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 856,
-    "xWidthAvg": 906,
-    "category": "display"
+    "xWidthAvg": 906
   },
-  {
+  "prozaLibre": {
     "familyName": "Proza Libre",
+    "category": "sans-serif",
     "capHeight": 1465,
     "ascent": 1996,
     "descent": -800,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1060,
-    "xWidthAvg": 981,
-    "category": "sans-serif"
+    "xWidthAvg": 981
   },
-  {
+  "praise": {
     "familyName": "Praise",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 850,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 425,
-    "xWidthAvg": 318,
-    "category": "handwriting"
+    "xWidthAvg": 318
   },
-  {
+  "qahiri": {
     "familyName": "Qahiri",
+    "category": "sans-serif",
     "capHeight": 560,
     "ascent": 600,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 750,
     "xHeight": 230,
-    "xWidthAvg": 189,
-    "category": "sans-serif"
+    "xWidthAvg": 189
   },
-  {
+  "quando": {
     "familyName": "Quando",
+    "category": "serif",
     "capHeight": 1533,
     "ascent": 2030,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1200,
-    "xWidthAvg": 1111,
-    "category": "serif"
+    "xWidthAvg": 1111
   },
-  {
+  "quantico": {
     "familyName": "Quantico",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1063,
     "descent": -367,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 468,
-    "category": "sans-serif"
+    "xWidthAvg": 468
   },
-  {
+  "quattrocento": {
     "familyName": "Quattrocento",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 848,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 459,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "quattrocentoSans": {
     "familyName": "Quattrocento Sans",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 848,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 431,
-    "category": "sans-serif"
+    "xWidthAvg": 431
   },
-  {
+  "puppiesPlay": {
     "familyName": "Puppies Play",
+    "category": "handwriting",
     "capHeight": 530,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 260,
-    "xWidthAvg": 222,
-    "category": "handwriting"
+    "xWidthAvg": 222
   },
-  {
+  "quintessential": {
     "familyName": "Quintessential",
+    "category": "handwriting",
     "capHeight": 1489,
     "ascent": 2341,
     "descent": -799,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1057,
-    "xWidthAvg": 791,
-    "category": "handwriting"
+    "xWidthAvg": 791
   },
-  {
+  "quicksand": {
     "familyName": "Quicksand",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 503,
-    "xWidthAvg": 465,
-    "category": "sans-serif"
+    "xWidthAvg": 465
   },
-  {
+  "questrial": {
     "familyName": "Questrial",
+    "category": "sans-serif",
     "capHeight": 662,
     "ascent": 820,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 441,
-    "category": "sans-serif"
+    "xWidthAvg": 441
   },
-  {
+  "qwigley": {
     "familyName": "Qwigley",
+    "category": "handwriting",
     "capHeight": 460,
     "ascent": 750,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 240,
-    "category": "handwriting"
+    "xWidthAvg": 240
   },
-  {
+  "pottaOne": {
     "familyName": "Potta One",
+    "category": "display",
     "capHeight": 780,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 565,
-    "xWidthAvg": 557,
-    "category": "display"
+    "xWidthAvg": 557
   },
-  {
+  "qwitcherGrypen": {
     "familyName": "Qwitcher Grypen",
+    "category": "handwriting",
     "capHeight": 500,
     "ascent": 800,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 220,
-    "xWidthAvg": 232,
-    "category": "handwriting"
+    "xWidthAvg": 232
   },
-  {
+  "racingSansOne": {
     "familyName": "Racing Sans One",
+    "category": "display",
     "capHeight": 635,
     "ascent": 976,
     "descent": -284,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 430,
-    "xWidthAvg": 459,
-    "category": "display"
+    "xWidthAvg": 459
   },
-  {
+  "radioCanada": {
     "familyName": "Radio Canada",
+    "category": "sans-serif",
     "capHeight": 690,
     "ascent": 945,
     "descent": -255,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 463,
-    "category": "sans-serif"
+    "xWidthAvg": 463
   },
-  {
+  "radley": {
     "familyName": "Radley",
+    "category": "serif",
     "capHeight": 1302,
     "ascent": 1973,
     "descent": -615,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 899,
-    "xWidthAvg": 888,
-    "category": "serif"
+    "xWidthAvg": 888
   },
-  {
+  "rakkas": {
     "familyName": "Rakkas",
+    "category": "display",
     "capHeight": 670,
     "ascent": 1046,
     "descent": -445,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 392,
-    "category": "display"
+    "xWidthAvg": 392
   },
-  {
+  "rajdhani": {
     "familyName": "Rajdhani",
+    "category": "sans-serif",
     "capHeight": 643,
     "ascent": 930,
     "descent": -346,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 408,
-    "category": "sans-serif"
+    "xWidthAvg": 408
   },
-  {
+  "poorStory": {
     "familyName": "Poor Story",
+    "category": "display",
     "capHeight": 641,
     "ascent": 819,
     "descent": -205,
     "lineGap": 256,
     "unitsPerEm": 1024,
     "xHeight": 389,
-    "xWidthAvg": 473,
-    "category": "display"
+    "xWidthAvg": 473
   },
-  {
+  "ralewayDots": {
     "familyName": "Raleway Dots",
+    "category": "display",
     "capHeight": 710,
     "ascent": 918,
     "descent": -213,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 453,
-    "category": "display"
+    "xWidthAvg": 453
   },
-  {
+  "rammettoOne": {
     "familyName": "Rammetto One",
+    "category": "display",
     "capHeight": 1597,
     "ascent": 2437,
     "descent": -1022,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1243,
-    "xWidthAvg": 1276,
-    "category": "display"
+    "xWidthAvg": 1276
   },
-  {
+  "rambla": {
     "familyName": "Rambla",
+    "category": "sans-serif",
     "capHeight": 668,
     "ascent": 929,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 506,
-    "xWidthAvg": 408,
-    "category": "sans-serif"
+    "xWidthAvg": 408
   },
-  {
+  "raleway": {
     "familyName": "Raleway",
+    "category": "sans-serif",
     "capHeight": 710,
     "ascent": 940,
     "descent": -234,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 519,
-    "xWidthAvg": 463,
-    "category": "sans-serif"
+    "xWidthAvg": 463
   },
-  {
+  "ramabhadra": {
     "familyName": "Ramabhadra",
+    "category": "sans-serif",
     "capHeight": 571,
     "ascent": 1101,
     "descent": -474,
     "lineGap": 0,
     "unitsPerEm": 830,
     "xHeight": 439,
-    "xWidthAvg": 393,
-    "category": "sans-serif"
+    "xWidthAvg": 393
   },
-  {
+  "rancho": {
     "familyName": "Rancho",
+    "category": "handwriting",
     "capHeight": 705,
     "ascent": 919,
     "descent": -329,
     "lineGap": 24,
     "unitsPerEm": 1024,
     "xHeight": 407,
-    "xWidthAvg": 306,
-    "category": "handwriting"
+    "xWidthAvg": 306
   },
-  {
+  "ranchers": {
     "familyName": "Ranchers",
+    "category": "display",
     "capHeight": 818,
     "ascent": 1045,
     "descent": -205,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 598,
-    "xWidthAvg": 376,
-    "category": "display"
+    "xWidthAvg": 376
   },
-  {
+  "ranga": {
     "familyName": "Ranga",
+    "category": "display",
     "capHeight": 1483,
     "ascent": 2218,
     "descent": -1027,
     "lineGap": 0,
     "unitsPerEm": 2218,
     "xHeight": 1040,
-    "xWidthAvg": 659,
-    "category": "display"
+    "xWidthAvg": 659
   },
-  {
+  "rationale": {
     "familyName": "Rationale",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 903,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 360,
-    "category": "sans-serif"
+    "xWidthAvg": 360
   },
-  {
+  "rasa": {
     "familyName": "Rasa",
+    "category": "serif",
     "capHeight": 568,
     "ascent": 728,
     "descent": -272,
     "lineGap": 218,
     "unitsPerEm": 1000,
     "xHeight": 413,
-    "xWidthAvg": 394,
-    "category": "serif"
+    "xWidthAvg": 394
   },
-  {
+  "ramaraja": {
     "familyName": "Ramaraja",
+    "category": "serif",
     "capHeight": 439,
     "ascent": 741,
     "descent": -544,
     "lineGap": 0,
     "unitsPerEm": 750,
     "xHeight": 293,
-    "xWidthAvg": 273,
-    "category": "serif"
+    "xWidthAvg": 273
   },
-  {
+  "raviPrakash": {
     "familyName": "Ravi Prakash",
+    "category": "display",
     "capHeight": 552,
     "ascent": 938,
     "descent": -684,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 410,
-    "xWidthAvg": 411,
-    "category": "display"
+    "xWidthAvg": 411
   },
-  {
+  "readexPro": {
     "familyName": "Readex Pro",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 525,
-    "xWidthAvg": 481,
-    "category": "sans-serif"
+    "xWidthAvg": 481
   },
-  {
+  "redHatDisplay": {
     "familyName": "Red Hat Display",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -305,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 436,
-    "category": "sans-serif"
+    "xWidthAvg": 436
   },
-  {
+  "redHatMono": {
     "familyName": "Red Hat Mono",
+    "category": "monospace",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -305,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 481,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "recursive": {
     "familyName": "Recursive",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 532,
-    "xWidthAvg": 508,
-    "category": "sans-serif"
+    "xWidthAvg": 508
   },
-  {
+  "redHatText": {
     "familyName": "Red Hat Text",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1018,
     "descent": -305,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 481,
-    "xWidthAvg": 442,
-    "category": "sans-serif"
+    "xWidthAvg": 442
   },
-  {
+  "redRose": {
     "familyName": "Red Rose",
+    "category": "display",
     "capHeight": 600,
     "ascent": 937,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 468,
-    "xWidthAvg": 483,
-    "category": "display"
+    "xWidthAvg": 483
   },
-  {
+  "redacted": {
     "familyName": "Redacted",
+    "category": "display",
     "capHeight": 0,
     "ascent": 800,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 0,
-    "xWidthAvg": 307,
-    "category": "display"
+    "xWidthAvg": 307
   },
-  {
+  "redressed": {
     "familyName": "Redressed",
+    "category": "handwriting",
     "capHeight": 1495,
     "ascent": 1907,
     "descent": -494,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 834,
-    "xWidthAvg": 713,
-    "category": "handwriting"
+    "xWidthAvg": 713
   },
-  {
+  "redactedScript": {
     "familyName": "Redacted Script",
+    "category": "display",
     "capHeight": 702,
     "ascent": 800,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 439,
-    "xWidthAvg": 463,
-    "category": "display"
+    "xWidthAvg": 463
   },
-  {
+  "reemKufi": {
     "familyName": "Reem Kufi",
+    "category": "sans-serif",
     "capHeight": 725,
     "ascent": 1100,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 418,
-    "xWidthAvg": 425,
-    "category": "sans-serif"
+    "xWidthAvg": 425
   },
-  {
+  "reemKufiFun": {
     "familyName": "Reem Kufi Fun",
+    "category": "sans-serif",
     "capHeight": 725,
     "ascent": 1100,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 418,
-    "xWidthAvg": 425,
-    "category": "sans-serif"
+    "xWidthAvg": 425
   },
-  {
+  "revalia": {
     "familyName": "Revalia",
+    "category": "display",
     "capHeight": 879,
     "ascent": 2146,
     "descent": 382,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1140,
-    "xWidthAvg": 1324,
-    "category": "display"
+    "xWidthAvg": 1324
   },
-  {
+  "reemKufiInk": {
     "familyName": "Reem Kufi Ink",
+    "category": "sans-serif",
     "capHeight": 725,
     "ascent": 1100,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 418,
-    "xWidthAvg": 425,
-    "category": "sans-serif"
+    "xWidthAvg": 425
   },
-  {
+  "righteous": {
     "familyName": "Righteous",
+    "category": "display",
     "capHeight": 1434,
     "ascent": 2017,
     "descent": -526,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1077,
-    "xWidthAvg": 962,
-    "category": "display"
+    "xWidthAvg": 962
   },
-  {
+  "ribeyeMarrow": {
     "familyName": "Ribeye Marrow",
+    "category": "display",
     "capHeight": 1460,
     "ascent": 2130,
     "descent": -668,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1061,
-    "xWidthAvg": 1088,
-    "category": "display"
+    "xWidthAvg": 1088
   },
-  {
+  "reenieBeanie": {
     "familyName": "Reenie Beanie",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 339,
-    "category": "handwriting"
+    "xWidthAvg": 339
   },
-  {
+  "ribeye": {
     "familyName": "Ribeye",
+    "category": "display",
     "capHeight": 1491,
     "ascent": 2130,
     "descent": -668,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1061,
-    "xWidthAvg": 1088,
-    "category": "display"
+    "xWidthAvg": 1088
   },
-  {
+  "rhodiumLibre": {
     "familyName": "Rhodium Libre",
+    "category": "serif",
     "capHeight": 680,
     "ascent": 1100,
     "descent": -610,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 502,
-    "xWidthAvg": 502,
-    "category": "serif"
+    "xWidthAvg": 502
   },
-  {
+  "rampartOne": {
     "familyName": "Rampart One",
+    "category": "display",
     "capHeight": 764,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 555,
-    "xWidthAvg": 530,
-    "category": "display"
+    "xWidthAvg": 530
   },
-  {
+  "risque": {
     "familyName": "Risque",
+    "category": "display",
     "capHeight": 1413,
     "ascent": 1853,
     "descent": -514,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1016,
-    "xWidthAvg": 875,
-    "category": "display"
+    "xWidthAvg": 875
   },
-  {
+  "roadRage": {
     "familyName": "Road Rage",
+    "category": "display",
     "capHeight": 600,
     "ascent": 850,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 257,
-    "category": "display"
+    "xWidthAvg": 257
   },
-  {
+  "notoSerifHK": {
     "familyName": "Noto Serif HK",
+    "category": "serif",
     "capHeight": 729,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 489,
-    "category": "serif"
+    "xWidthAvg": 489
   },
-  {
+  "reggaeOne": {
     "familyName": "Reggae One",
+    "category": "display",
     "capHeight": 780,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 557,
-    "xWidthAvg": 535,
-    "category": "display"
+    "xWidthAvg": 535
   },
-  {
+  "robotoFlex": {
     "familyName": "Roboto Flex",
+    "category": "sans-serif",
     "capHeight": 1456,
     "ascent": 1900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1052,
-    "xWidthAvg": 899,
-    "category": "sans-serif"
+    "xWidthAvg": 899
   },
-  {
+  "robotoCondensed": {
     "familyName": "Roboto Condensed",
+    "category": "sans-serif",
     "capHeight": 1456,
     "ascent": 1900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 805,
-    "category": "sans-serif"
+    "xWidthAvg": 805
   },
-  {
+  "robotoMono": {
     "familyName": "Roboto Mono",
+    "category": "monospace",
     "capHeight": 1456,
     "ascent": 2146,
     "descent": -555,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 1229,
-    "category": "monospace"
+    "xWidthAvg": 1229
   },
-  {
+  "robotoSerif": {
     "familyName": "Roboto Serif",
+    "category": "serif",
     "capHeight": 710,
     "ascent": 927,
     "descent": -244,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 508,
-    "xWidthAvg": 513,
-    "category": "serif"
+    "xWidthAvg": 513
   },
-  {
-    "familyName": "Roboto",
-    "capHeight": 1456,
-    "ascent": 1900,
-    "descent": -500,
-    "lineGap": 0,
-    "unitsPerEm": 2048,
-    "xHeight": 1082,
-    "xWidthAvg": 905,
-    "category": "sans-serif"
-  },
-  {
+  "rochester": {
     "familyName": "Rochester",
+    "category": "handwriting",
     "capHeight": 326,
     "ascent": 2109,
     "descent": -528,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 192,
-    "xWidthAvg": 661,
-    "category": "handwriting"
+    "xWidthAvg": 661
   },
-  {
+  "robotoSlab": {
     "familyName": "Roboto Slab",
+    "category": "serif",
     "capHeight": 1456,
     "ascent": 2146,
     "descent": -555,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 969,
-    "category": "serif"
+    "xWidthAvg": 969
   },
-  {
+  "rockSalt": {
     "familyName": "Rock Salt",
+    "category": "handwriting",
     "capHeight": 1154,
     "ascent": 1623,
     "descent": -788,
     "lineGap": 32,
     "unitsPerEm": 1024,
     "xHeight": 833,
-    "xWidthAvg": 636,
-    "category": "handwriting"
+    "xWidthAvg": 636
   },
-  {
+  "rokkitt": {
     "familyName": "Rokkitt",
+    "category": "serif",
     "capHeight": 563,
     "ascent": 817,
     "descent": -320,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 393,
-    "xWidthAvg": 420,
-    "category": "serif"
+    "xWidthAvg": 420
   },
-  {
+  "romanesco": {
     "familyName": "Romanesco",
+    "category": "handwriting",
     "capHeight": 1393,
     "ascent": 1866,
     "descent": -483,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 780,
-    "xWidthAvg": 484,
-    "category": "handwriting"
+    "xWidthAvg": 484
   },
-  {
+  "ropaSans": {
     "familyName": "Ropa Sans",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 841,
     "descent": -231,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 375,
-    "category": "sans-serif"
+    "xWidthAvg": 375
   },
-  {
+  "rosario": {
     "familyName": "Rosario",
+    "category": "sans-serif",
     "capHeight": 728,
     "ascent": 977,
     "descent": -235,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 497,
-    "xWidthAvg": 418,
-    "category": "sans-serif"
+    "xWidthAvg": 418
   },
-  {
+  "rosarivo": {
     "familyName": "Rosarivo",
+    "category": "serif",
     "capHeight": 757,
     "ascent": 979,
     "descent": -424,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 170,
-    "xWidthAvg": 473,
-    "category": "serif"
+    "xWidthAvg": 473
   },
-  {
+  "rougeScript": {
     "familyName": "Rouge Script",
+    "category": "handwriting",
     "capHeight": 385,
     "ascent": 1050,
     "descent": -419,
     "lineGap": 0,
     "unitsPerEm": 1250,
     "xHeight": 534,
-    "xWidthAvg": 353,
-    "category": "handwriting"
+    "xWidthAvg": 353
   },
-  {
+  "rowdies": {
     "familyName": "Rowdies",
+    "category": "display",
     "capHeight": 708,
     "ascent": 997,
     "descent": -245,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 481,
-    "category": "display"
+    "xWidthAvg": 481
   },
-  {
+  "rocknRollOne": {
     "familyName": "RocknRoll One",
+    "category": "sans-serif",
     "capHeight": 800,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 572,
-    "xWidthAvg": 518,
-    "category": "sans-serif"
+    "xWidthAvg": 518
   },
-  {
+  "rozhaOne": {
     "familyName": "Rozha One",
+    "category": "serif",
     "capHeight": 560,
     "ascent": 998,
     "descent": -422,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 468,
-    "category": "serif"
+    "xWidthAvg": 468
   },
-  {
+  "rubikBubbles": {
     "familyName": "Rubik Bubbles",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikBeastly": {
     "familyName": "Rubik Beastly",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikBurned": {
     "familyName": "Rubik Burned",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubik": {
     "familyName": "Rubik",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 466,
-    "category": "sans-serif"
+    "xWidthAvg": 466
   },
-  {
+  "rubikMarkerHatch": {
     "familyName": "Rubik Marker Hatch",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikGlitch": {
     "familyName": "Rubik Glitch",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikIso": {
     "familyName": "Rubik Iso",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikGemstones": {
     "familyName": "Rubik Gemstones",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikDirt": {
     "familyName": "Rubik Dirt",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikMaze": {
     "familyName": "Rubik Maze",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikDistressed": {
     "familyName": "Rubik Distressed",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikMoonrocks": {
     "familyName": "Rubik Moonrocks",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikMonoOne": {
     "familyName": "Rubik Mono One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 932,
     "descent": -306,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 700,
-    "xWidthAvg": 850,
-    "category": "sans-serif"
+    "xWidthAvg": 850
   },
-  {
+  "rubikMicrobe": {
     "familyName": "Rubik Microbe",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubik80sFade": {
     "familyName": "Rubik 80s Fade",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "ruda": {
     "familyName": "Ruda",
+    "category": "sans-serif",
     "capHeight": 695,
     "ascent": 922,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 582,
-    "xWidthAvg": 462,
-    "category": "sans-serif"
+    "xWidthAvg": 462
   },
-  {
+  "rubikPuddles": {
     "familyName": "Rubik Puddles",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rufina": {
     "familyName": "Rufina",
+    "category": "serif",
     "capHeight": 668,
     "ascent": 945,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 464,
-    "category": "serif"
+    "xWidthAvg": 464
   },
-  {
+  "rubikVinyl": {
     "familyName": "Rubik Vinyl",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "ruluko": {
     "familyName": "Ruluko",
+    "category": "sans-serif",
     "capHeight": 690,
     "ascent": 914,
     "descent": -241,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 410,
-    "category": "sans-serif"
+    "xWidthAvg": 410
   },
-  {
+  "rubikStorm": {
     "familyName": "Rubik Storm",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikWetPaint": {
     "familyName": "Rubik Wet Paint",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rubikSprayPaint": {
     "familyName": "Rubik Spray Paint",
+    "category": "display",
     "capHeight": 700,
     "ascent": 935,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 523,
-    "category": "display"
+    "xWidthAvg": 523
   },
-  {
+  "rumRaisin": {
     "familyName": "Rum Raisin",
+    "category": "sans-serif",
     "capHeight": 1466,
     "ascent": 2013,
     "descent": -629,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1118,
-    "xWidthAvg": 723,
-    "category": "sans-serif"
+    "xWidthAvg": 723
   },
-  {
+  "rugeBoogie": {
     "familyName": "Ruge Boogie",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 875,
     "descent": -375,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 390,
-    "xWidthAvg": 294,
-    "category": "handwriting"
+    "xWidthAvg": 294
   },
-  {
+  "ruslanDisplay": {
     "familyName": "Ruslan Display",
+    "category": "display",
     "capHeight": 500,
     "ascent": 688,
     "descent": -397,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 621,
-    "category": "display"
+    "xWidthAvg": 621
   },
-  {
+  "russoOne": {
     "familyName": "Russo One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 926,
     "descent": -279,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 516,
-    "category": "sans-serif"
+    "xWidthAvg": 516
   },
-  {
+  "ruthie": {
     "familyName": "Ruthie",
+    "category": "handwriting",
     "capHeight": 701,
     "ascent": 800,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 315,
-    "xWidthAvg": 271,
-    "category": "handwriting"
+    "xWidthAvg": 271
   },
-  {
+  "rye": {
     "familyName": "Rye",
+    "category": "display",
     "capHeight": 363,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 387,
-    "xWidthAvg": 1071,
-    "category": "display"
+    "xWidthAvg": 1071
   },
-  {
+  "sacramento": {
     "familyName": "Sacramento",
+    "category": "handwriting",
     "capHeight": 1550,
     "ascent": 1905,
     "descent": -1084,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 627,
-    "xWidthAvg": 607,
-    "category": "handwriting"
+    "xWidthAvg": 607
   },
-  {
+  "sail": {
     "familyName": "Sail",
+    "category": "display",
     "capHeight": 666,
     "ascent": 860,
     "descent": -294,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 435,
-    "xWidthAvg": 384,
-    "category": "display"
+    "xWidthAvg": 384
   },
-  {
+  "sTIXTwoText": {
     "familyName": "STIX Two Text",
+    "category": "serif",
     "capHeight": 657,
     "ascent": 762,
     "descent": -238,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 421,
-    "category": "serif"
+    "xWidthAvg": 421
   },
-  {
+  "saira": {
     "familyName": "Saira",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 460,
-    "category": "sans-serif"
+    "xWidthAvg": 460
   },
-  {
+  "sairaCondensed": {
     "familyName": "Saira Condensed",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 353,
-    "category": "sans-serif"
+    "xWidthAvg": 353
   },
-  {
+  "sairaExtraCondensed": {
     "familyName": "Saira ExtraCondensed",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 301,
-    "category": "sans-serif"
+    "xWidthAvg": 301
   },
-  {
+  "sairaSemiCondensed": {
     "familyName": "Saira SemiCondensed",
+    "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 408,
-    "category": "sans-serif"
+    "xWidthAvg": 408
   },
-  {
+  "salsa": {
     "familyName": "Salsa",
+    "category": "display",
     "capHeight": 82,
     "ascent": 974,
     "descent": -252,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 113,
-    "xWidthAvg": 456,
-    "category": "display"
+    "xWidthAvg": 456
   },
-  {
+  "sanchez": {
     "familyName": "Sanchez",
+    "category": "serif",
     "capHeight": 718,
     "ascent": 1004,
     "descent": -274,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 492,
-    "xWidthAvg": 490,
-    "category": "serif"
+    "xWidthAvg": 490
   },
-  {
+  "sancreek": {
     "familyName": "Sancreek",
+    "category": "display",
     "capHeight": 281,
     "ascent": 2104,
     "descent": -738,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 402,
-    "xWidthAvg": 958,
-    "category": "display"
+    "xWidthAvg": 958
   },
-  {
+  "sairaStencilOne": {
     "familyName": "Saira Stencil One",
+    "category": "display",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 475,
-    "category": "display"
+    "xWidthAvg": 475
   },
-  {
+  "sansita": {
     "familyName": "Sansita",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 1020,
     "descent": -180,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 399,
-    "category": "sans-serif"
+    "xWidthAvg": 399
   },
-  {
+  "sahitya": {
     "familyName": "Sahitya",
+    "category": "serif",
     "capHeight": 637,
     "ascent": 1106,
     "descent": -447,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 452,
-    "xWidthAvg": 406,
-    "category": "serif"
+    "xWidthAvg": 406
   },
-  {
+  "sansitaSwashed": {
     "familyName": "Sansita Swashed",
+    "category": "display",
     "capHeight": 660,
     "ascent": 1020,
     "descent": -180,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 406,
-    "category": "display"
+    "xWidthAvg": 406
   },
-  {
+  "sarabun": {
     "familyName": "Sarabun",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1068,
     "descent": -232,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 433,
-    "category": "sans-serif"
+    "xWidthAvg": 433
   },
-  {
+  "sarala": {
     "familyName": "Sarala",
+    "category": "sans-serif",
     "capHeight": 1450,
     "ascent": 2398,
     "descent": -941,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1053,
-    "xWidthAvg": 930,
-    "category": "sans-serif"
+    "xWidthAvg": 930
   },
-  {
+  "satisfy": {
     "familyName": "Satisfy",
+    "category": "handwriting",
     "capHeight": 767,
     "ascent": 957,
     "descent": -501,
     "lineGap": 17,
     "unitsPerEm": 1024,
     "xHeight": 417,
-    "xWidthAvg": 386,
-    "category": "handwriting"
+    "xWidthAvg": 386
   },
-  {
+  "sassyFrass": {
     "familyName": "Sassy Frass",
+    "category": "handwriting",
     "capHeight": 550,
     "ascent": 800,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 220,
-    "xWidthAvg": 199,
-    "category": "handwriting"
+    "xWidthAvg": 199
   },
-  {
+  "sarpanch": {
     "familyName": "Sarpanch",
+    "category": "sans-serif",
     "capHeight": 622,
     "ascent": 1050,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 485,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "sarina": {
     "familyName": "Sarina",
+    "category": "display",
     "capHeight": 1530,
     "ascent": 1916,
     "descent": -644,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1022,
-    "xWidthAvg": 1246,
-    "category": "display"
+    "xWidthAvg": 1246
   },
-  {
+  "schoolbell": {
     "familyName": "Schoolbell",
+    "category": "handwriting",
     "capHeight": 770,
     "ascent": 1019,
     "descent": -383,
     "lineGap": 24,
     "unitsPerEm": 1024,
     "xHeight": 485,
-    "xWidthAvg": 420,
-    "category": "handwriting"
+    "xWidthAvg": 420
   },
-  {
+  "scopeOne": {
     "familyName": "Scope One",
+    "category": "serif",
     "capHeight": 645,
     "ascent": 928,
     "descent": -455,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 457,
-    "category": "serif"
+    "xWidthAvg": 457
   },
-  {
+  "seaweedScript": {
     "familyName": "Seaweed Script",
+    "category": "display",
     "capHeight": 765,
     "ascent": 969,
     "descent": -421,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 380,
-    "xWidthAvg": 371,
-    "category": "display"
+    "xWidthAvg": 371
   },
-  {
+  "sawarabiGothic": {
     "familyName": "Sawarabi Gothic",
+    "category": "sans-serif",
     "capHeight": 725,
     "ascent": 1110,
     "descent": -272,
     "lineGap": 90,
     "unitsPerEm": 1000,
     "xHeight": 524,
-    "xWidthAvg": 455,
-    "category": "sans-serif"
+    "xWidthAvg": 455
   },
-  {
+  "secularOne": {
     "familyName": "Secular One",
+    "category": "sans-serif",
     "capHeight": 666,
     "ascent": 1022,
     "descent": -433,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 476,
-    "category": "sans-serif"
+    "xWidthAvg": 476
   },
-  {
+  "sawarabiMincho": {
     "familyName": "Sawarabi Mincho",
+    "category": "serif",
     "capHeight": 727,
     "ascent": 1070,
     "descent": -319,
     "lineGap": 90,
     "unitsPerEm": 1000,
     "xHeight": 512,
-    "xWidthAvg": 480,
-    "category": "serif"
+    "xWidthAvg": 480
   },
-  {
+  "sedgwickAveDisplay": {
     "familyName": "Sedgwick Ave Display",
+    "category": "handwriting",
     "capHeight": 950,
     "ascent": 937,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 650,
-    "xWidthAvg": 412,
-    "category": "handwriting"
+    "xWidthAvg": 412
   },
-  {
+  "scheherazadeNew": {
     "familyName": "Scheherazade New",
+    "category": "serif",
     "capHeight": 1034,
     "ascent": 2750,
     "descent": -1427,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 684,
-    "xWidthAvg": 758,
-    "category": "serif"
+    "xWidthAvg": 758
   },
-  {
+  "scada": {
     "familyName": "Scada",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 955,
     "descent": -289,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "sen": {
     "familyName": "Sen",
+    "category": "sans-serif",
     "capHeight": 670,
     "ascent": 962,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 500,
-    "xWidthAvg": 487,
-    "category": "sans-serif"
+    "xWidthAvg": 487
   },
-  {
+  "sendFlowers": {
     "familyName": "Send Flowers",
+    "category": "handwriting",
     "capHeight": 710,
     "ascent": 975,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 395,
-    "xWidthAvg": 350,
-    "category": "handwriting"
+    "xWidthAvg": 350
   },
-  {
+  "sedgwickAve": {
     "familyName": "Sedgwick Ave",
+    "category": "handwriting",
     "capHeight": 950,
     "ascent": 937,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 660,
-    "xWidthAvg": 418,
-    "category": "handwriting"
+    "xWidthAvg": 418
   },
-  {
+  "seymourOne": {
     "familyName": "Seymour One",
+    "category": "sans-serif",
     "ascent": 2015,
     "descent": -559,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 1448,
-    "category": "sans-serif"
+    "xWidthAvg": 1448
   },
-  {
+  "sevillana": {
     "familyName": "Sevillana",
+    "category": "display",
     "capHeight": 1679,
     "ascent": 2062,
     "descent": -717,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 860,
-    "xWidthAvg": 744,
-    "category": "display"
+    "xWidthAvg": 744
   },
-  {
+  "shadowsIntoLight": {
     "familyName": "Shadows Into Light",
+    "category": "handwriting",
     "capHeight": 648,
     "ascent": 1203,
     "descent": -442,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 616,
-    "xWidthAvg": 391,
-    "category": "handwriting"
+    "xWidthAvg": 391
   },
-  {
+  "shadowsIntoLightTwo": {
     "familyName": "Shadows Into Light Two",
+    "category": "handwriting",
     "capHeight": 848,
     "ascent": 1145,
     "descent": -341,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 610,
-    "xWidthAvg": 416,
-    "category": "handwriting"
+    "xWidthAvg": 416
   },
-  {
+  "shanti": {
     "familyName": "Shanti",
+    "category": "sans-serif",
     "capHeight": 1412,
     "ascent": 2012,
     "descent": -599,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 904,
-    "category": "sans-serif"
+    "xWidthAvg": 904
   },
-  {
+  "share": {
     "familyName": "Share",
+    "category": "display",
     "capHeight": 707,
     "ascent": 885,
     "descent": -242,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 405,
-    "category": "display"
+    "xWidthAvg": 405
   },
-  {
+  "shareTech": {
     "familyName": "Share Tech",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 885,
     "descent": -242,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 400,
-    "category": "sans-serif"
+    "xWidthAvg": 400
   },
-  {
+  "shalimar": {
     "familyName": "Shalimar",
+    "category": "handwriting",
     "capHeight": 560,
     "ascent": 800,
     "descent": -420,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 315,
-    "xWidthAvg": 219,
-    "category": "handwriting"
+    "xWidthAvg": 219
   },
-  {
+  "shareTechMono": {
     "familyName": "Share Tech Mono",
+    "category": "monospace",
     "capHeight": 700,
     "ascent": 885,
     "descent": -242,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 540,
-    "category": "monospace"
+    "xWidthAvg": 540
   },
-  {
+  "shojumaru": {
     "familyName": "Shojumaru",
+    "category": "display",
     "capHeight": 1534,
     "ascent": 2020,
     "descent": -692,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1206,
-    "xWidthAvg": 1398,
-    "category": "display"
+    "xWidthAvg": 1398
   },
-  {
+  "shortStack": {
     "familyName": "Short Stack",
+    "category": "handwriting",
     "capHeight": 1367,
     "ascent": 1913,
     "descent": -609,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 758,
-    "xWidthAvg": 1192,
-    "category": "handwriting"
+    "xWidthAvg": 1192
   },
-  {
+  "sigmarOne": {
     "familyName": "Sigmar One",
+    "category": "display",
     "capHeight": 676,
     "ascent": 1172,
     "descent": -466,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 578,
-    "xWidthAvg": 619,
-    "category": "display"
+    "xWidthAvg": 619
   },
-  {
+  "siemreap": {
     "familyName": "Siemreap",
+    "category": "display",
     "capHeight": 0,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 67,
     "unitsPerEm": 2048,
     "xHeight": 0,
-    "xWidthAvg": 1360,
-    "category": "display"
+    "xWidthAvg": 1360
   },
-  {
+  "shrikhand": {
     "familyName": "Shrikhand",
+    "category": "display",
     "capHeight": 669,
     "ascent": 1026,
     "descent": -432,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 525,
-    "category": "display"
+    "xWidthAvg": 525
   },
-  {
+  "signika": {
     "familyName": "Signika",
+    "category": "sans-serif",
     "capHeight": 1370,
     "ascent": 1880,
     "descent": -584,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 981,
-    "xWidthAvg": 847,
-    "category": "sans-serif"
+    "xWidthAvg": 847
   },
-  {
+  "silkscreen": {
     "familyName": "Silkscreen",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1030,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 669,
-    "category": "display"
+    "xWidthAvg": 669
   },
-  {
+  "simonetta": {
     "familyName": "Simonetta",
+    "category": "display",
     "capHeight": 1391,
     "ascent": 1970,
     "descent": -594,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 897,
-    "xWidthAvg": 819,
-    "category": "display"
+    "xWidthAvg": 819
   },
-  {
+  "sintony": {
     "familyName": "Sintony",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 995,
     "descent": -308,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 572,
-    "xWidthAvg": 492,
-    "category": "sans-serif"
+    "xWidthAvg": 492
   },
-  {
+  "signikaNegative": {
     "familyName": "Signika Negative",
+    "category": "sans-serif",
     "capHeight": 1370,
     "ascent": 1880,
     "descent": -584,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 980,
-    "xWidthAvg": 846,
-    "category": "sans-serif"
+    "xWidthAvg": 846
   },
-  {
+  "sixCaps": {
     "familyName": "Six Caps",
+    "category": "sans-serif",
     "ascent": 2263,
     "descent": -432,
     "lineGap": 0,
     "unitsPerEm": 2048,
-    "xWidthAvg": 409,
-    "category": "sans-serif"
+    "xWidthAvg": 409
   },
-  {
+  "singleDay": {
     "familyName": "Single Day",
+    "category": "display",
     "capHeight": 582,
     "ascent": 779,
     "descent": -245,
     "lineGap": 256,
     "unitsPerEm": 1024,
     "xHeight": 390,
-    "xWidthAvg": 395,
-    "category": "display"
+    "xWidthAvg": 395
   },
-  {
+  "sirinStencil": {
     "familyName": "SirinStencil",
+    "category": "display",
     "capHeight": 1423,
     "ascent": 2380,
     "descent": -604,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1055,
-    "xWidthAvg": 830,
-    "category": "display"
+    "xWidthAvg": 830
   },
-  {
+  "smokum": {
     "familyName": "Smokum",
+    "category": "display",
     "capHeight": 1536,
     "ascent": 1986,
     "descent": -512,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1024,
-    "xWidthAvg": 689,
-    "category": "display"
+    "xWidthAvg": 689
   },
-  {
+  "slabo27px": {
     "familyName": "Slabo 27px",
+    "category": "serif",
     "capHeight": 540,
     "ascent": 750,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 810,
     "xHeight": 390,
-    "xWidthAvg": 317,
-    "category": "serif"
+    "xWidthAvg": 317
   },
-  {
+  "slackey": {
     "familyName": "Slackey",
+    "category": "display",
     "capHeight": 772,
     "ascent": 1078,
     "descent": -351,
     "lineGap": 28,
     "unitsPerEm": 1024,
     "xHeight": 691,
-    "xWidthAvg": 634,
-    "category": "display"
+    "xWidthAvg": 634
   },
-  {
+  "smythe": {
     "familyName": "Smythe",
+    "category": "display",
     "capHeight": 1317,
     "ascent": 1883,
     "descent": -480,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 963,
-    "xWidthAvg": 622,
-    "category": "display"
+    "xWidthAvg": 622
   },
-  {
+  "sniglet": {
     "familyName": "Sniglet",
+    "category": "display",
     "capHeight": 700,
     "ascent": 956,
     "descent": -289,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 439,
-    "category": "display"
+    "xWidthAvg": 439
   },
-  {
+  "smoochSans": {
     "familyName": "Smooch Sans",
+    "category": "sans-serif",
     "capHeight": 620,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 312,
-    "category": "sans-serif"
+    "xWidthAvg": 312
   },
-  {
+  "skranji": {
     "familyName": "Skranji",
+    "category": "display",
     "capHeight": 0,
     "ascent": 1008,
     "descent": -383,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 0,
-    "xWidthAvg": 469,
-    "category": "display"
+    "xWidthAvg": 469
   },
-  {
+  "snippet": {
     "familyName": "Snippet",
+    "category": "sans-serif",
     "capHeight": 684,
     "ascent": 890,
     "descent": -261,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "slabo13px": {
     "familyName": "Slabo 13px",
+    "category": "serif",
     "capHeight": 540,
     "ascent": 720,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 780,
     "xHeight": 420,
-    "xWidthAvg": 369,
-    "category": "serif"
+    "xWidthAvg": 369
   },
-  {
+  "snowburstOne": {
     "familyName": "Snowburst One",
+    "category": "display",
     "capHeight": 1635,
     "ascent": 2134,
     "descent": -454,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1347,
-    "xWidthAvg": 1160,
-    "category": "display"
+    "xWidthAvg": 1160
   },
-  {
+  "sofiaSans": {
     "familyName": "Sofia Sans",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 428,
-    "category": "sans-serif"
+    "xWidthAvg": 428
   },
-  {
+  "sofia": {
     "familyName": "Sofia",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1138,
     "descent": -438,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 441,
-    "xWidthAvg": 431,
-    "category": "handwriting"
+    "xWidthAvg": 431
   },
-  {
+  "smooch": {
     "familyName": "Smooch",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 950,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 375,
-    "xWidthAvg": 335,
-    "category": "handwriting"
+    "xWidthAvg": 335
   },
-  {
+  "sofiaSansCondensed": {
     "familyName": "Sofia Sans Condensed",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 487,
-    "xWidthAvg": 332,
-    "category": "sans-serif"
+    "xWidthAvg": 332
   },
-  {
+  "sofiaSansExtraCondensed": {
     "familyName": "Sofia Sans Extra Condensed",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 271,
-    "category": "sans-serif"
+    "xWidthAvg": 271
   },
-  {
+  "sofadiOne": {
     "familyName": "Sofadi One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 856,
     "descent": -310,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 492,
-    "category": "display"
+    "xWidthAvg": 492
   },
-  {
+  "solitreo": {
     "familyName": "Solitreo",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 880,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 490,
-    "xWidthAvg": 420,
-    "category": "handwriting"
+    "xWidthAvg": 420
   },
-  {
+  "sofiaSansSemiCondensed": {
     "familyName": "Sofia Sans Semi Condensed",
+    "category": "sans-serif",
     "capHeight": 655,
     "ascent": 900,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 487,
-    "xWidthAvg": 407,
-    "category": "sans-serif"
+    "xWidthAvg": 407
   },
-  {
+  "sonoMonospace": {
     "familyName": "Sono Monospace",
+    "category": "sans-serif",
     "capHeight": 1238,
     "ascent": 1824,
     "descent": -576,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 952,
-    "xWidthAvg": 1238,
-    "category": "sans-serif"
+    "xWidthAvg": 1238
   },
-  {
+  "solway": {
     "familyName": "Solway",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 488,
-    "category": "serif"
+    "xWidthAvg": 488
   },
-  {
+  "sonsieOne": {
     "familyName": "Sonsie One",
+    "category": "display",
     "capHeight": 506,
     "ascent": 2050,
     "descent": -600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 272,
-    "xWidthAvg": 1466,
-    "category": "display"
+    "xWidthAvg": 1466
   },
-  {
+  "sora": {
     "familyName": "Sora",
+    "category": "sans-serif",
     "capHeight": 730,
     "ascent": 970,
     "descent": -290,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 502,
-    "category": "sans-serif"
+    "xWidthAvg": 502
   },
-  {
+  "sortsMillGoudy": {
     "familyName": "Sorts Mill Goudy",
+    "category": "serif",
     "capHeight": 713,
     "ascent": 960,
     "descent": -478,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 442,
-    "xWidthAvg": 424,
-    "category": "serif"
+    "xWidthAvg": 424
   },
-  {
+  "songMyung": {
     "familyName": "Song Myung",
+    "category": "serif",
     "capHeight": 635,
     "ascent": 848,
     "descent": -152,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 457,
-    "xWidthAvg": 439,
-    "category": "serif"
+    "xWidthAvg": 439
   },
-  {
+  "sourceSans3": {
     "familyName": "Source Sans 3",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 1024,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 416,
-    "category": "sans-serif"
+    "xWidthAvg": 416
   },
-  {
+  "sourceSansPro": {
     "familyName": "Source Sans Pro",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 984,
     "descent": -273,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 416,
-    "category": "sans-serif"
+    "xWidthAvg": 416
   },
-  {
+  "sourceSerifPro": {
     "familyName": "Source Serif Pro",
+    "category": "serif",
     "capHeight": 670,
     "ascent": 918,
     "descent": -335,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 446,
-    "category": "serif"
+    "xWidthAvg": 446
   },
-  {
+  "sourceCodePro": {
     "familyName": "Source Code Pro",
+    "category": "monospace",
     "capHeight": 660,
     "ascent": 984,
     "descent": -273,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 600,
-    "category": "monospace"
+    "xWidthAvg": 600
   },
-  {
+  "spaceGrotesk": {
     "familyName": "Space Grotesk",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 984,
     "descent": -292,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 486,
-    "xWidthAvg": 489,
-    "category": "sans-serif"
+    "xWidthAvg": 489
   },
-  {
+  "spaceMono": {
     "familyName": "Space Mono",
+    "category": "monospace",
     "capHeight": 700,
     "ascent": 1120,
     "descent": -361,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 496,
-    "xWidthAvg": 612,
-    "category": "monospace"
+    "xWidthAvg": 612
   },
-  {
+  "specialElite": {
     "familyName": "Special Elite",
+    "category": "display",
     "capHeight": 713,
     "ascent": 1440,
     "descent": -608,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 528,
-    "xWidthAvg": 1068,
-    "category": "display"
+    "xWidthAvg": 1068
   },
-  {
+  "spectralSC": {
     "familyName": "Spectral SC",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 1059,
     "descent": -463,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 560,
-    "category": "serif"
+    "xWidthAvg": 560
   },
-  {
+  "sourceSerif4": {
     "familyName": "Source Serif 4",
+    "category": "serif",
     "capHeight": 670,
     "ascent": 1036,
     "descent": -335,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 476,
-    "category": "serif"
+    "xWidthAvg": 476
   },
-  {
+  "spectral": {
     "familyName": "Spectral",
+    "category": "serif",
     "capHeight": 660,
     "ascent": 1059,
     "descent": -463,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 450,
-    "xWidthAvg": 441,
-    "category": "serif"
+    "xWidthAvg": 441
   },
-  {
+  "spicyRice": {
     "familyName": "Spicy Rice",
+    "category": "display",
     "capHeight": 1481,
     "ascent": 2091,
     "descent": -733,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1208,
-    "xWidthAvg": 854,
-    "category": "display"
+    "xWidthAvg": 854
   },
-  {
+  "spinnaker": {
     "familyName": "Spinnaker",
+    "category": "sans-serif",
     "capHeight": 1416,
     "ascent": 1920,
     "descent": -487,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1000,
-    "xWidthAvg": 986,
-    "category": "sans-serif"
+    "xWidthAvg": 986
   },
-  {
+  "spirax": {
     "familyName": "Spirax",
+    "category": "display",
     "capHeight": 696,
     "ascent": 947,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 463,
-    "xWidthAvg": 420,
-    "category": "display"
+    "xWidthAvg": 420
   },
-  {
+  "splineSansMono": {
     "familyName": "Spline Sans Mono",
+    "category": "monospace",
     "capHeight": 1454,
     "ascent": 1927,
     "descent": -473,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1091,
-    "xWidthAvg": 1200,
-    "category": "monospace"
+    "xWidthAvg": 1200
   },
-  {
+  "splineSans": {
     "familyName": "Spline Sans",
+    "category": "sans-serif",
     "capHeight": 1454,
     "ascent": 1927,
     "descent": -473,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1091,
-    "xWidthAvg": 898,
-    "category": "sans-serif"
+    "xWidthAvg": 898
   },
-  {
+  "squadaOne": {
     "familyName": "Squada One",
+    "category": "display",
     "capHeight": 647,
     "ascent": 861,
     "descent": -196,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 369,
-    "category": "display"
+    "xWidthAvg": 369
   },
-  {
+  "squarePeg": {
     "familyName": "Square Peg",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 920,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 260,
-    "xWidthAvg": 252,
-    "category": "handwriting"
+    "xWidthAvg": 252
   },
-  {
+  "splash": {
     "familyName": "Splash",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1050,
     "descent": -580,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 440,
-    "xWidthAvg": 376,
-    "category": "handwriting"
+    "xWidthAvg": 376
   },
-  {
+  "srisakdi": {
     "familyName": "Srisakdi",
+    "category": "display",
     "capHeight": 700,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 403,
-    "category": "display"
+    "xWidthAvg": 403
   },
-  {
+  "sreeKrushnadevaraya": {
     "familyName": "Sree Krushnadevaraya",
+    "category": "serif",
     "capHeight": 408,
     "ascent": 1105,
     "descent": -378,
     "lineGap": 0,
     "unitsPerEm": 720,
     "xHeight": 273,
-    "xWidthAvg": 282,
-    "category": "serif"
+    "xWidthAvg": 282
   },
-  {
+  "sriracha": {
     "familyName": "Sriracha",
+    "category": "handwriting",
     "capHeight": 656,
     "ascent": 1220,
     "descent": -550,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 474,
-    "xWidthAvg": 442,
-    "category": "handwriting"
+    "xWidthAvg": 442
   },
-  {
+  "staatliches": {
     "familyName": "Staatliches",
+    "category": "display",
     "capHeight": 696,
     "ascent": 950,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 380,
-    "category": "display"
+    "xWidthAvg": 380
   },
-  {
+  "stalemate": {
     "familyName": "Stalemate",
+    "category": "handwriting",
     "capHeight": 1501,
     "ascent": 1837,
     "descent": -1165,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 539,
-    "xWidthAvg": 423,
-    "category": "handwriting"
+    "xWidthAvg": 423
   },
-  {
+  "stalinistOne": {
     "familyName": "Stalinist One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1037,
     "descent": -439,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 530,
-    "xWidthAvg": 884,
-    "category": "display"
+    "xWidthAvg": 884
   },
-  {
+  "stardosStencil": {
     "familyName": "Stardos Stencil",
+    "category": "display",
     "capHeight": 1421,
     "ascent": 1994,
     "descent": -831,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 981,
-    "xWidthAvg": 899,
-    "category": "display"
+    "xWidthAvg": 899
   },
-  {
+  "stickNoBills": {
     "familyName": "Stick No Bills",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 940,
     "descent": -312,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 375,
-    "category": "sans-serif"
+    "xWidthAvg": 375
   },
-  {
+  "stintUltraCondensed": {
     "familyName": "Stint Ultra Condensed",
+    "category": "display",
     "capHeight": 1374,
     "ascent": 1829,
     "descent": -483,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 952,
-    "xWidthAvg": 507,
-    "category": "display"
+    "xWidthAvg": 507
   },
-  {
+  "stintUltraExpanded": {
     "familyName": "Stint Ultra Expanded",
+    "category": "display",
     "capHeight": 1374,
     "ascent": 1853,
     "descent": -483,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 952,
-    "xWidthAvg": 1210,
-    "category": "display"
+    "xWidthAvg": 1210
   },
-  {
+  "strait": {
     "familyName": "Strait",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 901,
     "descent": -194,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 413,
-    "category": "sans-serif"
+    "xWidthAvg": 413
   },
-  {
+  "stoke": {
     "familyName": "Stoke",
+    "category": "serif",
     "capHeight": 683,
     "ascent": 2030,
     "descent": -530,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 479,
-    "xWidthAvg": 1160,
-    "category": "serif"
+    "xWidthAvg": 1160
   },
-  {
+  "sueEllenFrancisco": {
     "familyName": "Sue Ellen Francisco ",
+    "category": "handwriting",
     "capHeight": 1085,
     "ascent": 1362,
     "descent": -634,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 439,
-    "xWidthAvg": 281,
-    "category": "handwriting"
+    "xWidthAvg": 281
   },
-  {
+  "styleScript": {
     "familyName": "Style Script",
+    "category": "handwriting",
     "capHeight": 700,
     "ascent": 1000,
     "descent": -520,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 434,
-    "xWidthAvg": 280,
-    "category": "handwriting"
+    "xWidthAvg": 280
   },
-  {
+  "suezOne": {
     "familyName": "Suez One",
+    "category": "serif",
     "capHeight": 674,
     "ascent": 987,
     "descent": -319,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 523,
-    "xWidthAvg": 471,
-    "category": "serif"
+    "xWidthAvg": 471
   },
-  {
+  "sulphurPoint": {
     "familyName": "Sulphur Point",
+    "category": "sans-serif",
     "capHeight": 665,
     "ascent": 790,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 475,
-    "category": "sans-serif"
+    "xWidthAvg": 475
   },
-  {
+  "sumana": {
     "familyName": "Sumana",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1922,
     "descent": -1005,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 438,
-    "category": "serif"
+    "xWidthAvg": 438
   },
-  {
+  "supermercado": {
     "familyName": "Supermercado",
+    "category": "display",
     "capHeight": 1359,
     "ascent": 1925,
     "descent": -527,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1066,
-    "xWidthAvg": 894,
-    "category": "display"
+    "xWidthAvg": 894
   },
-  {
+  "sunshiney": {
     "familyName": "Sunshiney",
+    "category": "handwriting",
     "capHeight": 759,
     "ascent": 1019,
     "descent": -306,
     "lineGap": 27,
     "unitsPerEm": 1024,
     "xHeight": 391,
-    "xWidthAvg": 347,
-    "category": "handwriting"
+    "xWidthAvg": 347
   },
-  {
+  "sunflowerLight": {
     "familyName": "Sunflower Light",
+    "category": "sans-serif",
     "capHeight": 692,
     "ascent": 782,
     "descent": -218,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "shipporiMincho": {
     "familyName": "Shippori Mincho",
+    "category": "serif",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 473,
-    "category": "serif"
+    "xWidthAvg": 473
   },
-  {
+  "stick": {
     "familyName": "Stick",
+    "category": "sans-serif",
     "capHeight": 715,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 460,
-    "category": "sans-serif"
+    "xWidthAvg": 460
   },
-  {
+  "sura": {
     "familyName": "Sura",
+    "category": "serif",
     "capHeight": 1464,
     "ascent": 2359,
     "descent": -872,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1022,
-    "xWidthAvg": 896,
-    "category": "serif"
+    "xWidthAvg": 896
   },
-  {
+  "suwannaphum": {
     "familyName": "Suwannaphum",
+    "category": "serif",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 1004,
-    "category": "serif"
+    "xWidthAvg": 1004
   },
-  {
+  "suranna": {
     "familyName": "Suranna",
+    "category": "serif",
     "capHeight": 492,
     "ascent": 1101,
     "descent": -607,
     "lineGap": 0,
     "unitsPerEm": 780,
     "xHeight": 319,
-    "xWidthAvg": 291,
-    "category": "serif"
+    "xWidthAvg": 291
   },
-  {
+  "suravaram": {
     "familyName": "Suravaram",
+    "category": "serif",
     "capHeight": 482,
     "ascent": 1295,
     "descent": -794,
     "lineGap": 0,
     "unitsPerEm": 980,
     "xHeight": 344,
-    "xWidthAvg": 348,
-    "category": "serif"
+    "xWidthAvg": 348
   },
-  {
+  "swankyAndMooMoo": {
     "familyName": "Swanky and Moo Moo",
+    "category": "handwriting",
     "capHeight": 424,
     "ascent": 995,
     "descent": -507,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 341,
-    "xWidthAvg": 429,
-    "category": "handwriting"
+    "xWidthAvg": 429
   },
-  {
+  "syncopate": {
     "familyName": "Syncopate",
+    "category": "sans-serif",
     "capHeight": 1374,
     "ascent": 1556,
     "descent": -426,
     "lineGap": 150,
     "unitsPerEm": 2048,
     "xHeight": 958,
-    "xWidthAvg": 1533,
-    "category": "sans-serif"
+    "xWidthAvg": 1533
   },
-  {
+  "syne": {
     "familyName": "Syne",
+    "category": "sans-serif",
     "capHeight": 650,
     "ascent": 925,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 437,
-    "category": "sans-serif"
+    "xWidthAvg": 437
   },
-  {
+  "shipporiAntique": {
     "familyName": "Shippori Antique",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 524,
-    "xWidthAvg": 480,
-    "category": "sans-serif"
+    "xWidthAvg": 480
   },
-  {
+  "syneMono": {
     "familyName": "Syne Mono",
+    "category": "monospace",
     "capHeight": 650,
     "ascent": 925,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 550,
-    "category": "monospace"
+    "xWidthAvg": 550
   },
-  {
+  "syneTactile": {
     "familyName": "Syne Tactile",
+    "category": "display",
     "capHeight": 650,
     "ascent": 925,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 396,
-    "category": "display"
+    "xWidthAvg": 396
   },
-  {
+  "taiHeritagePro": {
     "familyName": "Tai Heritage Pro",
+    "category": "serif",
     "capHeight": 1700,
     "ascent": 2700,
     "descent": -1600,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1150,
-    "xWidthAvg": 835,
-    "category": "serif"
+    "xWidthAvg": 835
   },
-  {
+  "tajawal": {
     "familyName": "Tajawal",
+    "category": "sans-serif",
     "capHeight": 633,
     "ascent": 643,
     "descent": -357,
     "lineGap": 200,
     "unitsPerEm": 1000,
     "xHeight": 454,
-    "xWidthAvg": 421,
-    "category": "sans-serif"
+    "xWidthAvg": 421
   },
-  {
+  "tangerine": {
     "familyName": "Tangerine",
+    "category": "handwriting",
     "capHeight": 644,
     "ascent": 750,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 255,
-    "xWidthAvg": 217,
-    "category": "handwriting"
+    "xWidthAvg": 217
   },
-  {
+  "taprom": {
     "familyName": "Taprom",
+    "category": "display",
     "capHeight": 1462,
     "ascent": 2500,
     "descent": -1200,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1098,
-    "xWidthAvg": 754,
-    "category": "display"
+    "xWidthAvg": 754
   },
-  {
+  "tauri": {
     "familyName": "Tauri",
+    "category": "sans-serif",
     "capHeight": 1571,
     "ascent": 2040,
     "descent": -520,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1135,
-    "xWidthAvg": 972,
-    "category": "sans-serif"
+    "xWidthAvg": 972
   },
-  {
+  "tapestry": {
     "familyName": "Tapestry",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 950,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 454,
-    "xWidthAvg": 427,
-    "category": "handwriting"
+    "xWidthAvg": 427
   },
-  {
+  "telex": {
     "familyName": "Telex",
+    "category": "sans-serif",
     "capHeight": 708,
     "ascent": 945,
     "descent": -260,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 514,
-    "xWidthAvg": 463,
-    "category": "sans-serif"
+    "xWidthAvg": 463
   },
-  {
+  "taviraj": {
     "familyName": "Taviraj",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1172,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 463,
-    "category": "serif"
+    "xWidthAvg": 463
   },
-  {
+  "teko": {
     "familyName": "Teko",
+    "category": "sans-serif",
     "capHeight": 626,
     "ascent": 958,
     "descent": -475,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 488,
-    "xWidthAvg": 291,
-    "category": "sans-serif"
+    "xWidthAvg": 291
   },
-  {
+  "textMeOne": {
     "familyName": "Text Me One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 952,
     "descent": -269,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 502,
-    "xWidthAvg": 453,
-    "category": "sans-serif"
+    "xWidthAvg": 453
   },
-  {
+  "tenaliRamakrishna": {
     "familyName": "Tenali Ramakrishna",
+    "category": "sans-serif",
     "capHeight": 367,
     "ascent": 661,
     "descent": -512,
     "lineGap": 0,
     "unitsPerEm": 750,
     "xHeight": 268,
-    "xWidthAvg": 264,
-    "category": "sans-serif"
+    "xWidthAvg": 264
   },
-  {
+  "tenorSans": {
     "familyName": "Tenor Sans",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 920,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 485,
-    "category": "sans-serif"
+    "xWidthAvg": 485
   },
-  {
+  "texturina12pt": {
     "familyName": "Texturina 12pt",
+    "category": "serif",
     "capHeight": 704,
     "ascent": 1260,
     "descent": -300,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 445,
-    "category": "serif"
+    "xWidthAvg": 445
   },
-  {
+  "thasadith": {
     "familyName": "Thasadith",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1005,
     "descent": -295,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 391,
-    "category": "sans-serif"
+    "xWidthAvg": 391
   },
-  {
+  "theNautigal": {
     "familyName": "The Nautigal",
+    "category": "handwriting",
     "capHeight": 600,
     "ascent": 870,
     "descent": -330,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 265,
-    "xWidthAvg": 230,
-    "category": "handwriting"
+    "xWidthAvg": 230
   },
-  {
+  "theGirlNextDoor": {
     "familyName": "The Girl Next Door",
+    "category": "handwriting",
     "capHeight": 627,
     "ascent": 1139,
     "descent": -748,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 519,
-    "xWidthAvg": 488,
-    "category": "handwriting"
+    "xWidthAvg": 488
   },
-  {
+  "tienne": {
     "familyName": "Tienne",
+    "category": "serif",
     "capHeight": 1437,
     "ascent": 2030,
     "descent": -724,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 363,
-    "xWidthAvg": 1041,
-    "category": "serif"
+    "xWidthAvg": 1041
   },
-  {
+  "tillana": {
     "familyName": "Tillana",
+    "category": "handwriting",
     "capHeight": 732,
     "ascent": 1158,
     "descent": -484,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 546,
-    "xWidthAvg": 446,
-    "category": "handwriting"
+    "xWidthAvg": 446
   },
-  {
+  "timmana": {
     "familyName": "Timmana",
+    "category": "sans-serif",
     "capHeight": 454,
     "ascent": 668,
     "descent": -554,
     "lineGap": 0,
     "unitsPerEm": 750,
     "xHeight": 354,
-    "xWidthAvg": 303,
-    "category": "sans-serif"
+    "xWidthAvg": 303
   },
-  {
+  "tinos": {
     "familyName": "Tinos",
+    "category": "serif",
     "capHeight": 1341,
     "ascent": 1825,
     "descent": -443,
     "lineGap": 87,
     "unitsPerEm": 2048,
     "xHeight": 940,
-    "xWidthAvg": 819,
-    "category": "serif"
+    "xWidthAvg": 819
   },
-  {
+  "tiroDevanagariMarathi": {
     "familyName": "Tiro Devanagari Marathi",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 330,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroDevanagariHindi": {
     "familyName": "Tiro Devanagari Hindi",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 330,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroBangla": {
     "familyName": "Tiro Bangla",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 330,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroGurmukhi": {
     "familyName": "Tiro Gurmukhi",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroDevanagariSanskrit": {
     "familyName": "Tiro Devanagari Sanskrit",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 330,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroKannada": {
     "familyName": "Tiro Kannada",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 794,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tiroTamil": {
     "familyName": "Tiro Tamil",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 436,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "titanOne": {
     "familyName": "Titan One",
+    "category": "display",
     "capHeight": 710,
     "ascent": 970,
     "descent": -175,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 580,
-    "xWidthAvg": 543,
-    "category": "display"
+    "xWidthAvg": 543
   },
-  {
+  "titilliumWeb": {
     "familyName": "Titillium Web",
+    "category": "sans-serif",
     "capHeight": 692,
     "ascent": 1133,
     "descent": -388,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 419,
-    "category": "sans-serif"
+    "xWidthAvg": 419
   },
-  {
+  "tiroTelugu": {
     "familyName": "Tiro Telugu",
+    "category": "serif",
     "capHeight": 699,
     "ascent": 755,
     "descent": -245,
     "lineGap": 794,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 451,
-    "category": "serif"
+    "xWidthAvg": 451
   },
-  {
+  "tomorrow": {
     "familyName": "Tomorrow",
+    "category": "sans-serif",
     "capHeight": 737,
     "ascent": 1000,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 523,
-    "xWidthAvg": 474,
-    "category": "sans-serif"
+    "xWidthAvg": 474
   },
-  {
+  "tourney": {
     "familyName": "Tourney",
+    "category": "display",
     "capHeight": 1400,
     "ascent": 1800,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1080,
-    "xWidthAvg": 1062,
-    "category": "display"
+    "xWidthAvg": 1062
   },
-  {
+  "tradeWinds": {
     "familyName": "Trade Winds",
+    "category": "display",
     "capHeight": 814,
     "ascent": 1019,
     "descent": -469,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 576,
-    "xWidthAvg": 520,
-    "category": "display"
+    "xWidthAvg": 520
   },
-  {
+  "stylish": {
     "familyName": "Stylish",
+    "category": "sans-serif",
     "capHeight": 600,
     "ascent": 821,
     "descent": -179,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 410,
-    "xWidthAvg": 393,
-    "category": "sans-serif"
+    "xWidthAvg": 393
   },
-  {
+  "trocchi": {
     "familyName": "Trocchi",
+    "category": "serif",
     "capHeight": 1,
     "ascent": 2085,
     "descent": -576,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1,
-    "xWidthAvg": 1014,
-    "category": "serif"
+    "xWidthAvg": 1014
   },
-  {
+  "trispace": {
     "familyName": "Trispace",
+    "category": "sans-serif",
     "capHeight": 1400,
     "ascent": 1830,
     "descent": -430,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1000,
-    "xWidthAvg": 1228,
-    "category": "sans-serif"
+    "xWidthAvg": 1228
   },
-  {
+  "trirong": {
     "familyName": "Trirong",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 1200,
     "descent": -534,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 498,
-    "xWidthAvg": 477,
-    "category": "serif"
+    "xWidthAvg": 477
   },
-  {
+  "trochut": {
     "familyName": "Trochut",
+    "category": "display",
     "capHeight": 690,
     "ascent": 967,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 347,
-    "category": "display"
+    "xWidthAvg": 347
   },
-  {
+  "trykker": {
     "familyName": "Trykker",
+    "category": "serif",
     "capHeight": 1492,
     "ascent": 2022,
     "descent": -538,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1013,
-    "xWidthAvg": 994,
-    "category": "serif"
+    "xWidthAvg": 994
   },
-  {
+  "truculenta": {
     "familyName": "Truculenta",
+    "category": "sans-serif",
     "capHeight": 693,
     "ascent": 1050,
     "descent": -340,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 366,
-    "category": "sans-serif"
+    "xWidthAvg": 366
   },
-  {
+  "trainOne": {
     "familyName": "Train One",
+    "category": "display",
     "capHeight": 780,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 557,
-    "xWidthAvg": 535,
-    "category": "display"
+    "xWidthAvg": 535
   },
-  {
+  "tulpenOne": {
     "familyName": "Tulpen One",
+    "category": "display",
     "capHeight": 1393,
     "ascent": 1767,
     "descent": -465,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1018,
-    "xWidthAvg": 397,
-    "category": "display"
+    "xWidthAvg": 397
   },
-  {
+  "turretRoad": {
     "familyName": "Turret Road",
+    "category": "display",
     "capHeight": 700,
     "ascent": 850,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 478,
-    "xWidthAvg": 477,
-    "category": "display"
+    "xWidthAvg": 477
   },
-  {
+  "ubuntu": {
     "familyName": "Ubuntu",
+    "category": "sans-serif",
     "capHeight": 693,
     "ascent": 932,
     "descent": -189,
     "lineGap": 28,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 453,
-    "category": "sans-serif"
+    "xWidthAvg": 453
   },
-  {
+  "twinkleStar": {
     "familyName": "Twinkle Star",
+    "category": "handwriting",
     "capHeight": 705,
     "ascent": 930,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 409,
-    "category": "handwriting"
+    "xWidthAvg": 409
   },
-  {
+  "ubuntuMono": {
     "familyName": "Ubuntu Mono",
+    "category": "monospace",
     "capHeight": 693,
     "ascent": 830,
     "descent": -170,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 500,
-    "category": "monospace"
+    "xWidthAvg": 500
   },
-  {
+  "ubuntuCondensed": {
     "familyName": "Ubuntu Condensed",
+    "category": "sans-serif",
     "capHeight": 693,
     "ascent": 932,
     "descent": -189,
     "lineGap": 28,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 368,
-    "category": "sans-serif"
+    "xWidthAvg": 368
   },
-  {
+  "uchen": {
     "familyName": "Uchen",
+    "category": "serif",
     "capHeight": 744,
     "ascent": 1248,
     "descent": -660,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 485,
-    "xWidthAvg": 507,
-    "category": "serif"
+    "xWidthAvg": 507
   },
-  {
+  "ultra": {
     "familyName": "Ultra",
+    "category": "serif",
     "capHeight": 1473,
     "ascent": 2066,
     "descent": -561,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1102,
-    "xWidthAvg": 1291,
-    "category": "serif"
+    "xWidthAvg": 1291
   },
-  {
+  "unbounded": {
     "familyName": "Unbounded",
+    "category": "display",
     "capHeight": 750,
     "ascent": 995,
     "descent": -245,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 566,
-    "xWidthAvg": 598,
-    "category": "display"
+    "xWidthAvg": 598
   },
-  {
+  "uncialAntiqua": {
     "familyName": "Uncial Antiqua",
+    "category": "display",
     "capHeight": 1841,
     "ascent": 2019,
     "descent": -676,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1079,
-    "xWidthAvg": 1163,
-    "category": "display"
+    "xWidthAvg": 1163
   },
-  {
+  "underdog": {
     "familyName": "Underdog",
+    "category": "display",
     "capHeight": 710,
     "ascent": 909,
     "descent": -247,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 459,
-    "category": "display"
+    "xWidthAvg": 459
   },
-  {
+  "unicaOne": {
     "familyName": "Unica One",
+    "category": "display",
     "capHeight": 650,
     "ascent": 917,
     "descent": -265,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 650,
-    "xWidthAvg": 431,
-    "category": "display"
+    "xWidthAvg": 431
   },
-  {
+  "unifrakturCook": {
     "familyName": "UnifrakturCook",
+    "category": "display",
     "capHeight": 485,
     "ascent": 2110,
     "descent": -570,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 319,
-    "xWidthAvg": 761,
-    "category": "display"
+    "xWidthAvg": 761
   },
-  {
+  "unifrakturMaguntia": {
     "familyName": "UnifrakturMaguntia",
+    "category": "display",
     "capHeight": 1409,
     "ascent": 1607,
     "descent": -513,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1095,
-    "xWidthAvg": 790,
-    "category": "display"
+    "xWidthAvg": 790
   },
-  {
+  "unlock": {
     "familyName": "Unlock",
+    "category": "display",
     "capHeight": 635,
     "ascent": 873,
     "descent": -195,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 550,
-    "xWidthAvg": 515,
-    "category": "display"
+    "xWidthAvg": 515
   },
-  {
+  "unkempt": {
     "familyName": "Unkempt",
+    "category": "display",
     "capHeight": 753,
     "ascent": 977,
     "descent": -246,
     "lineGap": 28,
     "unitsPerEm": 1024,
     "xHeight": 482,
-    "xWidthAvg": 435,
-    "category": "display"
+    "xWidthAvg": 435
   },
-  {
+  "unna": {
     "familyName": "Unna",
+    "category": "serif",
     "capHeight": 597,
     "ascent": 883,
     "descent": -269,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 420,
-    "xWidthAvg": 398,
-    "category": "serif"
+    "xWidthAvg": 398
   },
-  {
+  "updock": {
     "familyName": "Updock",
+    "category": "handwriting",
     "capHeight": 630,
     "ascent": 900,
     "descent": -350,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 350,
-    "xWidthAvg": 249,
-    "category": "handwriting"
+    "xWidthAvg": 249
   },
-  {
+  "vampiroOne": {
     "familyName": "Vampiro One",
+    "category": "display",
     "capHeight": 705,
     "ascent": 956,
     "descent": -294,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 534,
-    "xWidthAvg": 532,
-    "category": "display"
+    "xWidthAvg": 532
   },
-  {
+  "urbanist": {
     "familyName": "Urbanist",
+    "category": "sans-serif",
     "capHeight": 1400,
     "ascent": 1900,
     "descent": -500,
     "lineGap": 0,
     "unitsPerEm": 2000,
     "xHeight": 1000,
-    "xWidthAvg": 882,
-    "category": "sans-serif"
+    "xWidthAvg": 882
   },
-  {
+  "vT323": {
     "familyName": "VT323",
+    "category": "monospace",
     "capHeight": 560,
     "ascent": 800,
     "descent": -200,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 400,
-    "xWidthAvg": 400,
-    "category": "monospace"
+    "xWidthAvg": 400
   },
-  {
+  "varela": {
     "familyName": "Varela",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 1015,
     "descent": -285,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 475,
-    "category": "sans-serif"
+    "xWidthAvg": 475
   },
-  {
+  "shipporiAntiqueB1": {
     "familyName": "Shippori Antique B1",
+    "category": "sans-serif",
     "capHeight": 733,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 524,
-    "xWidthAvg": 480,
-    "category": "sans-serif"
+    "xWidthAvg": 480
   },
-  {
+  "varelaRound": {
     "familyName": "Varela Round",
+    "category": "sans-serif",
     "capHeight": 698,
     "ascent": 918,
     "descent": -286,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 474,
-    "category": "sans-serif"
+    "xWidthAvg": 474
   },
-  {
+  "varta": {
     "familyName": "Varta",
+    "category": "sans-serif",
     "capHeight": 1346,
     "ascent": 1902,
     "descent": -1068,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 990,
-    "xWidthAvg": 849,
-    "category": "sans-serif"
+    "xWidthAvg": 849
   },
-  {
+  "vastShadow": {
     "familyName": "Vast Shadow",
+    "category": "display",
     "capHeight": 1245,
     "ascent": 1875,
     "descent": -685,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 965,
-    "xWidthAvg": 1411,
-    "category": "display"
+    "xWidthAvg": 1411
   },
-  {
+  "vazirmatn": {
     "familyName": "Vazirmatn",
+    "category": "sans-serif",
     "capHeight": 1638,
     "ascent": 2100,
     "descent": -1100,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1082,
-    "xWidthAvg": 914,
-    "category": "sans-serif"
+    "xWidthAvg": 914
   },
-  {
+  "vesperLibre": {
     "familyName": "Vesper Libre",
+    "category": "serif",
     "capHeight": 1384,
     "ascent": 2330,
     "descent": -1550,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 950,
-    "xWidthAvg": 882,
-    "category": "serif"
+    "xWidthAvg": 882
   },
-  {
+  "vibes": {
     "familyName": "Vibes",
+    "category": "display",
     "capHeight": 38,
     "ascent": 1105,
     "descent": -680,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 375,
-    "category": "display"
+    "xWidthAvg": 375
   },
-  {
+  "vibur": {
     "familyName": "Vibur",
+    "category": "handwriting",
     "ascent": 1960,
     "descent": -792,
     "lineGap": 184,
     "unitsPerEm": 2048,
-    "xWidthAvg": 721,
-    "category": "handwriting"
+    "xWidthAvg": 721
   },
-  {
+  "vidaloka": {
     "familyName": "Vidaloka ",
+    "category": "serif",
     "capHeight": 1427,
     "ascent": 1927,
     "descent": -560,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1004,
-    "xWidthAvg": 882,
-    "category": "serif"
+    "xWidthAvg": 882
   },
-  {
+  "viga": {
     "familyName": "Viga",
+    "category": "sans-serif",
     "capHeight": 712,
     "ascent": 1015,
     "descent": -329,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 571,
-    "xWidthAvg": 448,
-    "category": "sans-serif"
+    "xWidthAvg": 448
   },
-  {
+  "voces": {
     "familyName": "Voces",
+    "category": "display",
     "capHeight": 700,
     "ascent": 1014,
     "descent": -335,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 520,
-    "xWidthAvg": 471,
-    "category": "display"
+    "xWidthAvg": 471
   },
-  {
+  "volkhov": {
     "familyName": "Volkhov",
+    "category": "serif",
     "capHeight": 700,
     "ascent": 971,
     "descent": -319,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 483,
-    "category": "serif"
+    "xWidthAvg": 483
   },
-  {
+  "viaodaLibre": {
     "familyName": "Viaoda Libre",
+    "category": "display",
     "capHeight": 740,
     "ascent": 1051,
     "descent": -360,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 467,
-    "xWidthAvg": 382,
-    "category": "display"
+    "xWidthAvg": 382
   },
-  {
+  "voltaire": {
     "familyName": "Voltaire",
+    "category": "sans-serif",
     "capHeight": 1593,
     "ascent": 2020,
     "descent": -531,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1062,
-    "xWidthAvg": 743,
-    "category": "sans-serif"
+    "xWidthAvg": 743
   },
-  {
+  "vollkorn": {
     "familyName": "Vollkorn",
+    "category": "serif",
     "capHeight": 676,
     "ascent": 952,
     "descent": -441,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 458,
-    "xWidthAvg": 433,
-    "category": "serif"
+    "xWidthAvg": 433
   },
-  {
+  "waitingForTheSunrise": {
     "familyName": "Waiting for the Sunrise",
+    "category": "handwriting",
     "capHeight": 755,
     "ascent": 1146,
     "descent": -547,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 570,
-    "xWidthAvg": 404,
-    "category": "handwriting"
+    "xWidthAvg": 404
   },
-  {
+  "vujahdayScript": {
     "familyName": "Vujahday Script",
+    "category": "handwriting",
     "capHeight": 640,
     "ascent": 950,
     "descent": -410,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 360,
-    "xWidthAvg": 367,
-    "category": "handwriting"
+    "xWidthAvg": 367
   },
-  {
+  "vollkornSC": {
     "familyName": "Vollkorn SC",
+    "category": "serif",
     "capHeight": 676,
     "ascent": 952,
     "descent": -441,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 458,
-    "xWidthAvg": 550,
-    "category": "serif"
+    "xWidthAvg": 550
   },
-  {
+  "warnes": {
     "familyName": "Warnes",
+    "category": "display",
     "capHeight": 710,
     "ascent": 994,
     "descent": -310,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 620,
-    "category": "display"
+    "xWidthAvg": 620
   },
-  {
+  "walterTurncoat": {
     "familyName": "Walter Turncoat",
+    "category": "handwriting",
     "capHeight": 752,
     "ascent": 1078,
     "descent": -323,
     "lineGap": 29,
     "unitsPerEm": 1024,
     "xHeight": 559,
-    "xWidthAvg": 501,
-    "category": "handwriting"
+    "xWidthAvg": 501
   },
-  {
+  "wallpoet": {
     "familyName": "Wallpoet",
+    "category": "display",
     "capHeight": 575,
     "ascent": 806,
     "descent": -196,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 440,
-    "xWidthAvg": 613,
-    "category": "display"
+    "xWidthAvg": 613
   },
-  {
+  "wendyOne": {
     "familyName": "Wendy One",
+    "category": "sans-serif",
     "capHeight": 606,
     "ascent": 819,
     "descent": -236,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 474,
-    "xWidthAvg": 474,
-    "category": "sans-serif"
+    "xWidthAvg": 474
   },
-  {
+  "waterBrush": {
     "familyName": "Water Brush",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 1000,
     "descent": -450,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 375,
-    "xWidthAvg": 293,
-    "category": "handwriting"
+    "xWidthAvg": 293
   },
-  {
+  "wellfleet": {
     "familyName": "Wellfleet",
+    "category": "display",
     "capHeight": 1535,
     "ascent": 2020,
     "descent": -540,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 747,
-    "xWidthAvg": 1027,
-    "category": "display"
+    "xWidthAvg": 1027
   },
-  {
+  "whisper": {
     "familyName": "Whisper",
+    "category": "handwriting",
     "capHeight": 620,
     "ascent": 880,
     "descent": -400,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 300,
-    "xWidthAvg": 286,
-    "category": "handwriting"
+    "xWidthAvg": 286
   },
-  {
+  "windSong": {
     "familyName": "WindSong",
+    "category": "handwriting",
     "capHeight": 705,
     "ascent": 890,
     "descent": -515,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 268,
-    "xWidthAvg": 451,
-    "category": "handwriting"
+    "xWidthAvg": 451
   },
-  {
+  "wireOne": {
     "familyName": "Wire One",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 890,
     "descent": -210,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 234,
-    "category": "sans-serif"
+    "xWidthAvg": 234
   },
-  {
+  "xanhMono": {
     "familyName": "Xanh Mono",
+    "category": "monospace",
     "capHeight": 740,
     "ascent": 970,
     "descent": -220,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 540,
-    "xWidthAvg": 500,
-    "category": "monospace"
+    "xWidthAvg": 500
   },
-  {
+  "workSans": {
     "familyName": "Work Sans",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 930,
     "descent": -243,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 500,
-    "category": "sans-serif"
+    "xWidthAvg": 500
   },
-  {
+  "waterfall": {
     "familyName": "Waterfall",
+    "category": "handwriting",
     "capHeight": 580,
     "ascent": 880,
     "descent": -280,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 215,
-    "xWidthAvg": 230,
-    "category": "handwriting"
+    "xWidthAvg": 230
   },
-  {
+  "yanoneKaffeesatz": {
     "familyName": "Yanone Kaffeesatz",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 735,
     "descent": -200,
     "lineGap": 57,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 306,
-    "category": "sans-serif"
+    "xWidthAvg": 306
   },
-  {
+  "yaldevi": {
     "familyName": "Yaldevi",
+    "category": "sans-serif",
     "capHeight": 769,
     "ascent": 1060,
     "descent": -256,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 570,
-    "xWidthAvg": 431,
-    "category": "sans-serif"
+    "xWidthAvg": 431
   },
-  {
+  "yantramanav": {
     "familyName": "Yantramanav",
+    "category": "sans-serif",
     "capHeight": 1279,
     "ascent": 1923,
     "descent": -733,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 986,
-    "xWidthAvg": 839,
-    "category": "sans-serif"
+    "xWidthAvg": 839
   },
-  {
+  "yellowtail": {
     "familyName": "Yellowtail",
+    "category": "handwriting",
     "ascent": 1990,
     "descent": -617,
     "lineGap": 184,
     "unitsPerEm": 2048,
-    "xWidthAvg": 665,
-    "category": "handwriting"
+    "xWidthAvg": 665
   },
-  {
+  "yatraOne": {
     "familyName": "Yatra One",
+    "category": "display",
     "capHeight": 679,
     "ascent": 991,
     "descent": -487,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 460,
-    "xWidthAvg": 495,
-    "category": "display"
+    "xWidthAvg": 495
   },
-  {
+  "yesevaOne": {
     "familyName": "Yeseva One",
+    "category": "display",
     "capHeight": 700,
     "ascent": 915,
     "descent": -240,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 500,
-    "xWidthAvg": 511,
-    "category": "display"
+    "xWidthAvg": 511
   },
-  {
+  "yesteryear": {
     "familyName": "Yesteryear",
+    "category": "handwriting",
     "capHeight": 1581,
     "ascent": 2001,
     "descent": -1004,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 625,
-    "xWidthAvg": 660,
-    "category": "handwriting"
+    "xWidthAvg": 660
   },
-  {
+  "yrsa": {
     "familyName": "Yrsa",
+    "category": "serif",
     "capHeight": 568,
     "ascent": 728,
     "descent": -272,
     "lineGap": 218,
     "unitsPerEm": 1000,
     "xHeight": 413,
-    "xWidthAvg": 394,
-    "category": "serif"
+    "xWidthAvg": 394
   },
-  {
+  "yeonSung": {
     "familyName": "Yeon Sung",
+    "category": "display",
     "capHeight": 659,
     "ascent": 800,
     "descent": -200,
     "lineGap": 250,
     "unitsPerEm": 1000,
     "xHeight": 446,
-    "xWidthAvg": 515,
-    "category": "display"
+    "xWidthAvg": 515
   },
-  {
+  "yomogi": {
     "familyName": "Yomogi",
+    "category": "handwriting",
     "capHeight": 720,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 475,
-    "xWidthAvg": 518,
-    "category": "handwriting"
+    "xWidthAvg": 518
   },
-  {
+  "zCOOLKuaiLe": {
     "familyName": "ZCOOL KuaiLe",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 512,
-    "xWidthAvg": 484,
-    "category": "sans-serif"
+    "xWidthAvg": 484
   },
-  {
+  "zenDots": {
     "familyName": "Zen Dots",
+    "category": "display",
     "capHeight": 715,
     "ascent": 930,
     "descent": -270,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 515,
-    "xWidthAvg": 619,
-    "category": "display"
+    "xWidthAvg": 619
   },
-  {
+  "yujiSyuku": {
     "familyName": "Yuji Syuku",
+    "category": "serif",
     "capHeight": 761,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 545,
-    "xWidthAvg": 524,
-    "category": "serif"
+    "xWidthAvg": 524
   },
-  {
+  "zenAntique": {
     "familyName": "Zen Antique",
+    "category": "serif",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "zCOOLXiaoWei": {
     "familyName": "ZCOOL XiaoWei",
+    "category": "sans-serif",
     "capHeight": 660,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 470,
-    "xWidthAvg": 424,
-    "category": "sans-serif"
+    "xWidthAvg": 424
   },
-  {
+  "zenKakuGothicAntique": {
     "familyName": "Zen Kaku Gothic Antique",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 479,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "zenKakuGothicNew": {
     "familyName": "Zen Kaku Gothic New",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 479,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "zenAntiqueSoft": {
     "familyName": "Zen Antique Soft",
+    "category": "serif",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 473,
-    "xWidthAvg": 482,
-    "category": "serif"
+    "xWidthAvg": 482
   },
-  {
+  "zenLoop": {
     "familyName": "Zen Loop",
+    "category": "display",
     "capHeight": 690,
     "ascent": 850,
     "descent": -275,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 477,
-    "xWidthAvg": 266,
-    "category": "display"
+    "xWidthAvg": 266
   },
-  {
+  "zenTokyoZoo": {
     "familyName": "Zen Tokyo Zoo",
+    "category": "display",
     "capHeight": 804,
     "ascent": 950,
     "descent": -250,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 402,
-    "xWidthAvg": 374,
-    "category": "display"
+    "xWidthAvg": 374
   },
-  {
+  "zeyada": {
     "familyName": "Zeyada",
+    "category": "handwriting",
     "capHeight": 602,
     "ascent": 934,
     "descent": -680,
     "lineGap": 0,
     "unitsPerEm": 1024,
     "xHeight": 312,
-    "xWidthAvg": 354,
-    "category": "handwriting"
+    "xWidthAvg": 354
   },
-  {
+  "zenKurenaido": {
     "familyName": "Zen Kurenaido",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 406,
-    "xWidthAvg": 398,
-    "category": "sans-serif"
+    "xWidthAvg": 398
   },
-  {
+  "zillaSlab": {
     "familyName": "Zilla Slab",
+    "category": "serif",
     "capHeight": 650,
     "ascent": 944,
     "descent": -256,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 445,
-    "xWidthAvg": 430,
-    "category": "serif"
+    "xWidthAvg": 430
   },
-  {
+  "zillaSlabHighlight": {
     "familyName": "Zilla Slab Highlight",
+    "category": "display",
     "capHeight": 650,
     "ascent": 944,
     "descent": -256,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 445,
-    "xWidthAvg": 432,
-    "category": "display"
+    "xWidthAvg": 432
   },
-  {
+  "zenMaruGothic": {
     "familyName": "Zen Maru Gothic",
+    "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 479,
-    "xWidthAvg": 440,
-    "category": "sans-serif"
+    "xWidthAvg": 440
   },
-  {
+  "zhiMangXing": {
     "familyName": "Zhi Mang Xing",
+    "category": "handwriting",
     "capHeight": 750,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 496,
-    "xWidthAvg": 305,
-    "category": "handwriting"
+    "xWidthAvg": 305
   },
-  {
+  "zCOOLQingKeHuangYou": {
     "familyName": "ZCOOL QingKe HuangYou",
+    "category": "sans-serif",
     "capHeight": 710,
     "ascent": 880,
     "descent": -120,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 485,
-    "xWidthAvg": 351,
-    "category": "sans-serif"
+    "xWidthAvg": 351
   },
-  {
+  "zenOldMincho": {
     "familyName": "Zen Old Mincho",
+    "category": "serif",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 430,
-    "xWidthAvg": 429,
-    "category": "serif"
+    "xWidthAvg": 429
   },
-  {
+  "yuseiMagic": {
     "familyName": "Yusei Magic",
+    "category": "sans-serif",
     "capHeight": 760,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 510,
-    "xWidthAvg": 499,
-    "category": "sans-serif"
+    "xWidthAvg": 499
   },
-  {
+  "yujiMai": {
     "familyName": "Yuji Mai",
+    "category": "serif",
     "capHeight": 761,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 545,
-    "xWidthAvg": 521,
-    "category": "serif"
+    "xWidthAvg": 521
   },
-  {
+  "shipporiMinchoB1": {
     "familyName": "Shippori Mincho B1",
+    "category": "serif",
     "capHeight": 726,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 480,
-    "xWidthAvg": 473,
-    "category": "serif"
+    "xWidthAvg": 473
   },
-  {
+  "yujiBoku": {
     "familyName": "Yuji Boku",
+    "category": "serif",
     "capHeight": 761,
     "ascent": 1160,
     "descent": -288,
     "lineGap": 0,
     "unitsPerEm": 1000,
     "xHeight": 545,
-    "xWidthAvg": 493,
-    "category": "serif"
+    "xWidthAvg": 493
   }
-]
+}

--- a/packages/metrics/src/entireMetricsCollection.ts
+++ b/packages/metrics/src/entireMetricsCollection.ts
@@ -1,0 +1,18 @@
+import metrics from './entireMetricsCollection.json';
+
+/**
+ * Provides the entire metrics collection as a JSON object, keyed by font family name.
+ *
+ * ## ⚠️ CAUTION: Importing this will result in a **large JSON structure** being pulled into your project! It is not recommended to use this client side.
+ *
+ * ---
+ * Example usage:
+ *
+ * ```ts
+ * import { entireMetricsCollection } from '@capsizecss/metrics/entireMetricsCollection';
+ *
+ * const metrics = entireMetricsCollection['arial'];
+ * ```
+ * ---
+ */
+export const entireMetricsCollection = metrics;

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Converts the font family name to the correct casing for the relevant metrics import.
+ *
+ * ---
+ * Example usage:
+ *
+ * ```ts
+ * import { fontFamilyToCamelCase } from '@capsizecss/metrics';
+ *
+ * const familyName = fontFamilyToCamelCase('--apple-system'); // => `appleSystem`
+ * const metrics = await import(`@capsizecss/metrics/${familyName}`);
+ * ```
+ * ---
+ */
+
+export function fontFamilyToCamelCase(str: string) {
+  return str
+    .split(/[\s|-]/)
+    .filter(Boolean)
+    .map(
+      (s, i) =>
+        `${s.charAt(0)[i > 0 ? 'toUpperCase' : 'toLowerCase']()}${s.slice(1)}`,
+    )
+    .join('');
+}

--- a/site/src/components/OutputCSS.tsx
+++ b/site/src/components/OutputCSS.tsx
@@ -5,16 +5,7 @@ import { createStyleString } from '@capsizecss/core';
 import { useAppState } from './AppStateContext';
 import tabStyles from '../tabStyles';
 import Code from './Code';
-
-const toMetricsImport = (str: string) =>
-  str
-    .split(/[\s|-]/)
-    .filter(Boolean)
-    .map(
-      (s, i) =>
-        `${s.charAt(0)[i > 0 ? 'toUpperCase' : 'toLowerCase']()}${s.slice(1)}`,
-    )
-    .join('');
+import { fontFamilyToCamelCase } from '@capsizecss/metrics';
 
 const OutputCSS = () => {
   const { state } = useAppState();
@@ -49,10 +40,10 @@ const OutputCSS = () => {
   }
 
   const fontMetricsImport: Record<typeof selectedFont.source, string> = {
-    GOOGLE_FONT: `import fontMetrics from '@capsizecss/metrics/${toMetricsImport(
+    GOOGLE_FONT: `import fontMetrics from '@capsizecss/metrics/${fontFamilyToCamelCase(
       selectedFont.name,
     )}';`,
-    SYSTEM_FONT: `import fontMetrics from '@capsizecss/metrics/${toMetricsImport(
+    SYSTEM_FONT: `import fontMetrics from '@capsizecss/metrics/${fontFamilyToCamelCase(
       selectedFont.name,
     )}';`,
     FILE_UPLOAD: `import { fromFile } from '@capsizecss/unpack';`,


### PR DESCRIPTION
Expose two new APIs: 

## **entireMetricsCollection**: Expose all metrics indexed by family name

Provides the entire metrics collection as a JSON object, keyed by font family name.

**⚠️ CAUTION: Importing this will result in a _large JSON structure_ being pulled into your project! It is not recommended to use this client side.**

```ts
import { entireMetricsCollection } from '@capsizecss/metrics/entireMetricsCollection';

const metrics = entireMetricsCollection['arial'];
```

and

## **fontFamilyToCamelCase**: Expose utility to convert family name to import name

A helper function to support tooling that needs to convert the font family name to the correct casing for the relevant metrics import.

```ts
import { fontFamilyToCamelCase } from '@capsizecss/metrics';

const familyName = fontFamilyToCamelCase('--apple-system'); // => `appleSystem`
const metrics = await import(`@capsizecss/metrics/${familyName}`);

