### PR TITLE
Use logical instead of physical block margins

### DIFF
--- a/packages/core/src/createStyleObject.test.ts
+++ b/packages/core/src/createStyleObject.test.ts
@@ -20,12 +20,12 @@ describe('createStyleObject', () => {
         "::after": {
           "content": "''",
           "display": "table",
-          "marginTop": "-0.2626em",
+          "marginBlockStart": "-0.2626em",
         },
         "::before": {
           "content": "''",
           "display": "table",
-          "marginBottom": "-0.2753em",
+          "marginBlockEnd": "-0.2753em",
         },
         "fontSize": "150px",
         "lineHeight": "180px",
@@ -43,12 +43,12 @@ describe('createStyleObject', () => {
         "::after": {
           "content": "''",
           "display": "table",
-          "marginTop": "-0.2375em",
+          "marginBlockStart": "-0.2375em",
         },
         "::before": {
           "content": "''",
           "display": "table",
-          "marginBottom": "-0.2502em",
+          "marginBlockEnd": "-0.2502em",
         },
         "fontSize": "150px",
         "lineHeight": "normal",
@@ -68,12 +68,12 @@ describe('createStyleObject', () => {
         "::after": {
           "content": "''",
           "display": "table",
-          "marginTop": "-0.2626em",
+          "marginBlockStart": "-0.2626em",
         },
         "::before": {
           "content": "''",
           "display": "table",
-          "marginBottom": "-0.2753em",
+          "marginBlockEnd": "-0.2753em",
         },
         "fontSize": "150px",
         "lineHeight": "180px",

--- a/packages/core/src/createStyleObject.ts
+++ b/packages/core/src/createStyleObject.ts
@@ -12,12 +12,12 @@ const _createStyleObject = ({
     lineHeight,
     '::before': {
       content: "''",
-      marginBottom: capHeightTrim,
+      marginBlockEnd: capHeightTrim,
       display: 'table',
     },
     '::after': {
       content: "''",
-      marginTop: baselineTrim,
+      marginBlockStart: baselineTrim,
       display: 'table',
     },
   };

--- a/packages/core/src/createStyleString.test.ts
+++ b/packages/core/src/createStyleString.test.ts
@@ -22,13 +22,13 @@ describe('createStyleString', () => {
 
       .testClassName::before {
         content: "";
-        margin-bottom: -0.2753em;
+        margin-block-end: -0.2753em;
         display: table;
       }
 
       .testClassName::after {
         content: "";
-        margin-top: -0.2626em;
+        margin-block-start: -0.2626em;
         display: table;
       }"
     `);
@@ -50,13 +50,13 @@ describe('createStyleString', () => {
 
       .testClassName::before {
         content: "";
-        margin-bottom: -0.2753em;
+        margin-block-end: -0.2753em;
         display: table;
       }
 
       .testClassName::after {
         content: "";
-        margin-top: -0.2626em;
+        margin-block-start: -0.2626em;
         display: table;
       }"
     `);

--- a/site/src/components/Preview.tsx
+++ b/site/src/components/Preview.tsx
@@ -91,7 +91,7 @@ const Preview = () => {
             backgroundSize: `100% ${resolvedCapHeightFromFontSize + lineGap}px`,
             backgroundPosition: `0 calc((${
               (resolvedCapHeightFromFontSize + lineGap - lineHeightNormal) / 2
-            }px) + ${capsizeStyles?.['::before'].marginBottom})`,
+            }px) + ${capsizeStyles?.['::before'].marginBlockEnd})`,
           }
         : {
             ...highlightGradient(
@@ -100,7 +100,7 @@ const Preview = () => {
             ),
             backgroundPosition: `0 calc((${
               (leading - lineHeightNormal) / 2
-            }px) + ${capsizeStyles?.['::before'].marginBottom})`,
+            }px) + ${capsizeStyles?.['::before'].marginBlockEnd})`,
           },
     leading: {
       backgroundImage: `linear-gradient(180deg, transparent ${leading}px, ${highlight} ${leading}px, ${highlight} ${


### PR DESCRIPTION
I am currently trying to use Capsize with text, that is rotated 90deg (using [`writing-mode: vertical-lr;`](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode)). The current implementation always applies `margin-top` and `margin-bottom`, regardless of the actual orientation.

This PR replaces `margin-top` with `margin-block-start` and `margin-bottom` with `margin-block-end`, as these properties respect aforementioned text orientation.

From [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block#syntax):
> This property corresponds to the [margin-top](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top) and [margin-bottom](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom), or the [margin-right](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right) and [margin-left](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left) properties, depending on the values defined for [writing-mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode), [direction](https://developer.mozilla.org/en-US/docs/Web/CSS/direction), and [text-orientation](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).

However while this fixes text in vertical writing mode, it does not work with text in vertical writing mode _and_ [upright text orientation](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation):

```css
writing-mode: vertical-lr; // or vertical-rl;
text-orientation: upright;
```

This incorrectly _(in the case of capsize)_ applies left and right margins when using start and end.

I personally think breaking this in favor of supporting vertical text is a worth trade-off, but this is of course up for discussion.

I am not sure if this would affect east asian languages that may be written vertically. To my knowledge these are also written horizontally on the web.