### PR TITLE
site: Add metrics viewer to site

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       react-helmet-async:
         specifier: ^2.0.4
         version: 2.0.4(react-dom@18.2.0)(react@18.2.0)
+      react-icons:
+        specifier: ^5.0.1
+        version: 5.0.1(react@18.2.0)
       react-syntax-highlighter:
         specifier: ^15.5.0
         version: 15.5.0(react@18.2.0)
@@ -14914,7 +14917,6 @@ packages:
       react: 16.14.0
       scheduler: 0.19.1
     dev: false
-    bundledDependencies: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -14960,6 +14962,14 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
+    dev: false
+
+  /react-icons@5.0.1(react@18.2.0):
+    resolution: {integrity: sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-is@16.13.1:
@@ -15066,7 +15076,6 @@ packages:
       object-assign: 4.1.1
       prop-types: 15.8.1
     dev: false
-    bundledDependencies: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}

--- a/site/package.json
+++ b/site/package.json
@@ -38,6 +38,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.4",
+    "react-icons": "^5.0.1",
     "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {

--- a/site/src/components/MetricsPreview.tsx
+++ b/site/src/components/MetricsPreview.tsx
@@ -1,7 +1,22 @@
 import React, { ChangeEvent, useState, useEffect } from 'react';
-import { Box, Text, Input, FormLabel, IconButton } from '@chakra-ui/react';
+import {
+  Box,
+  Text,
+  Input,
+  FormLabel,
+  IconButton,
+  Icon,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+} from '@chakra-ui/react';
+import { VscJson } from 'react-icons/vsc';
+import { TbRulerMeasure } from 'react-icons/tb';
 import { EditIcon } from '@chakra-ui/icons';
 import { useAppState } from './AppStateContext';
+import Code from './Code';
 
 const Metric = ({
   voffset = 0,
@@ -132,205 +147,250 @@ const MetricsPreview = () => {
   const lineHeightNormal = lineHeightScale * previewFontSize;
 
   return (
-    <Box
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-      pos="relative"
-      paddingBottom={!editMetrics ? [16, 16, 0] : undefined}
-    >
-      {!editMetrics && (
-        <IconButton
-          icon={<EditIcon />}
-          aria-label="Customise font metrics"
-          title="Customise font metrics"
-          variant="outline"
-          borderRadius={20}
-          _hover={{ color: 'pink.500', background: 'transparent' }}
-          _focus={{ boxShadow: 'outline', borderColor: 'transparent' }}
-          _active={{ transform: 'scale(.9)' }}
-          onClick={() => setEditMetrics(true)}
-          color="gray.600"
-          pos="absolute"
-          bottom={0}
-          right={0}
-        />
-      )}
-      <Box maxWidth="100%" display="flex" justifyContent="center">
-        <Box
-          fontSize={previewFontSize}
-          fontFamily={
-            selectedFont.name.indexOf(' ') > -1
-              ? `'${selectedFont.name}'`
-              : selectedFont.name
-          }
-          lineHeight="normal"
-          pos="relative"
-          overflow="auto"
-          paddingLeft="130px" // cater for arrow offsets
-          paddingRight="150px" // cater for arrow offsets
-          paddingTop="40px" // cater for ascender overflow
-          marginTop="-40px" // cater for ascender overflow
-          paddingBottom="60px" // cater for descender overflow
-          marginBottom="-60px" // cater for descender overflow
-        >
-          <Box display="inline-flex" justifyContent="center" pos="relative">
-            <Box
-              pos="absolute"
-              top={0}
-              bottom={0}
-              right={0}
-              left={0}
-              bg="pink.200"
-              opacity={0.3}
-            />
-            <Metric
-              position={previewFontSize}
-              hoffset={20}
-              voffset={(lineHeightNormal - previewFontSize) / 2}
-              label={`Em square (${metrics.unitsPerEm})`}
-              align="right"
-              guides="all"
-            />
+    <Tabs size="sm" variant="soft-rounded" align="center" colorScheme="gray">
+      <TabList position="relative" zIndex={1} mb={8}>
+        <Tab>
+          <Box as="span" mr="2" mt="1">
+            <Icon as={TbRulerMeasure} />
+          </Box>
+          Measurements
+        </Tab>
+        <Tab>
+          <Box as="span" mr="2" mt="1">
+            <Icon as={VscJson} />
+          </Box>{' '}
+          JSON
+        </Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel padding={0}>
+          <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            alignItems="center"
+            pos="relative"
+            paddingBottom={!editMetrics ? [16, 16, 0] : undefined}
+          >
+            {!editMetrics && (
+              <IconButton
+                icon={<EditIcon />}
+                aria-label="Customise font metrics"
+                title="Customise font metrics"
+                variant="outline"
+                borderRadius={20}
+                _hover={{ color: 'pink.500', background: 'transparent' }}
+                _focus={{ boxShadow: 'outline', borderColor: 'transparent' }}
+                _active={{ transform: 'scale(.9)' }}
+                onClick={() => setEditMetrics(true)}
+                color="gray.600"
+                pos="absolute"
+                bottom={0}
+                right={0}
+              />
+            )}
+            <Box maxWidth="100%" display="flex" justifyContent="center">
+              <Box
+                fontSize={previewFontSize}
+                fontFamily={
+                  selectedFont.name.indexOf(' ') > -1
+                    ? `'${selectedFont.name}'`
+                    : selectedFont.name
+                }
+                lineHeight="normal"
+                pos="relative"
+                overflow="auto"
+                paddingLeft="130px" // cater for arrow offsets
+                paddingRight="150px" // cater for arrow offsets
+                paddingTop="40px" // cater for ascender overflow
+                marginTop="-40px" // cater for ascender overflow
+                paddingBottom="60px" // cater for descender overflow
+                marginBottom="-60px" // cater for descender overflow
+              >
+                <Box
+                  display="inline-flex"
+                  justifyContent="center"
+                  pos="relative"
+                >
+                  <Box
+                    pos="absolute"
+                    top={0}
+                    bottom={0}
+                    right={0}
+                    left={0}
+                    bg="pink.200"
+                    opacity={0.3}
+                  />
+                  <Metric
+                    position={previewFontSize}
+                    hoffset={20}
+                    voffset={(lineHeightNormal - previewFontSize) / 2}
+                    label={`Em square (${metrics.unitsPerEm})`}
+                    align="right"
+                    guides="all"
+                  />
 
-            <Metric
-              position={capHeight}
-              hoffset={20}
-              voffset={descent + lineGap / 2}
-              label={`Cap Height (${metrics.capHeight})`}
-            />
+                  <Metric
+                    position={capHeight}
+                    hoffset={20}
+                    voffset={descent + lineGap / 2}
+                    label={`Cap Height (${metrics.capHeight})`}
+                  />
 
-            <Metric
-              position={descent}
-              hoffset={80}
-              voffset={lineGap / 2}
-              label={`Descender (${absoluteDescent})`}
-            />
+                  <Metric
+                    position={descent}
+                    hoffset={80}
+                    voffset={lineGap / 2}
+                    label={`Descender (${absoluteDescent})`}
+                  />
 
-            <Metric
-              position={ascent}
-              hoffset={80}
-              voffset={descent + lineGap / 2}
-              label={`Ascender (${metrics.ascent})`}
-              guides="none"
-            />
+                  <Metric
+                    position={ascent}
+                    hoffset={80}
+                    voffset={descent + lineGap / 2}
+                    label={`Ascender (${metrics.ascent})`}
+                    guides="none"
+                  />
 
-            <Metric
-              position={lineHeightNormal}
-              hoffset={80}
-              label="Line Height"
-              guides="none"
-              align="right"
-            />
+                  <Metric
+                    position={lineHeightNormal}
+                    hoffset={80}
+                    label="Line Height"
+                    guides="none"
+                    align="right"
+                  />
 
-            <Box zIndex={1} color="blue.800">
-              Hg
+                  <Box zIndex={1} color="blue.800">
+                    Hg
+                  </Box>
+                </Box>
+              </Box>
             </Box>
+            {editMetrics && (
+              <Box
+                paddingTop={8}
+                paddingRight={4}
+                display="flex"
+                flexDirection={['column', 'column', 'row']}
+              >
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  paddingBottom={[2, 2, 0]}
+                  paddingX={[0, 6]}
+                >
+                  <FormLabel
+                    htmlFor="customAscent"
+                    whiteSpace="nowrap"
+                    fontSize={['md', 'lg']}
+                    color="gray.500"
+                    flexGrow={1}
+                  >
+                    Ascender
+                  </FormLabel>
+                  <Input
+                    id="customAscent"
+                    value={customMetrics.ascent}
+                    autoFocus
+                    type="number"
+                    onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+                      setCustomMetrics({
+                        ...customMetrics,
+                        ascent: parseInt(ev.currentTarget.value, 10),
+                      });
+                    }}
+                    borderRadius={12}
+                    _focus={{
+                      boxShadow: 'outline',
+                      borderColor: 'transparent',
+                    }}
+                    w="80px"
+                  />
+                </Box>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  paddingBottom={[2, 2, 0]}
+                  paddingX={[0, 6]}
+                >
+                  <FormLabel
+                    htmlFor="customCapHeight"
+                    whiteSpace="nowrap"
+                    fontSize={['md', 'lg']}
+                    color="gray.500"
+                    flexGrow={1}
+                  >
+                    Cap Height
+                  </FormLabel>
+                  <Input
+                    id="customCapHeight"
+                    value={customMetrics.capHeight}
+                    type="number"
+                    onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+                      setCustomMetrics({
+                        ...customMetrics,
+                        capHeight: parseInt(ev.currentTarget.value, 10),
+                      });
+                    }}
+                    borderRadius={12}
+                    _focus={{
+                      boxShadow: 'outline',
+                      borderColor: 'transparent',
+                    }}
+                    w="80px"
+                  />
+                </Box>
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  paddingBottom={[2, 2, 0]}
+                  paddingX={[0, 6]}
+                >
+                  <FormLabel
+                    htmlFor="customDescent"
+                    whiteSpace="nowrap"
+                    fontSize={['md', 'lg']}
+                    color="gray.500"
+                    flexGrow={1}
+                  >
+                    Descender
+                  </FormLabel>
+                  <Input
+                    id="customDescent"
+                    value={customMetrics.descent}
+                    type="number"
+                    onChange={(ev: ChangeEvent<HTMLInputElement>) => {
+                      setCustomMetrics({
+                        ...customMetrics,
+                        descent: parseInt(ev.currentTarget.value, 10),
+                      });
+                    }}
+                    borderRadius={12}
+                    _focus={{
+                      boxShadow: 'outline',
+                      borderColor: 'transparent',
+                    }}
+                    w="80px"
+                  />
+                </Box>
+              </Box>
+            )}
           </Box>
-        </Box>
-      </Box>
-      {editMetrics && (
-        <Box
-          paddingTop={8}
-          paddingRight={4}
-          display="flex"
-          flexDirection={['column', 'column', 'row']}
-        >
+        </TabPanel>
+        <TabPanel padding={0}>
           <Box
+            maxWidth="100%"
             display="flex"
-            alignItems="center"
-            paddingBottom={[2, 2, 0]}
-            paddingX={[0, 6]}
+            justifyContent="center"
+            textAlign="left"
           >
-            <FormLabel
-              htmlFor="customAscent"
-              whiteSpace="nowrap"
-              fontSize={['md', 'lg']}
-              color="gray.500"
-              flexGrow={1}
-            >
-              Ascender
-            </FormLabel>
-            <Input
-              id="customAscent"
-              value={customMetrics.ascent}
-              autoFocus
-              type="number"
-              onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-                setCustomMetrics({
-                  ...customMetrics,
-                  ascent: parseInt(ev.currentTarget.value, 10),
-                });
-              }}
-              borderRadius={12}
-              _focus={{ boxShadow: 'outline', borderColor: 'transparent' }}
-              w="80px"
-            />
+            <Code language="json">
+              {JSON.stringify(metrics, null, 2).replace(/"([^:].*)":/g, `$1:`)}
+            </Code>
           </Box>
-          <Box
-            display="flex"
-            alignItems="center"
-            paddingBottom={[2, 2, 0]}
-            paddingX={[0, 6]}
-          >
-            <FormLabel
-              htmlFor="customCapHeight"
-              whiteSpace="nowrap"
-              fontSize={['md', 'lg']}
-              color="gray.500"
-              flexGrow={1}
-            >
-              Cap Height
-            </FormLabel>
-            <Input
-              id="customCapHeight"
-              value={customMetrics.capHeight}
-              type="number"
-              onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-                setCustomMetrics({
-                  ...customMetrics,
-                  capHeight: parseInt(ev.currentTarget.value, 10),
-                });
-              }}
-              borderRadius={12}
-              _focus={{ boxShadow: 'outline', borderColor: 'transparent' }}
-              w="80px"
-            />
-          </Box>
-          <Box
-            display="flex"
-            alignItems="center"
-            paddingBottom={[2, 2, 0]}
-            paddingX={[0, 6]}
-          >
-            <FormLabel
-              htmlFor="customDescent"
-              whiteSpace="nowrap"
-              fontSize={['md', 'lg']}
-              color="gray.500"
-              flexGrow={1}
-            >
-              Descender
-            </FormLabel>
-            <Input
-              id="customDescent"
-              value={customMetrics.descent}
-              type="number"
-              onChange={(ev: ChangeEvent<HTMLInputElement>) => {
-                setCustomMetrics({
-                  ...customMetrics,
-                  descent: parseInt(ev.currentTarget.value, 10),
-                });
-              }}
-              borderRadius={12}
-              _focus={{ boxShadow: 'outline', borderColor: 'transparent' }}
-              w="80px"
-            />
-          </Box>
-        </Box>
-      )}
-    </Box>
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
   );
 };
 

--- a/site/src/components/MetricsPreview.tsx
+++ b/site/src/components/MetricsPreview.tsx
@@ -158,7 +158,7 @@ const MetricsPreview = () => {
         <Tab>
           <Box as="span" mr="2" mt="1">
             <Icon as={VscJson} />
-          </Box>{' '}
+          </Box>
           JSON
         </Tab>
       </TabList>


### PR DESCRIPTION
Introduce a new tab that makes metric viewing a first class part of the site. When selecting a font the default is still viewing measurements, but optionally a `JSON` tab is now available.

https://github.com/seek-oss/capsize/assets/912060/9e3f90c1-e47f-44ad-8058-2ca509bfd8d5

Closes https://github.com/seek-oss/capsize/issues/66