### PR TITLE
metrics: Ensure metrics files are published to npm

### DIFF
--- a/.changeset/gold-lions-study.md
+++ b/.changeset/gold-lions-study.md
@@ -1,0 +1,5 @@
+---
+'@capsizecss/metrics': patch
+---
+
+Ensure metrics files are published to npm

--- a/packages/metrics/.npmignore
+++ b/packages/metrics/.npmignore
@@ -1,1 +1,2 @@
 scripts
+src

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -14,10 +14,6 @@
       "entireMetricsCollection.ts"
     ]
   },
-  "files": [
-    "/dist",
-    "/entireMetricsCollection"
-  ],
   "scripts": {
     "clean": "ts-node scripts/clean",
     "prebuild": "pnpm clean",


### PR DESCRIPTION
With the last PR introducing new entrypoints and adding a `files` array to the `metrics` package, this saw all the generated metrics files be excluded from publishing.

Removing the files array to ensure everything gets published.

Tested with a snapshot published and installed into a code sandbox.