### PR TITLE
metrics: Prefer public family name to internal `familyName` metrics

### DIFF
--- a/.changeset/funny-trees-listen.md
+++ b/.changeset/funny-trees-listen.md
@@ -1,0 +1,53 @@
+---
+'@capsizecss/metrics': major
+---
+
+metrics: Prefer public family name to internal `familyName` metrics
+
+Ensure metrics are available using the public family name as seen on Google Fonts as opposed to the internal family name metric.
+This makes sense as consumers are looking to import the metrics relevant to a specific system font or from Google Fonts (also aligns with the names Google use in their font declarations generated in the hosted stylesheets).
+
+### BREAKING CHANGES:
+
+#### Google Fonts
+
+Previously, the metrics were imported with a path that used the internal family name, now they align with the font as seen on Google Fonts.
+
+```diff
+-import metrics from '@capsizecss/metrics/roundedMplus1c';
++import metrics from '@capsizecss/metrics/mPLUSRounded1c';
+```
+
+With only a small number of Google Fonts affected, this is only a break for the following fonts:
+- Ballet
+- Bodoni Moda
+- Buda
+- Bungee Spice
+- Fjord One
+- Geologica
+- Imbue
+- M PLUS Rounded 1c
+- Material Symbols Outlined
+- Material Symbols Rounded
+- Material Symbols Sharp
+- Montagu Slab
+- Nanum Pen Script
+- Newsreader
+- Nunito Sans
+- Pathway Extreme
+- Sono
+- Sunflower
+- Supermercado One
+- Texturina
+
+
+#### System fonts
+
+The system fonts only had one example where the names diverged:
+
+```diff
+-import metrics from '@capsizecss/metrics/brushScriptMT';
++import metrics from '@capsizecss/metrics/brushScript';
+```
+
+This now aligns with the name consumers use to reference the font on their system.

--- a/packages/metrics/scripts/extract.ts
+++ b/packages/metrics/scripts/extract.ts
@@ -23,6 +23,7 @@ const extractor: Record<SourceType, typeof fromFile | typeof fromUrl> = {
 };
 
 export type FontSourceList = Array<{
+  family: string;
   variants?: string[];
   files: Record<string, string>;
   category: FontCategory;
@@ -58,17 +59,21 @@ const metricsForFamily = async ({
   });
 
   const result = await queue.addAll(
-    fonts.map(({ files, variants = [], overrides, category }) => async () => {
-      const variant = files.regular ? 'regular' : variants[0];
-      const url = files[variant];
-      const metrics = await extractor[sourceType](url);
+    fonts.map(
+      ({ family, files, variants = [], overrides, category }) =>
+        async () => {
+          const variant = files.regular ? 'regular' : variants[0];
+          const url = files[variant];
+          const metrics = await extractor[sourceType](url);
 
-      return {
-        ...metrics,
-        ...overrides,
-        category,
-      };
-    }),
+          return {
+            ...metrics,
+            ...overrides,
+            familyName: family,
+            category,
+          };
+        },
+    ),
   );
 
   progress.stop();

--- a/packages/metrics/scripts/googleFonts.json
+++ b/packages/metrics/scripts/googleFonts.json
@@ -2534,7 +2534,7 @@
     "category": "display"
   },
   {
-    "familyName": "Ballet 16pt",
+    "familyName": "Ballet",
     "capHeight": 1209,
     "ascent": 1130,
     "descent": -770,
@@ -3824,7 +3824,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Bodoni Moda 11pt",
+    "familyName": "Bodoni Moda",
     "capHeight": 1500,
     "ascent": 2250,
     "descent": -800,
@@ -4166,7 +4166,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Buda Light",
+    "familyName": "Buda",
     "ascent": 1836,
     "descent": -724,
     "lineGap": 0,
@@ -4297,7 +4297,7 @@
     "category": "display"
   },
   {
-    "familyName": "Bungee Spice Regular",
+    "familyName": "Bungee Spice",
     "capHeight": 720,
     "ascent": 860,
     "descent": -140,
@@ -8239,7 +8239,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Fjord",
+    "familyName": "Fjord One",
     "capHeight": 1448,
     "ascent": 1940,
     "descent": -620,
@@ -9056,7 +9056,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Geologica Roman",
+    "familyName": "Geologica",
     "capHeight": 1400,
     "ascent": 1950,
     "descent": -550,
@@ -10192,7 +10192,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "HeadlandOne",
+    "familyName": "Headland One",
     "capHeight": 1530,
     "ascent": 2043,
     "descent": -522,
@@ -10781,7 +10781,7 @@
     "category": "display"
   },
   {
-    "familyName": "IM FELL Double Pica",
+    "familyName": "IM Fell Double Pica",
     "capHeight": 1509,
     "ascent": 1924,
     "descent": -643,
@@ -10800,7 +10800,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL Double Pica SC",
+    "familyName": "IM Fell Double Pica SC",
     "capHeight": 1509,
     "ascent": 1924,
     "descent": -643,
@@ -10819,7 +10819,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL DW Pica",
+    "familyName": "IM Fell DW Pica",
     "capHeight": 1438,
     "ascent": 1868,
     "descent": -692,
@@ -10838,7 +10838,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL DW Pica SC",
+    "familyName": "IM Fell DW Pica SC",
     "capHeight": 1438,
     "ascent": 1868,
     "descent": -692,
@@ -10857,7 +10857,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL English",
+    "familyName": "IM Fell English",
     "capHeight": 1417,
     "ascent": 1854,
     "descent": -744,
@@ -10876,7 +10876,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL English SC",
+    "familyName": "IM Fell English SC",
     "capHeight": 1417,
     "ascent": 1854,
     "descent": -744,
@@ -10895,7 +10895,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL French Canon",
+    "familyName": "IM Fell French Canon",
     "capHeight": 1465,
     "ascent": 1868,
     "descent": -530,
@@ -10914,7 +10914,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL French Canon SC",
+    "familyName": "IM Fell French Canon SC",
     "capHeight": 1465,
     "ascent": 1868,
     "descent": -530,
@@ -10933,7 +10933,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL Great Primer",
+    "familyName": "IM Fell Great Primer",
     "capHeight": 1488,
     "ascent": 1942,
     "descent": -562,
@@ -10952,7 +10952,7 @@
     "category": "serif"
   },
   {
-    "familyName": "IM FELL Great Primer SC",
+    "familyName": "IM Fell Great Primer SC",
     "capHeight": 1488,
     "ascent": 1942,
     "descent": -562,
@@ -10971,7 +10971,7 @@
     "category": "serif"
   },
   {
-    "familyName": "Imbue 10pt",
+    "familyName": "Imbue",
     "capHeight": 1400,
     "ascent": 1900,
     "descent": -500,
@@ -14233,6 +14233,23 @@
     "category": "sans-serif"
   },
   {
+    "familyName": "M PLUS Rounded 1c",
+    "ascent": 1075,
+    "descent": -320,
+    "lineGap": 90,
+    "unitsPerEm": 1000,
+    "xWidthAvg": 476,
+    "subsets": {
+      "latin": {
+        "xWidthAvg": 476
+      },
+      "thai": {
+        "xWidthAvg": 364
+      }
+    },
+    "category": "sans-serif"
+  },
+  {
     "familyName": "Ma Shan Zheng",
     "capHeight": 760,
     "ascent": 880,
@@ -14898,7 +14915,7 @@
     "category": "monospace"
   },
   {
-    "familyName": "Material Symbols Outlined 24pt",
+    "familyName": "Material Symbols Outlined",
     "capHeight": 960,
     "ascent": 1056,
     "descent": -96,
@@ -14917,7 +14934,7 @@
     "category": "monospace"
   },
   {
-    "familyName": "Material Symbols Rounded 24pt",
+    "familyName": "Material Symbols Rounded",
     "capHeight": 960,
     "ascent": 1056,
     "descent": -96,
@@ -14936,7 +14953,7 @@
     "category": "monospace"
   },
   {
-    "familyName": "Material Symbols Sharp 24pt",
+    "familyName": "Material Symbols Sharp",
     "capHeight": 960,
     "ascent": 1056,
     "descent": -96,
@@ -15770,7 +15787,7 @@
     "category": "serif"
   },
   {
-    "familyName": "Montagu Slab 144pt",
+    "familyName": "Montagu Slab",
     "capHeight": 682,
     "ascent": 982,
     "descent": -300,
@@ -16359,26 +16376,7 @@
     "category": "handwriting"
   },
   {
-    "familyName": "Nanum Pen",
-    "capHeight": 674,
-    "ascent": 920,
-    "descent": -230,
-    "lineGap": 0,
-    "unitsPerEm": 1000,
-    "xHeight": 476,
-    "xWidthAvg": 354,
-    "subsets": {
-      "latin": {
-        "xWidthAvg": 354
-      },
-      "thai": {
-        "xWidthAvg": 940
-      }
-    },
-    "category": "handwriting"
-  },
-  {
-    "familyName": "NanumGothic",
+    "familyName": "Nanum Gothic",
     "capHeight": 700,
     "ascent": 920,
     "descent": -230,
@@ -16397,7 +16395,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "NanumGothicCoding",
+    "familyName": "Nanum Gothic Coding",
     "capHeight": 699,
     "ascent": 800,
     "descent": -200,
@@ -16416,7 +16414,7 @@
     "category": "handwriting"
   },
   {
-    "familyName": "NanumMyeongjo",
+    "familyName": "Nanum Myeongjo",
     "capHeight": 755,
     "ascent": 942,
     "descent": -236,
@@ -16433,6 +16431,25 @@
       }
     },
     "category": "serif"
+  },
+  {
+    "familyName": "Nanum Pen Script",
+    "capHeight": 674,
+    "ascent": 920,
+    "descent": -230,
+    "lineGap": 0,
+    "unitsPerEm": 1000,
+    "xHeight": 476,
+    "xWidthAvg": 354,
+    "subsets": {
+      "latin": {
+        "xWidthAvg": 354
+      },
+      "thai": {
+        "xWidthAvg": 940
+      }
+    },
+    "category": "handwriting"
   },
   {
     "familyName": "Narnoor",
@@ -16585,7 +16602,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Newsreader 16pt",
+    "familyName": "Newsreader",
     "capHeight": 1340,
     "ascent": 1470,
     "descent": -530,
@@ -19093,7 +19110,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Noto Sans PhagsPa",
+    "familyName": "Noto Sans Phags Pa",
     "capHeight": 670,
     "ascent": 1069,
     "descent": -293,
@@ -20765,6 +20782,25 @@
     "category": "display"
   },
   {
+    "familyName": "Nova Mono",
+    "capHeight": 1509,
+    "ascent": 2215,
+    "descent": -639,
+    "lineGap": 0,
+    "unitsPerEm": 2048,
+    "xHeight": 1120,
+    "xWidthAvg": 1150,
+    "subsets": {
+      "latin": {
+        "xWidthAvg": 1150
+      },
+      "thai": {
+        "xWidthAvg": 1150
+      }
+    },
+    "category": "monospace"
+  },
+  {
     "familyName": "Nova Oval",
     "capHeight": 1550,
     "ascent": 1966,
@@ -20860,25 +20896,6 @@
     "category": "display"
   },
   {
-    "familyName": "NovaMono",
-    "capHeight": 1509,
-    "ascent": 2215,
-    "descent": -639,
-    "lineGap": 0,
-    "unitsPerEm": 2048,
-    "xHeight": 1120,
-    "xWidthAvg": 1150,
-    "subsets": {
-      "latin": {
-        "xWidthAvg": 1150
-      },
-      "thai": {
-        "xWidthAvg": 1150
-      }
-    },
-    "category": "monospace"
-  },
-  {
     "familyName": "NTR",
     "capHeight": 572,
     "ascent": 1294,
@@ -20936,7 +20953,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Nunito Sans 12pt",
+    "familyName": "Nunito Sans",
     "capHeight": 705,
     "ascent": 1011,
     "descent": -353,
@@ -21770,7 +21787,7 @@
     "category": "handwriting"
   },
   {
-    "familyName": "Pathway Extreme 12pt",
+    "familyName": "Pathway Extreme",
     "capHeight": 700,
     "ascent": 1070,
     "descent": -286,
@@ -22414,7 +22431,7 @@
     "category": "serif"
   },
   {
-    "familyName": "Pompiere ",
+    "familyName": "Pompiere",
     "capHeight": 1315,
     "ascent": 1918,
     "descent": -543,
@@ -24200,23 +24217,6 @@
     "category": "handwriting"
   },
   {
-    "familyName": "Rounded Mplus 1c",
-    "ascent": 1075,
-    "descent": -320,
-    "lineGap": 90,
-    "unitsPerEm": 1000,
-    "xWidthAvg": 476,
-    "subsets": {
-      "latin": {
-        "xWidthAvg": 476
-      },
-      "thai": {
-        "xWidthAvg": 364
-      }
-    },
-    "category": "sans-serif"
-  },
-  {
     "familyName": "Rowdies",
     "capHeight": 708,
     "ascent": 997,
@@ -24939,7 +24939,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Saira ExtraCondensed",
+    "familyName": "Saira Extra Condensed",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
@@ -24958,7 +24958,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Saira SemiCondensed",
+    "familyName": "Saira Semi Condensed",
     "capHeight": 688,
     "ascent": 1135,
     "descent": -439,
@@ -25965,7 +25965,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "SirinStencil",
+    "familyName": "Sirin Stencil",
     "capHeight": 1423,
     "ascent": 2380,
     "descent": -604,
@@ -26419,7 +26419,7 @@
     "category": "serif"
   },
   {
-    "familyName": "Sono Monospace",
+    "familyName": "Sono",
     "capHeight": 1238,
     "ascent": 1824,
     "descent": -576,
@@ -27103,7 +27103,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Sue Ellen Francisco ",
+    "familyName": "Sue Ellen Francisco",
     "capHeight": 1085,
     "ascent": 1362,
     "descent": -634,
@@ -27179,7 +27179,7 @@
     "category": "serif"
   },
   {
-    "familyName": "Sunflower Light",
+    "familyName": "Sunflower",
     "capHeight": 692,
     "ascent": 782,
     "descent": -218,
@@ -27217,7 +27217,7 @@
     "category": "handwriting"
   },
   {
-    "familyName": "Supermercado",
+    "familyName": "Supermercado One",
     "capHeight": 1359,
     "ascent": 1925,
     "descent": -527,
@@ -27654,7 +27654,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Texturina 12pt",
+    "familyName": "Texturina",
     "capHeight": 704,
     "ascent": 1260,
     "descent": -300,
@@ -28830,7 +28830,7 @@
     "category": "monospace"
   },
   {
-    "familyName": "Vidaloka ",
+    "familyName": "Vidaloka",
     "capHeight": 1427,
     "ascent": 1927,
     "descent": -560,

--- a/packages/metrics/scripts/source-data/systemFontsData.ts
+++ b/packages/metrics/scripts/source-data/systemFontsData.ts
@@ -8,7 +8,7 @@ if (!fontDirectory) {
   );
 }
 
-const sfProBase = {
+const sfProBase: Omit<FontSourceList[number], 'family'> = {
   category: 'sans-serif',
   files: {
     regular: `${fontDirectory}/SF Pro.ttf`,
@@ -21,25 +21,21 @@ const sfProBase = {
 const systemFonts: FontSourceList = [
   {
     ...sfProBase,
-    overrides: {
-      ...sfProBase.overrides,
-      familyName: '-apple-system',
-    },
+    family: '-apple-system',
   },
   {
     ...sfProBase,
-    overrides: {
-      ...sfProBase.overrides,
-      familyName: 'BlinkMacSystemFont',
-    },
+    family: 'BlinkMacSystemFont',
   },
   {
+    family: 'Arial',
     files: {
       regular: `${fontDirectory}/Arial.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Brush Script',
     files: {
       regular: `${fontDirectory}/Brush Script.ttf`,
     },
@@ -50,42 +46,49 @@ const systemFonts: FontSourceList = [
     },
   },
   {
+    family: 'Courier New',
     files: {
       regular: `${fontDirectory}/Courier New.ttf`,
     },
     category: 'monospace',
   },
   {
+    family: 'Georgia',
     files: {
       regular: `${fontDirectory}/Georgia.ttf`,
     },
     category: 'serif',
   },
   {
+    family: 'Helvetica',
     files: {
       regular: `${fontDirectory}/Helvetica.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Helvetica Neue',
     files: {
       regular: `${fontDirectory}/Helvetica Neue.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Segoe UI',
     files: {
       regular: `${fontDirectory}/Segoe UI.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Lucida Grande',
     files: {
       regular: `${fontDirectory}/Lucida Grande.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Oxygen',
     files: {
       regular: `${fontDirectory}/Oxygen.ttf`,
     },
@@ -96,24 +99,28 @@ const systemFonts: FontSourceList = [
     },
   },
   {
+    family: 'Roboto',
     files: {
       regular: `${fontDirectory}/Roboto.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Tahoma',
     files: {
       regular: `${fontDirectory}/Tahoma.ttf`,
     },
     category: 'sans-serif',
   },
   {
+    family: 'Times New Roman',
     files: {
       regular: `${fontDirectory}/Times New Roman.ttf`,
     },
     category: 'serif',
   },
   {
+    family: 'Trebuchet MS',
     files: {
       regular: `${fontDirectory}/Trebuchet MS.ttf`,
     },
@@ -124,6 +131,7 @@ const systemFonts: FontSourceList = [
     },
   },
   {
+    family: 'Verdana',
     files: {
       regular: `${fontDirectory}/Verdana.ttf`,
     },

--- a/packages/metrics/scripts/systemFonts.json
+++ b/packages/metrics/scripts/systemFonts.json
@@ -57,7 +57,7 @@
     "category": "sans-serif"
   },
   {
-    "familyName": "Brush Script MT",
+    "familyName": "Brush Script",
     "capHeight": 1230,
     "ascent": 1820,
     "descent": -692,

--- a/packages/metrics/src/entireMetricsCollection.json
+++ b/packages/metrics/src/entireMetricsCollection.json
@@ -2647,8 +2647,8 @@
       }
     }
   },
-  "ballet16pt": {
-    "familyName": "Ballet 16pt",
+  "ballet": {
+    "familyName": "Ballet",
     "category": "handwriting",
     "capHeight": 1209,
     "ascent": 1130,
@@ -3880,8 +3880,8 @@
       }
     }
   },
-  "bodoniModa11pt": {
-    "familyName": "Bodoni Moda 11pt",
+  "bodoniModa": {
+    "familyName": "Bodoni Moda",
     "category": "serif",
     "capHeight": 1500,
     "ascent": 2250,
@@ -4165,8 +4165,8 @@
       }
     }
   },
-  "brushScriptMT": {
-    "familyName": "Brush Script MT",
+  "brushScript": {
+    "familyName": "Brush Script",
     "category": "handwriting",
     "capHeight": 1230,
     "ascent": 1820,
@@ -4241,8 +4241,8 @@
       }
     }
   },
-  "budaLight": {
-    "familyName": "Buda Light",
+  "buda": {
+    "familyName": "Buda",
     "category": "display",
     "ascent": 1836,
     "descent": -724,
@@ -4372,8 +4372,8 @@
       }
     }
   },
-  "bungeeSpiceRegular": {
-    "familyName": "Bungee Spice Regular",
+  "bungeeSpice": {
+    "familyName": "Bungee Spice",
     "category": "display",
     "capHeight": 720,
     "ascent": 860,
@@ -8333,8 +8333,8 @@
       }
     }
   },
-  "fjord": {
-    "familyName": "Fjord",
+  "fjordOne": {
+    "familyName": "Fjord One",
     "category": "serif",
     "capHeight": 1448,
     "ascent": 1940,
@@ -9188,8 +9188,8 @@
       }
     }
   },
-  "geologicaRoman": {
-    "familyName": "Geologica Roman",
+  "geologica": {
+    "familyName": "Geologica",
     "category": "sans-serif",
     "capHeight": 1400,
     "ascent": 1950,
@@ -10306,7 +10306,7 @@
     }
   },
   "headlandOne": {
-    "familyName": "HeadlandOne",
+    "familyName": "Headland One",
     "category": "serif",
     "capHeight": 1530,
     "ascent": 2043,
@@ -10875,8 +10875,8 @@
       }
     }
   },
-  "iMFELLDWPica": {
-    "familyName": "IM FELL DW Pica",
+  "iMFellDWPica": {
+    "familyName": "IM Fell DW Pica",
     "category": "serif",
     "capHeight": 1438,
     "ascent": 1868,
@@ -10894,8 +10894,8 @@
       }
     }
   },
-  "iMFELLDWPicaSC": {
-    "familyName": "IM FELL DW Pica SC",
+  "iMFellDWPicaSC": {
+    "familyName": "IM Fell DW Pica SC",
     "category": "serif",
     "capHeight": 1438,
     "ascent": 1868,
@@ -10913,8 +10913,8 @@
       }
     }
   },
-  "iMFELLDoublePica": {
-    "familyName": "IM FELL Double Pica",
+  "iMFellDoublePica": {
+    "familyName": "IM Fell Double Pica",
     "category": "serif",
     "capHeight": 1509,
     "ascent": 1924,
@@ -10932,8 +10932,8 @@
       }
     }
   },
-  "iMFELLDoublePicaSC": {
-    "familyName": "IM FELL Double Pica SC",
+  "iMFellDoublePicaSC": {
+    "familyName": "IM Fell Double Pica SC",
     "category": "serif",
     "capHeight": 1509,
     "ascent": 1924,
@@ -10951,8 +10951,8 @@
       }
     }
   },
-  "iMFELLEnglish": {
-    "familyName": "IM FELL English",
+  "iMFellEnglish": {
+    "familyName": "IM Fell English",
     "category": "serif",
     "capHeight": 1417,
     "ascent": 1854,
@@ -10970,8 +10970,8 @@
       }
     }
   },
-  "iMFELLEnglishSC": {
-    "familyName": "IM FELL English SC",
+  "iMFellEnglishSC": {
+    "familyName": "IM Fell English SC",
     "category": "serif",
     "capHeight": 1417,
     "ascent": 1854,
@@ -10989,8 +10989,8 @@
       }
     }
   },
-  "iMFELLFrenchCanon": {
-    "familyName": "IM FELL French Canon",
+  "iMFellFrenchCanon": {
+    "familyName": "IM Fell French Canon",
     "category": "serif",
     "capHeight": 1465,
     "ascent": 1868,
@@ -11008,8 +11008,8 @@
       }
     }
   },
-  "iMFELLFrenchCanonSC": {
-    "familyName": "IM FELL French Canon SC",
+  "iMFellFrenchCanonSC": {
+    "familyName": "IM Fell French Canon SC",
     "category": "serif",
     "capHeight": 1465,
     "ascent": 1868,
@@ -11027,8 +11027,8 @@
       }
     }
   },
-  "iMFELLGreatPrimer": {
-    "familyName": "IM FELL Great Primer",
+  "iMFellGreatPrimer": {
+    "familyName": "IM Fell Great Primer",
     "category": "serif",
     "capHeight": 1488,
     "ascent": 1942,
@@ -11046,8 +11046,8 @@
       }
     }
   },
-  "iMFELLGreatPrimerSC": {
-    "familyName": "IM FELL Great Primer SC",
+  "iMFellGreatPrimerSC": {
+    "familyName": "IM Fell Great Primer SC",
     "category": "serif",
     "capHeight": 1488,
     "ascent": 1942,
@@ -11122,8 +11122,8 @@
       }
     }
   },
-  "imbue10pt": {
-    "familyName": "Imbue 10pt",
+  "imbue": {
+    "familyName": "Imbue",
     "category": "serif",
     "capHeight": 1400,
     "ascent": 1900,
@@ -14403,6 +14403,23 @@
       }
     }
   },
+  "mPLUSRounded1c": {
+    "familyName": "M PLUS Rounded 1c",
+    "category": "sans-serif",
+    "ascent": 1075,
+    "descent": -320,
+    "lineGap": 90,
+    "unitsPerEm": 1000,
+    "xWidthAvg": 476,
+    "subsets": {
+      "latin": {
+        "xWidthAvg": 476
+      },
+      "thai": {
+        "xWidthAvg": 364
+      }
+    }
+  },
   "maShanZheng": {
     "familyName": "Ma Shan Zheng",
     "category": "handwriting",
@@ -15068,8 +15085,8 @@
       }
     }
   },
-  "materialSymbolsOutlined24pt": {
-    "familyName": "Material Symbols Outlined 24pt",
+  "materialSymbolsOutlined": {
+    "familyName": "Material Symbols Outlined",
     "category": "monospace",
     "capHeight": 960,
     "ascent": 1056,
@@ -15087,8 +15104,8 @@
       }
     }
   },
-  "materialSymbolsRounded24pt": {
-    "familyName": "Material Symbols Rounded 24pt",
+  "materialSymbolsRounded": {
+    "familyName": "Material Symbols Rounded",
     "category": "monospace",
     "capHeight": 960,
     "ascent": 1056,
@@ -15106,8 +15123,8 @@
       }
     }
   },
-  "materialSymbolsSharp24pt": {
-    "familyName": "Material Symbols Sharp 24pt",
+  "materialSymbolsSharp": {
+    "familyName": "Material Symbols Sharp",
     "category": "monospace",
     "capHeight": 960,
     "ascent": 1056,
@@ -15940,8 +15957,8 @@
       }
     }
   },
-  "montaguSlab144pt": {
-    "familyName": "Montagu Slab 144pt",
+  "montaguSlab": {
+    "familyName": "Montagu Slab",
     "category": "serif",
     "capHeight": 682,
     "ascent": 982,
@@ -16549,7 +16566,7 @@
     }
   },
   "nanumGothic": {
-    "familyName": "NanumGothic",
+    "familyName": "Nanum Gothic",
     "category": "sans-serif",
     "capHeight": 700,
     "ascent": 920,
@@ -16568,7 +16585,7 @@
     }
   },
   "nanumGothicCoding": {
-    "familyName": "NanumGothicCoding",
+    "familyName": "Nanum Gothic Coding",
     "category": "handwriting",
     "capHeight": 699,
     "ascent": 800,
@@ -16587,7 +16604,7 @@
     }
   },
   "nanumMyeongjo": {
-    "familyName": "NanumMyeongjo",
+    "familyName": "Nanum Myeongjo",
     "category": "serif",
     "capHeight": 755,
     "ascent": 942,
@@ -16605,8 +16622,8 @@
       }
     }
   },
-  "nanumPen": {
-    "familyName": "Nanum Pen",
+  "nanumPenScript": {
+    "familyName": "Nanum Pen Script",
     "category": "handwriting",
     "capHeight": 674,
     "ascent": 920,
@@ -16774,8 +16791,8 @@
       }
     }
   },
-  "newsreader16pt": {
-    "familyName": "Newsreader 16pt",
+  "newsreader": {
+    "familyName": "Newsreader",
     "category": "serif",
     "capHeight": 1340,
     "ascent": 1470,
@@ -19283,7 +19300,7 @@
     }
   },
   "notoSansPhagsPa": {
-    "familyName": "Noto Sans PhagsPa",
+    "familyName": "Noto Sans Phags Pa",
     "category": "sans-serif",
     "capHeight": 670,
     "ascent": 1069,
@@ -20955,7 +20972,7 @@
     }
   },
   "novaMono": {
-    "familyName": "NovaMono",
+    "familyName": "Nova Mono",
     "category": "monospace",
     "capHeight": 1509,
     "ascent": 2215,
@@ -21106,8 +21123,8 @@
       }
     }
   },
-  "nunitoSans12pt": {
-    "familyName": "Nunito Sans 12pt",
+  "nunitoSans": {
+    "familyName": "Nunito Sans",
     "category": "sans-serif",
     "capHeight": 705,
     "ascent": 1011,
@@ -22054,8 +22071,8 @@
       }
     }
   },
-  "pathwayExtreme12pt": {
-    "familyName": "Pathway Extreme 12pt",
+  "pathwayExtreme": {
+    "familyName": "Pathway Extreme",
     "category": "sans-serif",
     "capHeight": 700,
     "ascent": 1070,
@@ -22699,7 +22716,7 @@
     }
   },
   "pompiere": {
-    "familyName": "Pompiere ",
+    "familyName": "Pompiere",
     "category": "display",
     "capHeight": 1315,
     "ascent": 1918,
@@ -24370,23 +24387,6 @@
       }
     }
   },
-  "roundedMplus1c": {
-    "familyName": "Rounded Mplus 1c",
-    "category": "sans-serif",
-    "ascent": 1075,
-    "descent": -320,
-    "lineGap": 90,
-    "unitsPerEm": 1000,
-    "xWidthAvg": 476,
-    "subsets": {
-      "latin": {
-        "xWidthAvg": 476
-      },
-      "thai": {
-        "xWidthAvg": 364
-      }
-    }
-  },
   "rowdies": {
     "familyName": "Rowdies",
     "category": "display",
@@ -25129,7 +25129,7 @@
     }
   },
   "sairaExtraCondensed": {
-    "familyName": "Saira ExtraCondensed",
+    "familyName": "Saira Extra Condensed",
     "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
@@ -25148,7 +25148,7 @@
     }
   },
   "sairaSemiCondensed": {
-    "familyName": "Saira SemiCondensed",
+    "familyName": "Saira Semi Condensed",
     "category": "sans-serif",
     "capHeight": 688,
     "ascent": 1135,
@@ -26174,7 +26174,7 @@
     }
   },
   "sirinStencil": {
-    "familyName": "SirinStencil",
+    "familyName": "Sirin Stencil",
     "category": "display",
     "capHeight": 1423,
     "ascent": 2380,
@@ -26627,8 +26627,8 @@
       }
     }
   },
-  "sonoMonospace": {
-    "familyName": "Sono Monospace",
+  "sono": {
+    "familyName": "Sono",
     "category": "sans-serif",
     "capHeight": 1238,
     "ascent": 1824,
@@ -27293,7 +27293,7 @@
     }
   },
   "sueEllenFrancisco": {
-    "familyName": "Sue Ellen Francisco ",
+    "familyName": "Sue Ellen Francisco",
     "category": "handwriting",
     "capHeight": 1085,
     "ascent": 1362,
@@ -27368,8 +27368,8 @@
       }
     }
   },
-  "sunflowerLight": {
-    "familyName": "Sunflower Light",
+  "sunflower": {
+    "familyName": "Sunflower",
     "category": "sans-serif",
     "capHeight": 692,
     "ascent": 782,
@@ -27406,8 +27406,8 @@
       }
     }
   },
-  "supermercado": {
-    "familyName": "Supermercado",
+  "supermercadoOne": {
+    "familyName": "Supermercado One",
     "category": "display",
     "capHeight": 1359,
     "ascent": 1925,
@@ -27862,8 +27862,8 @@
       }
     }
   },
-  "texturina12pt": {
-    "familyName": "Texturina 12pt",
+  "texturina": {
+    "familyName": "Texturina",
     "category": "serif",
     "capHeight": 704,
     "ascent": 1260,
@@ -29115,7 +29115,7 @@
     }
   },
   "vidaloka": {
-    "familyName": "Vidaloka ",
+    "familyName": "Vidaloka",
     "category": "serif",
     "capHeight": 1427,
     "ascent": 1927,


### PR DESCRIPTION
Ensure metrics are available using the public family name as seen on Google Fonts as opposed to the internal family name metric.
This makes sense as consumers are looking to import the metrics relevant to a specific system font or from Google Fonts (also aligns with the names Google use in their font declarations generated in the hosted stylesheets).

### BREAKING CHANGES:

#### Google Fonts

Previously, the metrics were imported with a path that used the internal family name, now they align with the font as seen on Google Fonts.

```diff
-import metrics from '@capsizecss/metrics/roundedMplus1c';
+import metrics from '@capsizecss/metrics/mPLUSRounded1c';
```

With only a small number of Google Fonts affected, this is only a break for the following fonts:
- Ballet
- Bodoni Moda
- Buda
- Bungee Spice
- Fjord One
- Geologica
- Imbue
- M PLUS Rounded 1c
- Material Symbols Outlined
- Material Symbols Rounded
- Material Symbols Sharp
- Montagu Slab
- Nanum Pen Script
- Newsreader
- Nunito Sans
- Pathway Extreme
- Sono
- Sunflower
- Supermercado One
- Texturina

#### System fonts

The system fonts only had one example where the names diverged:

```diff
-import metrics from '@capsizecss/metrics/brushScriptMT';
+import metrics from '@capsizecss/metrics/brushScript';
```

This now aligns with the name consumers use to reference the font on their system.

--- 

Closes https://github.com/seek-oss/capsize/issues/189