### PR TITLE
metrics: Update apple system font metrics

### DIFF
--- a/.changeset/curvy-forks-brush.md
+++ b/.changeset/curvy-forks-brush.md
@@ -6,5 +6,5 @@ metrics: Update apple system font metrics
 
 Previously the metrics provided for `-apple-system` and `BlinkMacSystemFont` were extracted from the `SF Pro` font, with a custom override to correct the `descent` metric.
 
-Through upcoming work to support font weights and styles, it has been identified that MacOS uses the `SFNS` font.
+Through work to support metrics for different font weights and styles, it was identified that MacOS uses the `SFNS` font.
 Extracting the metrics from this font means no more custom overrides, and will now enable using this font as a fallback via postscript name soon too.

--- a/.changeset/curvy-forks-brush.md
+++ b/.changeset/curvy-forks-brush.md
@@ -1,0 +1,10 @@
+---
+'@capsizecss/metrics': patch
+---
+
+metrics: Update apple system font metrics
+
+Previously the metrics provided for `-apple-system` and `BlinkMacSystemFont` were extracted from the `SF Pro` font, with a custom override to correct the `descent` metric.
+
+Through upcoming work to support font weights and styles, it has been identified that MacOS uses the `SFNS` font.
+Extracting the metrics from this font means no more custom overrides, and will now enable using this font as a fallback via postscript name soon too.

--- a/packages/metrics/scripts/source-data/systemFontsData.ts
+++ b/packages/metrics/scripts/source-data/systemFontsData.ts
@@ -8,23 +8,20 @@ if (!fontDirectory) {
   );
 }
 
-const sfProBase: Omit<FontSourceList[number], 'family'> = {
+const sfNSBase: Omit<FontSourceList[number], 'family'> = {
   category: 'sans-serif',
   files: {
-    regular: `${fontDirectory}/SF Pro.ttf`,
-  },
-  overrides: {
-    descent: -420,
+    regular: `${fontDirectory}/SFNS.ttf`,
   },
 } as const;
 
 const systemFonts: FontSourceList = [
   {
-    ...sfProBase,
+    ...sfNSBase,
     family: '-apple-system',
   },
   {
-    ...sfProBase,
+    ...sfNSBase,
     family: 'BlinkMacSystemFont',
   },
   {

--- a/packages/metrics/scripts/systemFonts.json
+++ b/packages/metrics/scripts/systemFonts.json
@@ -2,8 +2,8 @@
   {
     "familyName": "-apple-system",
     "capHeight": 1443,
-    "ascent": 1950,
-    "descent": -420,
+    "ascent": 1980,
+    "descent": -432,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1040,
@@ -40,8 +40,8 @@
   {
     "familyName": "BlinkMacSystemFont",
     "capHeight": 1443,
-    "ascent": 1950,
-    "descent": -420,
+    "ascent": 1980,
+    "descent": -432,
     "lineGap": 0,
     "unitsPerEm": 2048,
     "xHeight": 1040,


### PR DESCRIPTION
metrics: Update apple system font metrics

Previously the metrics provided for `-apple-system` and `BlinkMacSystemFont` were extracted from the `SF Pro` font, with a custom override to correct the `descent` metric.

Through work to support metrics for different font weights and styles, it was identified that MacOS uses the `SFNS` font.
Extracting the metrics from this font means no more custom overrides, and will now enable using this font as a fallback via postscript name soon too.

#### SF Pro Metrics
![SF Pro Metrics Preview](https://github.com/seek-oss/capsize/assets/912060/291f5ee5-65ed-45e8-8cf7-b2ac2acc2c09)

#### SF Pro Metrics (with `descent` override)
![SF Pro Override Metrics Preview](https://github.com/seek-oss/capsize/assets/912060/7d1679ee-dcc8-4f6f-a3e1-00c2a4c69db0)

#### SFNS Metrics
![SFNS Metrics Preview](https://github.com/seek-oss/capsize/assets/912060/ed1ad29d-d960-4d6c-b02c-bd599ffee42f)