### PR TITLE
createFontStack: Add original fallback name & quote in declaration

### DIFF
--- a/.changeset/clever-cobras-check.md
+++ b/.changeset/clever-cobras-check.md
@@ -1,0 +1,24 @@
+---
+'@capsizecss/core': patch
+---
+
+createFontStack: Append original fallback font name to the font stack
+
+The `fontFamily` returned from `createFontStack` now includes the original fallback font name(s). These are appended to the end of the font stack in the case the preferred font and generated fallbacks are not available.
+
+```ts
+import lobster from '@capsizecss/metrics/lobster';
+import arial from '@capsizecss/metrics/arial';
+
+const { fontFamily } = createFontStack([
+  lobster,
+  arial,
+]);
+```
+
+Where `fontFamily` is now:
+
+```diff
+- `Lobster, 'Lobster Fallback: Arial'`
++ `Lobster, 'Lobster Fallback: Arial', Arial`
+```

--- a/.changeset/sour-tools-crash.md
+++ b/.changeset/sour-tools-crash.md
@@ -1,0 +1,8 @@
+---
+'@capsizecss/core': patch
+---
+
+createFontStack: Quote `font-family` in `@font-face` declaration if needed
+
+Previously, when using `fontFaceFormat: 'styleObject'`, the generated fallback name  was not quoted as necessary within the `@font-face` declaration.
+This could cause issues if the font family name contained spaces or other characters that required quoting.

--- a/.changeset/sour-tools-crash.md
+++ b/.changeset/sour-tools-crash.md
@@ -4,5 +4,5 @@
 
 createFontStack: Quote `font-family` in `@font-face` declaration if needed
 
-Previously, when using `fontFaceFormat: 'styleObject'`, the generated fallback name  was not quoted as necessary within the `@font-face` declaration.
+Previously, when using `fontFaceFormat: 'styleObject'`, the generated fallback name was not quoted as necessary within the `@font-face` declaration.
 This could cause issues if the font family name contained spaces or other characters that required quoting.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ This will produce the following CSS:
 ```css
 .heading {
   font-family: Lobster, 'Lobster Fallback: Helvetica Neue',
-    'Lobster Fallback: Arial';
+    'Lobster Fallback: Arial', 'Helvetica Neue', Arial;
 }
 
 @font-face {

--- a/packages/core/src/createFontStack.test.ts
+++ b/packages/core/src/createFontStack.test.ts
@@ -193,7 +193,7 @@ describe('createFontStack', () => {
                 "@font-face": {
                   "ascentOverride": "92.3409%",
                   "descentOverride": "25.619%",
-                  "fontFamily": "Merriweather Sans Fallback",
+                  "fontFamily": ""Merriweather Sans Fallback"",
                   "sizeAdjust": "106.5617%",
                   "src": "local('Arial')",
                 },
@@ -216,7 +216,7 @@ describe('createFontStack', () => {
                 "@font-face": {
                   "ascentOverride": "91.8077%",
                   "descentOverride": "21.4911%",
-                  "fontFamily": "Arial Fallback",
+                  "fontFamily": ""Arial Fallback"",
                   "lineGapOverride": "3.3178%",
                   "sizeAdjust": "98.6054%",
                   "src": "local('Helvetica Neue')",
@@ -243,7 +243,7 @@ describe('createFontStack', () => {
                 "@font-face": {
                   "ascentOverride": "86.6128%",
                   "descentOverride": "24.0298%",
-                  "fontFamily": "Merriweather Sans Fallback: -apple-system",
+                  "fontFamily": ""Merriweather Sans Fallback: -apple-system"",
                   "sizeAdjust": "113.6091%",
                   "src": "local('-apple-system')",
                 },
@@ -252,7 +252,7 @@ describe('createFontStack', () => {
                 "@font-face": {
                   "ascentOverride": "92.3409%",
                   "descentOverride": "25.619%",
-                  "fontFamily": "Merriweather Sans Fallback: Arial",
+                  "fontFamily": ""Merriweather Sans Fallback: Arial"",
                   "sizeAdjust": "106.5617%",
                   "src": "local('Arial')",
                 },
@@ -261,7 +261,7 @@ describe('createFontStack', () => {
                 "@font-face": {
                   "ascentOverride": "93.6469%",
                   "descentOverride": "25.9813%",
-                  "fontFamily": "Merriweather Sans Fallback: Helvetica Neue",
+                  "fontFamily": ""Merriweather Sans Fallback: Helvetica Neue"",
                   "sizeAdjust": "105.0756%",
                   "src": "local('Helvetica Neue')",
                 },

--- a/packages/core/src/createFontStack.test.ts
+++ b/packages/core/src/createFontStack.test.ts
@@ -122,7 +122,7 @@ describe('createFontStack', () => {
             descent-override: 25.619%;
             size-adjust: 106.5617%;
           }",
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
           }
         `);
       });
@@ -138,7 +138,7 @@ describe('createFontStack', () => {
             line-gap-override: 3.3178%;
             size-adjust: 98.6054%;
           }",
-            "fontFamily": "Arial, "Arial Fallback"",
+            "fontFamily": "Arial, "Arial Fallback", "Helvetica Neue"",
           }
         `);
       });
@@ -174,7 +174,7 @@ describe('createFontStack', () => {
             descent-override: 25.9813%;
             size-adjust: 105.0756%;
           }",
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue", -apple-system, Arial, "Helvetica Neue"",
           }
         `);
       });
@@ -199,7 +199,7 @@ describe('createFontStack', () => {
                 },
               },
             ],
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
           }
         `);
       });
@@ -223,7 +223,7 @@ describe('createFontStack', () => {
                 },
               },
             ],
-            "fontFamily": "Arial, "Arial Fallback"",
+            "fontFamily": "Arial, "Arial Fallback", "Helvetica Neue"",
           }
         `);
       });
@@ -267,7 +267,7 @@ describe('createFontStack', () => {
                 },
               },
             ],
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue", -apple-system, Arial, "Helvetica Neue"",
           }
         `);
       });
@@ -288,7 +288,7 @@ describe('createFontStack', () => {
             descent-override: 25.619%;
             size-adjust: 106.5617%;
           }",
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
           }
         `);
       });
@@ -308,7 +308,7 @@ describe('createFontStack', () => {
             line-gap-override: 3.3178%;
             size-adjust: 98.6054%;
           }",
-            "fontFamily": "Arial, "Arial Fallback"",
+            "fontFamily": "Arial, "Arial Fallback", "Helvetica Neue"",
           }
         `);
       });
@@ -344,7 +344,7 @@ describe('createFontStack', () => {
             descent-override: 25.9813%;
             size-adjust: 105.0756%;
           }",
-            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue"",
+            "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue", -apple-system, Arial, "Helvetica Neue"",
           }
         `);
       });
@@ -359,7 +359,7 @@ describe('createFontStack', () => {
           font-family: "Arial Fallback";
           src: local('Arial');
         }",
-          "fontFamily": "Arial, "Arial Fallback"",
+          "fontFamily": "Arial, "Arial Fallback", Arial",
         }
       `);
     });
@@ -381,7 +381,7 @@ describe('createFontStack', () => {
           descent-override: 25.619%;
           size-adjust: 106.5617%;
         }",
-          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
         }
       `));
 
@@ -416,7 +416,7 @@ describe('createFontStack', () => {
           descent-override: 25.9813%;
           size-adjust: 105.0756%;
         }",
-          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue"",
+          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue", -apple-system, Arial, "Helvetica Neue"",
         }
       `);
     });
@@ -438,7 +438,7 @@ describe('createFontStack', () => {
           descent-override: 25.619%;
           size-adjust: 106.5617%;
         }",
-          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
         }
       `);
     });
@@ -474,7 +474,7 @@ describe('createFontStack', () => {
           descent-override: 25.9813%;
           size-adjust: 105.0756%;
         }",
-          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue"",
+          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback: -apple-system", "Merriweather Sans Fallback: Arial", "Merriweather Sans Fallback: Helvetica Neue", -apple-system, Arial, "Helvetica Neue"",
         }
       `);
     });
@@ -498,7 +498,7 @@ describe('createFontStack', () => {
           ascent-override: 92.3409%;
           descent-override: 25.619%;
         }",
-          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback"",
+          "fontFamily": ""Merriweather Sans", "Merriweather Sans Fallback", Arial",
         }
       `);
     });

--- a/packages/core/src/createFontStack.ts
+++ b/packages/core/src/createFontStack.ts
@@ -167,11 +167,13 @@ export function createFontStack(
   const fontFaces: FontFace[] = [];
 
   fallbackMetrics.forEach((fallback) => {
-    const fontFamily = `${familyName} Fallback${
-      fallbackMetrics.length > 1 ? `: ${fallback.familyName}` : ''
-    }`;
+    const fontFamily = quoteIfNeeded(
+      `${familyName} Fallback${
+        fallbackMetrics.length > 1 ? `: ${fallback.familyName}` : ''
+      }`,
+    );
 
-    fontFamilies.push(quoteIfNeeded(fontFamily));
+    fontFamilies.push(fontFamily);
     fontFaces.push({
       '@font-face': {
         ...fontFaceProperties,

--- a/packages/core/src/createFontStack.ts
+++ b/packages/core/src/createFontStack.ts
@@ -188,6 +188,11 @@ export function createFontStack(
     });
   });
 
+  // Include original fallback font families after generated fallbacks
+  fallbackMetrics.forEach((fallback) => {
+    fontFamilies.push(quoteIfNeeded(fallback.familyName));
+  });
+
   return {
     fontFamily: fontFamilies.join(', '),
     fontFaces: {


### PR DESCRIPTION
Two improvements to `createFontStack` API:

### createFontStack: Append original fallback font name to the font stack

The `fontFamily` returned from `createFontStack` now includes the original fallback font name(s). These are appended to the end of the font stack in the case the preferred font and generated fallbacks are not available.

```ts
import lobster from '@capsizecss/metrics/lobster';
import arial from '@capsizecss/metrics/arial';

const { fontFamily } = createFontStack([
  lobster,
  arial,
]);
```

Where `fontFamily` is now:

```diff
- `Lobster, 'Lobster Fallback: Arial'`
+ `Lobster, 'Lobster Fallback: Arial', Arial`
```
---

### createFontStack: Quote `font-family` in `@font-face` declaration if needed

Previously, when using `fontFaceFormat: 'styleObject'`, the generated fallback name  was not quoted as necessary within the `@font-face` declaration. This could cause issues if the font family name contained spaces or other characters that required quoting.