### PR TITLE
Fix CSS in FAQ

### DIFF
--- a/site/src/components/FAQs.tsx
+++ b/site/src/components/FAQs.tsx
@@ -256,7 +256,7 @@ const FAQs = () => {
                 {css`
                   .capsizedText {
                     font-size: ${displaySize}cap;
-                    line-height: line-height: ${
+                    line-height: ${
                       capsizeValues && 'lineHeight' in capsizeValues
                         ? Math.round(
                             parseInt(


### PR DESCRIPTION
Removes a duplicate `line-height` rule accidentally added in #160.