### PR TITLE
createFontStack: Apply metric overrides conditionally

### DIFF
--- a/.changeset/wild-lemons-love.md
+++ b/.changeset/wild-lemons-love.md
@@ -1,0 +1,8 @@
+---
+'@capsizecss/core': patch
+---
+
+createFontStack: Apply metric overrides conditionally
+
+Addresses an issue where metric overrides would be applied for fonts with the same metric values.
+The `ascent-override`, `descent-override` and `line-gap-override` properties are now all conditional, only returned when the metrics differ between the preferred font and its fallback(s).

--- a/packages/core/src/createFontStack.test.ts
+++ b/packages/core/src/createFontStack.test.ts
@@ -351,6 +351,20 @@ describe('createFontStack', () => {
     });
   });
 
+  describe('metric overrides', () => {
+    it('with same metrics', () => {
+      expect(createFontStack([arial, arial])).toMatchInlineSnapshot(`
+        {
+          "fontFaces": "@font-face {
+          font-family: "Arial Fallback";
+          src: local('Arial');
+        }",
+          "fontFamily": "Arial, "Arial Fallback"",
+        }
+      `);
+    });
+  });
+
   describe('fontFaceProperties', () => {
     it('with a single fallback', () =>
       expect(

--- a/packages/core/src/createFontStack.ts
+++ b/packages/core/src/createFontStack.ts
@@ -37,15 +37,21 @@ const calculateOverrideValues = ({
   const descentOverride = Math.abs(metrics.descent) / adjustedEmSquare;
   const lineGapOverride = metrics.lineGap / adjustedEmSquare;
 
+  // Calculate metric overrides for fallback font
+  const fallbackAscentOverride = fallbackMetrics.ascent / adjustedEmSquare;
+  const fallbackDescentOverride =
+    Math.abs(fallbackMetrics.descent) / adjustedEmSquare;
+  const fallbackLineGapOverride = fallbackMetrics.lineGap / adjustedEmSquare;
+
   // Conditionally populate font face properties and format to percent
   const fontFace: AtRule.FontFace = {};
-  if (ascentOverride) {
+  if (ascentOverride && ascentOverride !== fallbackAscentOverride) {
     fontFace['ascentOverride'] = toPercentString(ascentOverride);
   }
-  if (descentOverride) {
+  if (descentOverride && descentOverride !== fallbackDescentOverride) {
     fontFace['descentOverride'] = toPercentString(descentOverride);
   }
-  if (lineGapOverride) {
+  if (lineGapOverride && lineGapOverride !== fallbackLineGapOverride) {
     fontFace['lineGapOverride'] = toPercentString(lineGapOverride);
   }
   if (sizeAdjust && sizeAdjust !== 1) {


### PR DESCRIPTION
createFontStack: Apply metric overrides conditionally

Addresses an issue where metric overrides would be applied for fonts with the same metric values.
The `ascent-override`, `descent-override` and `line-gap-override` properties are now all conditional, only returned when the metrics differ between the preferred font and its fallback(s).

Fixes #136 