### PR TITLE
Add `@container` query support to the `createTextStyle` function

### DIFF
--- a/packages/vanilla-extract/README.md
+++ b/packages/vanilla-extract/README.md
@@ -137,6 +137,8 @@ export const text = createTextStyle(vars.bodyText.mobile, {
 });
 ```
 
+As an alternative to passing a media query object, can also provide a vanilla-extract [container query object](https://vanilla-extract.style/documentation/styling/#container-queries).
+
 ### Debug identifiers
 
 To improve the developer experience, `createTextStyle` accepts a debug identifier as the last argument.

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -9,34 +9,59 @@ import { precomputeValues } from '@capsizecss/core';
 import { ComputedValues, CreateStyleObjectParameters } from './types';
 import { capsizeStyle, capsizeVars } from './capsize.css';
 
-interface MediaQueries {
-  '@media': Record<string, CreateStyleObjectParameters>;
+interface ConditionalQueries {
+  '@media'?: Record<string, CreateStyleObjectParameters>;
+  '@container'?: Record<string, CreateStyleObjectParameters>;
 }
+
+const generateQueryVars = ({
+  queryType,
+  queries,
+}: {
+  queryType: '@media' | '@container';
+  queries: Record<string, any>;
+}) => {
+  const queryVars: StyleRule[typeof queryType] = {};
+
+  Object.entries(queries).forEach(([query, value]) => {
+    const builtValues =
+      'capHeightTrim' in value
+        ? (value as ComputedValues)
+        : precomputeValues(value);
+
+    queryVars[query] = { vars: assignVars(capsizeVars, builtValues) };
+  });
+
+  return queryVars;
+};
 
 const createVanillaStyle = ({
   values,
-  mediaQueries,
+  conditionalQueries,
   debugId,
 }: {
   values: ComputedValues;
-  mediaQueries?: MediaQueries;
+  conditionalQueries?: ConditionalQueries;
   debugId?: string;
 }) => {
   const vars: StyleRule = {
     vars: assignVars(capsizeVars, values),
   };
 
-  if (typeof mediaQueries !== 'undefined') {
-    const mqs: StyleRule['@media'] = {};
-    Object.entries(mediaQueries['@media']).forEach(([mq, val]) => {
-      const builtValues =
-        'capHeightTrim' in val
-          ? (val as ComputedValues)
-          : precomputeValues(val);
+  if (typeof conditionalQueries !== 'undefined') {
+    if (conditionalQueries['@media']) {
+      vars['@media'] = generateQueryVars({
+        queryType: '@media',
+        queries: conditionalQueries['@media'],
+      });
+    }
 
-      mqs[mq] = { vars: assignVars(capsizeVars, builtValues) };
-    });
-    vars['@media'] = mqs;
+    if (conditionalQueries['@container']) {
+      vars['@container'] = generateQueryVars({
+        queryType: '@container',
+        queries: conditionalQueries['@container'],
+      });
+    }
   }
 
   return composeStyles(capsizeStyle, style(vars, debugId));
@@ -48,26 +73,27 @@ function createTextStyle(
 ): string;
 function createTextStyle(
   args: CreateStyleObjectParameters,
-  mediaQueries?: MediaQueries,
+  conditionalQueries?: ConditionalQueries,
   debugId?: string,
 ): string;
 function createTextStyle(...args: any[]) {
-  const hasMediaQueries =
+  const hasConditionalQueries =
     typeof args[1] !== 'undefined' && typeof args[1] !== 'string';
-  const debugId = hasMediaQueries ? args[2] : args[1];
-  const mediaQueries = hasMediaQueries ? args[1] : undefined;
+
+  const debugId = hasConditionalQueries ? args[2] : args[1];
+  const conditionalQueries = hasConditionalQueries ? args[1] : undefined;
 
   if ('capHeightTrim' in args[0]) {
     return createVanillaStyle({
       values: args[0],
-      mediaQueries,
+      conditionalQueries,
       debugId,
     });
   }
 
   return createVanillaStyle({
     values: precomputeValues(args[0]),
-    mediaQueries,
+    conditionalQueries,
     debugId,
   });
 }

--- a/packages/vanilla-extract/stories/Text.css.ts
+++ b/packages/vanilla-extract/stories/Text.css.ts
@@ -1,4 +1,8 @@
-import { style, createGlobalTheme } from '@vanilla-extract/css';
+import {
+  style,
+  createGlobalTheme,
+  createContainer,
+} from '@vanilla-extract/css';
 import { createTextStyle, precomputeValues } from '../src';
 
 const fontMetrics = {
@@ -53,6 +57,25 @@ export const responsiveText = createTextStyle(
     '@media': {
       'screen and (min-width: 768px)': textValues.tablet,
       'screen and (min-width: 1024px)': textValues.desktop,
+    },
+  },
+  'responsiveText',
+);
+
+const containerName = createContainer();
+
+export const container = style({
+  containerName,
+  containerType: 'inline-size',
+  outline: 'solid 1px blue',
+});
+
+export const containerText = createTextStyle(
+  textValues.mobile,
+  {
+    '@container': {
+      [`${containerName} (min-width: 400px)`]: textValues.tablet,
+      [`${containerName} (min-width: 600px)`]: textValues.desktop,
     },
   },
   'responsiveText',

--- a/packages/vanilla-extract/stories/Text.ts
+++ b/packages/vanilla-extract/stories/Text.ts
@@ -15,7 +15,7 @@ export const ThemedText = ({ text, background }: Props) =>
     background ? ` style="background: ${background}"` : ''
   }>${text}</div>`;
 
-export const ResponsiveText = ({ text, background }: Props) =>
+export const MediaResponsiveText = ({ text, background }: Props) =>
   `<div class="${styles.fontFamily} ${styles.responsiveText}"${
     background ? ` style="background: ${background}"` : ''
   }>${text}</div>`;
@@ -24,3 +24,17 @@ export const ResponsiveThemedText = ({ text, background }: Props) =>
   `<div class="${styles.fontFamily} ${styles.responsiveThemedText}"${
     background ? ` style="background: ${background}"` : ''
   }>${text}</div>`;
+
+export const ContainerResponsiveText = ({ text, background }: Props) =>
+  [350, 550, 700]
+    .map(
+      (width) => `
+      <div style="width: ${width}px;" class="${styles.container}">
+        <div class="${styles.fontFamily} ${styles.containerText}"${
+        background ? ` style="background: ${background}"` : ''
+      }>
+          ${text}
+        </div>
+      </div>`,
+    )
+    .join('\n');

--- a/packages/vanilla-extract/stories/vanilla-extract.stories.ts
+++ b/packages/vanilla-extract/stories/vanilla-extract.stories.ts
@@ -1,8 +1,9 @@
 import {
   BasicText,
   ThemedText,
-  ResponsiveText,
+  MediaResponsiveText,
   ResponsiveThemedText,
+  ContainerResponsiveText,
 } from './Text';
 
 export default {
@@ -24,8 +25,12 @@ export const Basic = container(BasicText({ text: 'Heading' }));
 
 export const Themed = container(ThemedText({ text: 'Heading' }));
 
-export const Responsive = container(ResponsiveText({ text: 'Heading' }));
+export const Responsive = container(MediaResponsiveText({ text: 'Heading' }));
 
 export const ResponsiveThemed = container(
   ResponsiveThemedText({ text: 'Heading' }),
+);
+
+export const Container = container(
+  ContainerResponsiveText({ text: 'Heading' }),
 );


### PR DESCRIPTION
Thanks for providing the `@capsizecss/vanilla-extract` package - it makes generating and consuming capsized text styles in a vanilla-extract project very easy.

I was recently trying to size text based on the container it's in with a `@container` query and noticed this isn't supported like `@media` queries are. Rather than opening an issue I decided to make the change myself, but I'm happy to make an issue instead if you'd prefer.

---

This is a PR to add [@container](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries) query support to the `createTextStyle` function from the `@capsizecss/vanilla-extract` package.

`createTextStyle` already supports [@media](https://developer.mozilla.org/en-US/docs/Web/CSS/@media) queries, accepting a vanilla-extract [media query object](https://vanilla-extract.style/documentation/styling/#media-queries) as a second argument like so:
```ts
export const text = createTextStyle(textDefinitions.mobile, {
  '@media': {
    'screen and (min-width: 768px)': textDefinitions.tablet,
    'screen and (min-width: 1024px)': textDefinitions.desktop,
  },
});
```

This PR extends `createTextStyle` so that you can also provide a vanilla-extract [container query object](https://vanilla-extract.style/documentation/styling/#container-queries) as the second argument like so:

```ts
import { style, createContainer } from '@vanilla-extract/css';

const containerName = createContainer();

export const container = style({
  containerName,
  containerType: 'inline-size',
  outline: 'solid 1px blue',
});

export const containerText = createTextStyle(textValues.mobile, {
  '@container': {
    [`${containerName} (min-width: 768px)`]: textValues.tablet,
    [`${containerName} (min-width: 1024px)`]: textValues.desktop,
  },
});
```

I've added a basic story to `vanilla-extract` Storybook named `Container` that provides a visual demonstration of the `container` based behaviour:

<img width="600" alt="image" src="https://github.com/seek-oss/capsize/assets/19183324/81e9b2b2-e087-4185-a3dc-f10910214b2e">

The blue outlines around each text row delimits the width of the containers wrapping each text row. 

This is to indicate that the text within each container responds to the width of the container.

As mentioned, I'd be happy to open an issue instead, but thought I'd have a crack at adding `@container` support first.