### PR TITLE
site: Dont focus slider thumb on value change

### DIFF
--- a/site/src/components/CapSizeSelector.tsx
+++ b/site/src/components/CapSizeSelector.tsx
@@ -93,6 +93,7 @@ const Setting = ({
         onFocus={onFocus}
         onBlur={onBlur}
         onChange={onChange}
+        focusThumbOnChange={false}
         opacity={!active ? 0 : undefined}
         transition="opacity .2s ease-in"
         pointerEvents={!active ? 'none' : undefined}


### PR DESCRIPTION
Fixes a particularly annoying bug in the site since we [upgraded all the things](#160). By default, the Chakra `Slider` component will focus the thumb on change, meaning if you change the value in the text box, the focus shifts to the thumb.

Super annoying, easy fix 😄 