### PR TITLE
vanilla-extract: Drop support for Vanilla Extract below v1.4

### DIFF
--- a/.changeset/sour-files-tease.md
+++ b/.changeset/sour-files-tease.md
@@ -1,0 +1,10 @@
+---
+'@capsizecss/vanilla-extract': major
+---
+
+Drop support for Vanilla Extract below v1.4
+
+Upgrading to use Vanilla Extract's [style composition] API in favour of the long time deprecated `composeStyles` function.
+There is no API change for Capsize consumers, but this change will require a peer dependency of `vanilla-extract@1.4.0` or greater.
+
+[style composition]: https://vanilla-extract.style/documentation/api/style/#style-composition

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -52,6 +52,6 @@
     "@vanilla-extract/css": "^1.9.2"
   },
   "peerDependencies": {
-    "@vanilla-extract/css": "^1.2.1"
+    "@vanilla-extract/css": "^1.4.0"
   }
 }

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -1,9 +1,4 @@
-import {
-  style,
-  assignVars,
-  composeStyles,
-  StyleRule,
-} from '@vanilla-extract/css';
+import { style, assignVars, StyleRule } from '@vanilla-extract/css';
 import { precomputeValues } from '@capsizecss/core';
 
 import { ComputedValues, CreateStyleObjectParameters } from './types';
@@ -39,7 +34,7 @@ const createVanillaStyle = ({
     vars['@media'] = mqs;
   }
 
-  return composeStyles(capsizeStyle, style(vars, debugId));
+  return style([capsizeStyle, style(vars, debugId)]);
 };
 
 function createTextStyle(


### PR DESCRIPTION
Drop support for Vanilla Extract below v1.4

Upgrading to use Vanilla Extract's [style composition] API in favour of the long time deprecated `composeStyles` function.
There is no API change for Capsize consumers, but this change will require a peer dependency of `vanilla-extract@1.4.0` or greater.

[style composition]: https://vanilla-extract.style/documentation/api/style/#style-composition