### PR TITLE
Add support for extracting from TrueType Collection by PostScript name

### DIFF
--- a/.changeset/eighty-pants-dress.md
+++ b/.changeset/eighty-pants-dress.md
@@ -1,0 +1,17 @@
+---
+'@capsizecss/unpack': minor
+---
+
+Add support for extracting from TrueType Collection by PostScript name
+
+Enable the extraction of font metrics for a specific font from TrueType Collection (TTC) file by providing the `postscriptName` option.
+
+For example:
+
+```ts
+import { fromFile } from '@capsizecss/unpack';
+
+const metrics = await fromFile('AvenirNext.ttc', {
+  postscriptName: 'AvenirNext-Bold',
+});
+```

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -42,7 +42,7 @@ const capsizeStyles = createStyleObject({
 Metrics for the available variants of a font can be imported by weight and font style.
 
 ```ts
-import metrics from "@capsizecss/metrics/ {font-family} / {weight}{style}"
+import metrics from '@capsizecss/metrics/ {font-family} / {weight}{style}';
 ```
 
 The format follows the convention used by Google Fonts for variant names: either a standalone weight or style (e.g. `regular`, `italic`), a specific weight (e.g. numeric `100` to `900`), or a combination of both (e.g. `100italic`-`900italic`).

--- a/packages/unpack/README.md
+++ b/packages/unpack/README.md
@@ -9,6 +9,14 @@ Unpack the capsize font metrics directly from a font file.
 npm install @capsizecss/unpack
 ```
 
+- [Usage](#usage)
+  - [fromBlob](#fromblob)
+  - [fromUrl](#fromurl)
+  - [fromFile](#fromfile)
+- [Options](#options)
+  - [postscriptName](#postscriptname)
+- [Font Metrics](#font-metrics)
+
 ## Usage
 
 ### `fromBlob`
@@ -39,6 +47,22 @@ Takes a file path string and returns the resolved [font metrics](#font-metrics).
 import { fromFile } from '@capsizecss/unpack';
 
 const metrics = await fromFile(filePath);
+```
+
+## Options
+
+All of the above APIs accept an optional second parameter with the following options:
+
+#### `postscriptName`
+
+Capsize can extract the metrics for a single font from a TrueType Collection (TTC) file by providing the `postscriptName`.
+
+```ts
+import { fromFile } from '@capsizecss/unpack';
+
+const metrics = await fromFile('AvenirNext.ttc', {
+  postscriptName: 'AvenirNext-Bold',
+});
 ```
 
 ## Font metrics


### PR DESCRIPTION
Inspired by #156, this PR goes a little further introducing an options object and error handling (opened a separate PR due to the previous PR laying dormant).

Add support for extracting from TrueType Collection by PostScript name

Enable the extraction of font metrics for a specific font from TrueType Collection (TTC) file by providing the `postscriptName` option.

For example:

```ts
import { fromFile } from '@capsizecss/unpack';

const metrics = await fromFile('AvenirNext.ttc', {
  postscriptName: 'AvenirNext-Bold',
});
```