### PR TITLE
Fix a Firefox specific whitespace bug

### DIFF
--- a/packages/core/src/createStyleObject.ts
+++ b/packages/core/src/createStyleObject.ts
@@ -14,11 +14,13 @@ const _createStyleObject = ({
       content: "''",
       marginBottom: capHeightTrim,
       display: 'table',
+      whiteSpace: 'normal',
     },
     '::after': {
       content: "''",
       marginTop: baselineTrim,
       display: 'table',
+      whiteSpace: 'normal',
     },
   };
 };


### PR DESCRIPTION
When text managed by Cap Size is contained within a `table` element and has `white-space` set as `break-line`, `pre`, or `pre-wrap` the `:before` and `:after` pseudo elements pick up excess spacing due to being `display: table`. This fix resets the `white-space` value of the pseudo elements to remove the excess spacing. 

Open this demo in Firefox to view the bug and fix https://stackblitz.com/edit/vitejs-vite-dwmuts?file=src%2FApp.css.ts,src%2FApp.tsx