### PR TITLE
Add layout style collison warning to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ See the [fontMetrics](#font-metrics) option documented below for more ways to ob
 </div>
 ```
 
+> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interferring with the styles used for the trim. Instead consider using a nested element.
+
 ### `createStyleString`
 
 Returns a CSS string that can be inserted into a `style` tag or appended to a stylesheet.
@@ -110,6 +112,8 @@ document.write(`
   </div>
 `);
 ```
+
+> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interferring with the styles used for the trim. Instead consider using a nested element.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See the [fontMetrics](#font-metrics) option documented below for more ways to ob
 </div>
 ```
 
-> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interferring with the styles used for the trim. Instead consider using a nested element.
+> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interfering with the styles used for the trim. Instead consider using a nested element.
 
 ### `createStyleString`
 
@@ -113,7 +113,7 @@ document.write(`
 `);
 ```
 
-> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interferring with the styles used for the trim. Instead consider using a nested element.
+> ⚠️ Note: It is not recommended to apply further layout-related styles to the same element, as this will risk interfering with the styles used for the trim. Instead consider using a nested element.
 
 ## Options
 


### PR DESCRIPTION
Adding a note to the readme to document the risk of applying layout-related styles to the same node as the capsize styles. 

This follows a few issues raised ([here](https://github.com/seek-oss/capsize/pull/132#issuecomment-1809317173) and [here](https://github.com/seek-oss/capsize/issues/15#issuecomment-663279448)) where the recommended solution would be to nest a separate node.