### PR TITLE
Remove mentions of partially supported flexbox gap

### DIFF
--- a/site/src/components/FAQs.tsx
+++ b/site/src/components/FAQs.tsx
@@ -305,14 +305,7 @@ const FAQs = () => {
                   gap
                 </Code>
               </Link>{' '}
-              for CSS grid (and soon{' '}
-              <Link
-                textDecoration="underline"
-                href="https://css-tricks.com/chromium-lands-flexbox-gap/"
-              >
-                flexbox
-              </Link>
-              ?) maybe this will feed into a future proposal.
+              for CSS grid and flexbox, maybe this will feed into a future proposal.
             </Text>
           </Stack>
         </Question>


### PR DESCRIPTION
`gap` in flexbox has been [widely supported](https://caniuse.com/flexbox-gap) for more than 2 years.