### PR TITLE
Update Google Fonts

### DIFF
--- a/.changeset/smart-sloths-hunt.md
+++ b/.changeset/smart-sloths-hunt.md
@@ -1,0 +1,5 @@
+---
+'@capsizecss/metrics': minor
+---
+
+Update Google Fonts

--- a/packages/metrics/scripts/googleFonts.json
+++ b/packages/metrics/scripts/googleFonts.json
@@ -950,6 +950,201 @@
     }
   },
   {
+    "familyName": "Afacad Flux",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Thin",
+        "postscriptName": "AfacadFlux-Thin",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 570,
+        "xWidthAvg": 558,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 558
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux ExtraLight",
+        "postscriptName": "AfacadFlux-ExtraLight",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 578,
+        "xWidthAvg": 562,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 562
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Light",
+        "postscriptName": "AfacadFlux-Light",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 585,
+        "xWidthAvg": 566,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 566
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Medium",
+        "postscriptName": "AfacadFlux-Medium",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 600,
+        "xWidthAvg": 572,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 572
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux SemiBold",
+        "postscriptName": "AfacadFlux-SemiBold",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 600,
+        "xWidthAvg": 570,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 570
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Bold",
+        "postscriptName": "AfacadFlux-Bold",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 600,
+        "xWidthAvg": 569,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 569
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux ExtraBold",
+        "postscriptName": "AfacadFlux-ExtraBold",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 615,
+        "xWidthAvg": 580,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 580
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Black",
+        "postscriptName": "AfacadFlux-Black",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 623,
+        "xWidthAvg": 586,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 586
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Afacad Flux",
+        "fullName": "Afacad Flux Regular",
+        "postscriptName": "AfacadFlux-Regular",
+        "capHeight": 900,
+        "ascent": 1440,
+        "descent": -480,
+        "lineGap": 0,
+        "unitsPerEm": 1440,
+        "xHeight": 600,
+        "xWidthAvg": 574,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 574
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Agbalumo",
     "defaultVariant": "regular",
     "variants": {
@@ -31360,6 +31555,201 @@
     }
   },
   {
+    "familyName": "Doto",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Doto",
+        "fullName": "Doto Thin",
+        "postscriptName": "Doto-Thin",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200": {
+        "familyName": "Doto",
+        "fullName": "Doto ExtraLight",
+        "postscriptName": "Doto-ExtraLight",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Doto",
+        "fullName": "Doto Light",
+        "postscriptName": "Doto-Light",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Doto",
+        "fullName": "Doto Medium",
+        "postscriptName": "Doto-Medium",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Doto",
+        "fullName": "Doto SemiBold",
+        "postscriptName": "Doto-SemiBold",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Doto",
+        "fullName": "Doto Bold",
+        "postscriptName": "Doto-Bold",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Doto",
+        "fullName": "Doto ExtraBold",
+        "postscriptName": "Doto-ExtraBold",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Doto",
+        "fullName": "Doto Black",
+        "postscriptName": "Doto-Black",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Doto",
+        "fullName": "Doto Regular",
+        "postscriptName": "Doto-Regular",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Dr Sugiyama",
     "defaultVariant": "regular",
     "variants": {
@@ -32029,6 +32419,186 @@
     }
   },
   {
+    "familyName": "Edu AU VIC WA NT Dots",
+    "defaultVariant": "regular",
+    "variants": {
+      "500": {
+        "familyName": "Edu AU VIC WA NT Dots",
+        "fullName": "Edu AU VIC WA NT Dots Medium",
+        "postscriptName": "EduAUVICWANTDots-Medium",
+        "capHeight": 1841,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1027,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1027
+          },
+          "thai": {
+            "xWidthAvg": 1307
+          }
+        },
+        "category": "handwriting"
+      },
+      "600": {
+        "familyName": "Edu AU VIC WA NT Dots",
+        "fullName": "Edu AU VIC WA NT Dots SemiBold",
+        "postscriptName": "EduAUVICWANTDots-SemiBold",
+        "capHeight": 1837,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1058,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1058
+          },
+          "thai": {
+            "xWidthAvg": 1351
+          }
+        },
+        "category": "handwriting"
+      },
+      "700": {
+        "familyName": "Edu AU VIC WA NT Dots",
+        "fullName": "Edu AU VIC WA NT Dots Bold",
+        "postscriptName": "EduAUVICWANTDots-Bold",
+        "capHeight": 1835,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1077,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1077
+          },
+          "thai": {
+            "xWidthAvg": 1378
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Edu AU VIC WA NT Dots",
+        "fullName": "Edu AU VIC WA NT Dots Regular",
+        "postscriptName": "EduAUVICWANTDots-Regular",
+        "capHeight": 1847,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 984,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 984
+          },
+          "thai": {
+            "xWidthAvg": 1245
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Edu AU VIC WA NT Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "500": {
+        "familyName": "Edu AU VIC WA NT Guides",
+        "fullName": "Edu AU VIC WA NT Guides Medium",
+        "postscriptName": "EduAUVICWANTGuides-Medium",
+        "capHeight": 1841,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 874,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 874
+          },
+          "thai": {
+            "xWidthAvg": 1307
+          }
+        },
+        "category": "handwriting"
+      },
+      "600": {
+        "familyName": "Edu AU VIC WA NT Guides",
+        "fullName": "Edu AU VIC WA NT Guides SemiBold",
+        "postscriptName": "EduAUVICWANTGuides-SemiBold",
+        "capHeight": 1837,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 900,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 900
+          },
+          "thai": {
+            "xWidthAvg": 1351
+          }
+        },
+        "category": "handwriting"
+      },
+      "700": {
+        "familyName": "Edu AU VIC WA NT Guides",
+        "fullName": "Edu AU VIC WA NT Guides Bold",
+        "postscriptName": "EduAUVICWANTGuides-Bold",
+        "capHeight": 1835,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 915,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 915
+          },
+          "thai": {
+            "xWidthAvg": 1378
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Edu AU VIC WA NT Guides",
+        "fullName": "Edu AU VIC WA NT Guides Regular",
+        "postscriptName": "EduAUVICWANTGuides-Regular",
+        "capHeight": 1847,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 838,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 838
+          },
+          "thai": {
+            "xWidthAvg": 1245
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Edu AU VIC WA NT Hand",
     "defaultVariant": "regular",
     "variants": {
@@ -32099,6 +32669,96 @@
         "familyName": "Edu AU VIC WA NT Hand",
         "fullName": "Edu AU VIC WA NT Hand Regular",
         "postscriptName": "EduAUVICWANTHand-Regular",
+        "capHeight": 1847,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 838,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 838
+          },
+          "thai": {
+            "xWidthAvg": 1245
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Edu AU VIC WA NT Pre",
+    "defaultVariant": "regular",
+    "variants": {
+      "500": {
+        "familyName": "Edu AU VIC WA NT Pre",
+        "fullName": "Edu AU VIC WA NT Pre Medium",
+        "postscriptName": "EduAUVICWANTPre-Medium",
+        "capHeight": 1841,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 874,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 874
+          },
+          "thai": {
+            "xWidthAvg": 1307
+          }
+        },
+        "category": "handwriting"
+      },
+      "600": {
+        "familyName": "Edu AU VIC WA NT Pre",
+        "fullName": "Edu AU VIC WA NT Pre SemiBold",
+        "postscriptName": "EduAUVICWANTPre-SemiBold",
+        "capHeight": 1837,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 900,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 900
+          },
+          "thai": {
+            "xWidthAvg": 1351
+          }
+        },
+        "category": "handwriting"
+      },
+      "700": {
+        "familyName": "Edu AU VIC WA NT Pre",
+        "fullName": "Edu AU VIC WA NT Pre Bold",
+        "postscriptName": "EduAUVICWANTPre-Bold",
+        "capHeight": 1835,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 915,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 915
+          },
+          "thai": {
+            "xWidthAvg": 1378
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Edu AU VIC WA NT Pre",
+        "fullName": "Edu AU VIC WA NT Pre Regular",
+        "postscriptName": "EduAUVICWANTPre-Regular",
         "capHeight": 1847,
         "ascent": 2576,
         "descent": -903,
@@ -35092,7 +35752,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 480,
         "xWidthAvg": 443,
         "subsets": {
           "latin": {
@@ -35113,7 +35773,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 482,
         "xWidthAvg": 446,
         "subsets": {
           "latin": {
@@ -35134,7 +35794,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 485,
         "xWidthAvg": 451,
         "subsets": {
           "latin": {
@@ -35155,7 +35815,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 488,
         "xWidthAvg": 459,
         "subsets": {
           "latin": {
@@ -35176,7 +35836,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 491,
         "xWidthAvg": 466,
         "subsets": {
           "latin": {
@@ -35197,7 +35857,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 494,
         "xWidthAvg": 475,
         "subsets": {
           "latin": {
@@ -35218,7 +35878,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 497,
         "xWidthAvg": 485,
         "subsets": {
           "latin": {
@@ -35239,7 +35899,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 500,
         "xWidthAvg": 493,
         "subsets": {
           "latin": {
@@ -35260,7 +35920,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 480,
         "xWidthAvg": 444,
         "subsets": {
           "latin": {
@@ -35281,7 +35941,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 482,
         "xWidthAvg": 447,
         "subsets": {
           "latin": {
@@ -35302,7 +35962,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 485,
         "xWidthAvg": 451,
         "subsets": {
           "latin": {
@@ -35323,7 +35983,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 488,
         "xWidthAvg": 459,
         "subsets": {
           "latin": {
@@ -35344,7 +36004,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 491,
         "xWidthAvg": 467,
         "subsets": {
           "latin": {
@@ -35365,7 +36025,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 494,
         "xWidthAvg": 476,
         "subsets": {
           "latin": {
@@ -35386,7 +36046,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 497,
         "xWidthAvg": 486,
         "subsets": {
           "latin": {
@@ -35407,7 +36067,7 @@
         "descent": -201,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
+        "xHeight": 500,
         "xWidthAvg": 495,
         "subsets": {
           "latin": {
@@ -35661,6 +36321,33 @@
           }
         },
         "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Faculty Glyphic",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Faculty Glyphic",
+        "fullName": "Faculty Glyphic Regular",
+        "postscriptName": "FacultyGlyphic-Regular",
+        "capHeight": 775,
+        "ascent": 1037,
+        "descent": -262,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 550,
+        "xWidthAvg": 469,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 469
+          },
+          "thai": {
+            "xWidthAvg": 493
+          }
+        },
+        "category": "sans-serif"
       }
     }
   },
@@ -40144,6 +40831,396 @@
     }
   },
   {
+    "familyName": "Funnel Display",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display Light",
+        "postscriptName": "FunnelDisplay-Light",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 565,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 565
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      },
+      "500": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display Medium",
+        "postscriptName": "FunnelDisplay-Medium",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 577,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 577
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      },
+      "600": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display SemiBold",
+        "postscriptName": "FunnelDisplay-SemiBold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 580,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 580
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      },
+      "700": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display Bold",
+        "postscriptName": "FunnelDisplay-Bold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 585,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 585
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      },
+      "800": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display ExtraBold",
+        "postscriptName": "FunnelDisplay-ExtraBold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 589,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 589
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      },
+      "regular": {
+        "familyName": "Funnel Display",
+        "fullName": "Funnel Display Regular",
+        "postscriptName": "FunnelDisplay-Regular",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 570,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 570
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
+    "familyName": "Funnel Sans",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Light",
+        "postscriptName": "FunnelSans-Light",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 538,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 538
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Medium",
+        "postscriptName": "FunnelSans-Medium",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 545,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 545
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans SemiBold",
+        "postscriptName": "FunnelSans-SemiBold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 548,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 548
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Bold",
+        "postscriptName": "FunnelSans-Bold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 551,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 551
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans ExtraBold",
+        "postscriptName": "FunnelSans-ExtraBold",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 554,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 554
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Light Italic",
+        "postscriptName": "FunnelSans-LightItalic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 538,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 538
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Medium Italic",
+        "postscriptName": "FunnelSans-MediumItalic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 545,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 545
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans SemiBold Italic",
+        "postscriptName": "FunnelSans-SemiBoldItalic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 548,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 548
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Bold Italic",
+        "postscriptName": "FunnelSans-BoldItalic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 551,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 551
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans ExtraBold Italic",
+        "postscriptName": "FunnelSans-ExtraBoldItalic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 554,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 554
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Italic",
+        "postscriptName": "FunnelSans-Italic",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 541,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 541
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Funnel Sans",
+        "fullName": "Funnel Sans Regular",
+        "postscriptName": "FunnelSans-Regular",
+        "capHeight": 810,
+        "ascent": 1200,
+        "descent": -300,
+        "lineGap": 0,
+        "unitsPerEm": 1200,
+        "xHeight": 600,
+        "xWidthAvg": 541,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 541
+          },
+          "thai": {
+            "xWidthAvg": 720
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Fustat",
     "defaultVariant": "regular",
     "variants": {
@@ -41238,6 +42315,396 @@
           }
         },
         "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Geist",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Geist",
+        "fullName": "Geist Thin",
+        "postscriptName": "Geist-Thin",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 445,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 445
+          },
+          "thai": {
+            "xWidthAvg": 605
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200": {
+        "familyName": "Geist",
+        "fullName": "Geist ExtraLight",
+        "postscriptName": "Geist-ExtraLight",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 452,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 452
+          },
+          "thai": {
+            "xWidthAvg": 603
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Geist",
+        "fullName": "Geist Light",
+        "postscriptName": "Geist-Light",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 460,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 460
+          },
+          "thai": {
+            "xWidthAvg": 602
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Geist",
+        "fullName": "Geist Medium",
+        "postscriptName": "Geist-Medium",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 532,
+        "xWidthAvg": 478,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 478
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Geist",
+        "fullName": "Geist SemiBold",
+        "postscriptName": "Geist-SemiBold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 534,
+        "xWidthAvg": 489,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 489
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Geist",
+        "fullName": "Geist Bold",
+        "postscriptName": "Geist-Bold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 536,
+        "xWidthAvg": 499,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 499
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Geist",
+        "fullName": "Geist ExtraBold",
+        "postscriptName": "Geist-ExtraBold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 538,
+        "xWidthAvg": 510,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 510
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Geist",
+        "fullName": "Geist Black",
+        "postscriptName": "Geist-Black",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 540,
+        "xWidthAvg": 521,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 521
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Geist",
+        "fullName": "Geist Regular",
+        "postscriptName": "Geist-Regular",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 467,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 467
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Geist Mono",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Thin",
+        "postscriptName": "GeistMono-Thin",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "200": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono ExtraLight",
+        "postscriptName": "GeistMono-ExtraLight",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "300": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Light",
+        "postscriptName": "GeistMono-Light",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "500": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Medium",
+        "postscriptName": "GeistMono-Medium",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 532,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "600": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono SemiBold",
+        "postscriptName": "GeistMono-SemiBold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 534,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "700": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Bold",
+        "postscriptName": "GeistMono-Bold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 536,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "800": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono ExtraBold",
+        "postscriptName": "GeistMono-ExtraBold",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 538,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "900": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Black",
+        "postscriptName": "GeistMono-Black",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 540,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
+      },
+      "regular": {
+        "familyName": "Geist Mono",
+        "fullName": "Geist Mono Regular",
+        "postscriptName": "GeistMono-Regular",
+        "capHeight": 710,
+        "ascent": 1005,
+        "descent": -295,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 600,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 600
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "monospace"
       }
     }
   },
@@ -48376,6 +49843,264 @@
     }
   },
   {
+    "familyName": "Host Grotesk",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Light",
+        "postscriptName": "HostGrotesk-Light",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Medium",
+        "postscriptName": "HostGrotesk-Medium",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk SemiBold",
+        "postscriptName": "HostGrotesk-SemiBold",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Bold",
+        "postscriptName": "HostGrotesk-Bold",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk ExtraBold",
+        "postscriptName": "HostGrotesk-ExtraBold",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Light Italic",
+        "postscriptName": "HostGrotesk-LightItalic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Medium Italic",
+        "postscriptName": "HostGrotesk-MediumItalic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk SemiBold Italic",
+        "postscriptName": "HostGrotesk-SemiBoldItalic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Bold Italic",
+        "postscriptName": "HostGrotesk-BoldItalic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk ExtraBold Italic",
+        "postscriptName": "HostGrotesk-ExtraBoldItalic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Italic",
+        "postscriptName": "HostGrotesk-Italic",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Host Grotesk",
+        "fullName": "Host Grotesk Regular",
+        "postscriptName": "HostGrotesk-Regular",
+        "capHeight": 700,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 640
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Hubballi",
     "defaultVariant": "regular",
     "variants": {
@@ -48396,6 +50121,348 @@
           },
           "thai": {
             "xWidthAvg": 756
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Hubot Sans",
+    "defaultVariant": "regular",
+    "variants": {
+      "200": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans ExtraLight",
+        "postscriptName": "HubotSans-ExtraLight",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 516,
+        "xWidthAvg": 427,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 427
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Light",
+        "postscriptName": "HubotSans-Light",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 520,
+        "xWidthAvg": 440,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 440
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Medium",
+        "postscriptName": "HubotSans-Medium",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 529,
+        "xWidthAvg": 468,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 468
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans SemiBold",
+        "postscriptName": "HubotSans-SemiBold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 533,
+        "xWidthAvg": 483,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 483
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Bold",
+        "postscriptName": "HubotSans-Bold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 537,
+        "xWidthAvg": 499,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 499
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans ExtraBold",
+        "postscriptName": "HubotSans-ExtraBold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 541,
+        "xWidthAvg": 514,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 514
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Black",
+        "postscriptName": "HubotSans-Black",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 545,
+        "xWidthAvg": 530,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 530
+          },
+          "thai": {
+            "xWidthAvg": 865
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans ExtraLight Italic",
+        "postscriptName": "HubotSans-ExtraLightItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 516,
+        "xWidthAvg": 429,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 429
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Light Italic",
+        "postscriptName": "HubotSans-LightItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 520,
+        "xWidthAvg": 443,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 443
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Medium Italic",
+        "postscriptName": "HubotSans-MediumItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 528,
+        "xWidthAvg": 472,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 472
+          },
+          "thai": {
+            "xWidthAvg": 881
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans SemiBold Italic",
+        "postscriptName": "HubotSans-SemiBoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 533,
+        "xWidthAvg": 487,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 487
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Bold Italic",
+        "postscriptName": "HubotSans-BoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 537,
+        "xWidthAvg": 502,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 502
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans ExtraBold Italic",
+        "postscriptName": "HubotSans-ExtraBoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 541,
+        "xWidthAvg": 517,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 517
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Black Italic",
+        "postscriptName": "HubotSans-BlackItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 545,
+        "xWidthAvg": 532,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 532
+          },
+          "thai": {
+            "xWidthAvg": 882
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Italic",
+        "postscriptName": "HubotSans-Italic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 524,
+        "xWidthAvg": 457,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 457
+          },
+          "thai": {
+            "xWidthAvg": 881
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Hubot Sans",
+        "fullName": "Hubot Sans Regular",
+        "postscriptName": "HubotSans-Regular",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 525,
+        "xWidthAvg": 453,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 453
+          },
+          "thai": {
+            "xWidthAvg": 865
           }
         },
         "category": "sans-serif"
@@ -58213,6 +60280,102 @@
     }
   },
   {
+    "familyName": "Karla Tamil Inclined",
+    "defaultVariant": "regular",
+    "variants": {
+      "700": {
+        "familyName": "Karla Tamil Inclined",
+        "fullName": "Karla Tamil Inclined Bold",
+        "postscriptName": "KarlaTamilInclined-Bold",
+        "capHeight": 717,
+        "ascent": 796,
+        "descent": -345,
+        "lineGap": 17,
+        "unitsPerEm": 1000,
+        "xHeight": 499,
+        "xWidthAvg": 470,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 470
+          },
+          "thai": {
+            "xWidthAvg": 524
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Karla Tamil Inclined",
+        "fullName": "Karla Tamil Inclined",
+        "postscriptName": "KarlaTamilInclined-Regular",
+        "capHeight": 717,
+        "ascent": 796,
+        "descent": -345,
+        "lineGap": 17,
+        "unitsPerEm": 1000,
+        "xHeight": 499,
+        "xWidthAvg": 444,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 444
+          },
+          "thai": {
+            "xWidthAvg": 495
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Karla Tamil Upright",
+    "defaultVariant": "regular",
+    "variants": {
+      "700": {
+        "familyName": "Karla Tamil Upright",
+        "fullName": "Karla Tamil Upright Bold",
+        "postscriptName": "KarlaTamilUpright-Bold",
+        "capHeight": 741,
+        "ascent": 750,
+        "descent": -250,
+        "lineGap": 9,
+        "unitsPerEm": 1000,
+        "xHeight": 509,
+        "xWidthAvg": 515,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 515
+          },
+          "thai": {
+            "xWidthAvg": 574
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Karla Tamil Upright",
+        "fullName": "Karla Tamil Upright",
+        "postscriptName": "KarlaTamilUpright-Regular",
+        "capHeight": 727,
+        "ascent": 750,
+        "descent": -250,
+        "lineGap": 9,
+        "unitsPerEm": 1000,
+        "xHeight": 503,
+        "xWidthAvg": 488,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 488
+          },
+          "thai": {
+            "xWidthAvg": 545
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Karma",
     "defaultVariant": "regular",
     "variants": {
@@ -58329,7 +60492,7 @@
     "variants": {
       "regular": {
         "familyName": "Katibeh",
-        "fullName": "Katibeh",
+        "fullName": "Katibeh Regular",
         "postscriptName": "Katibeh-Regular",
         "capHeight": 700,
         "ascent": 490,
@@ -73003,23 +75166,65 @@
     "familyName": "Miriam Libre",
     "defaultVariant": "regular",
     "variants": {
-      "700": {
+      "500": {
         "familyName": "Miriam Libre",
-        "fullName": "Miriam Libre Bold",
-        "postscriptName": "MiriamLibre-Bold",
-        "capHeight": 715,
+        "fullName": "Miriam Libre Medium",
+        "postscriptName": "MiriamLibre-Medium",
+        "capHeight": 695,
         "ascent": 969,
         "descent": -344,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 573,
+        "xHeight": 566,
+        "xWidthAvg": 493,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 493
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Miriam Libre",
+        "fullName": "Miriam Libre SemiBold",
+        "postscriptName": "MiriamLibre-SemiBold",
+        "capHeight": 695,
+        "ascent": 969,
+        "descent": -344,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 566,
+        "xWidthAvg": 499,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 499
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Miriam Libre",
+        "fullName": "Miriam Libre Bold",
+        "postscriptName": "MiriamLibre-Bold",
+        "capHeight": 695,
+        "ascent": 969,
+        "descent": -344,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 566,
         "xWidthAvg": 506,
         "subsets": {
           "latin": {
             "xWidthAvg": 506
           },
           "thai": {
-            "xWidthAvg": 480
+            "xWidthAvg": 500
           }
         },
         "category": "sans-serif"
@@ -73040,7 +75245,7 @@
             "xWidthAvg": 486
           },
           "thai": {
-            "xWidthAvg": 476
+            "xWidthAvg": 500
           }
         },
         "category": "sans-serif"
@@ -73861,6 +76066,348 @@
     }
   },
   {
+    "familyName": "Mona Sans",
+    "defaultVariant": "regular",
+    "variants": {
+      "200": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans ExtraLight",
+        "postscriptName": "MonaSans-ExtraLight",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 517,
+        "xWidthAvg": 455,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 455
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Light",
+        "postscriptName": "MonaSans-Light",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 521,
+        "xWidthAvg": 457,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 457
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Medium",
+        "postscriptName": "MonaSans-Medium",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 529,
+        "xWidthAvg": 472,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 472
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans SemiBold",
+        "postscriptName": "MonaSans-SemiBold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 532,
+        "xWidthAvg": 480,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 480
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Bold",
+        "postscriptName": "MonaSans-Bold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 536,
+        "xWidthAvg": 488,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 488
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans ExtraBold",
+        "postscriptName": "MonaSans-ExtraBold",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 540,
+        "xWidthAvg": 496,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 496
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Black",
+        "postscriptName": "MonaSans-Black",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 544,
+        "xWidthAvg": 504,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 504
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans ExtraLight Italic",
+        "postscriptName": "MonaSans-ExtraLightItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 517,
+        "xWidthAvg": 448,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 448
+          },
+          "thai": {
+            "xWidthAvg": 885
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Light Italic",
+        "postscriptName": "MonaSans-LightItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 521,
+        "xWidthAvg": 451,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 451
+          },
+          "thai": {
+            "xWidthAvg": 885
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Medium Italic",
+        "postscriptName": "MonaSans-MediumItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 529,
+        "xWidthAvg": 467,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 467
+          },
+          "thai": {
+            "xWidthAvg": 885
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans SemiBold Italic",
+        "postscriptName": "MonaSans-SemiBoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 532,
+        "xWidthAvg": 476,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 476
+          },
+          "thai": {
+            "xWidthAvg": 886
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Bold Italic",
+        "postscriptName": "MonaSans-BoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 536,
+        "xWidthAvg": 484,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 484
+          },
+          "thai": {
+            "xWidthAvg": 886
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans ExtraBold Italic",
+        "postscriptName": "MonaSans-ExtraBoldItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 540,
+        "xWidthAvg": 492,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 492
+          },
+          "thai": {
+            "xWidthAvg": 886
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Black Italic",
+        "postscriptName": "MonaSans-BlackItalic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 544,
+        "xWidthAvg": 500,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 500
+          },
+          "thai": {
+            "xWidthAvg": 886
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Italic",
+        "postscriptName": "MonaSans-Italic",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 525,
+        "xWidthAvg": 459,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 459
+          },
+          "thai": {
+            "xWidthAvg": 885
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Mona Sans",
+        "fullName": "Mona Sans Regular",
+        "postscriptName": "MonaSans-Regular",
+        "capHeight": 729,
+        "ascent": 1090,
+        "descent": -320,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 525,
+        "xWidthAvg": 464,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 464
+          },
+          "thai": {
+            "xWidthAvg": 866
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Monda",
     "defaultVariant": "regular",
     "variants": {
@@ -74326,7 +76873,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 519,
         "xWidthAvg": 492,
         "subsets": {
           "latin": {
@@ -74347,7 +76894,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 522,
         "xWidthAvg": 497,
         "subsets": {
           "latin": {
@@ -74368,7 +76915,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 530,
         "xWidthAvg": 511,
         "subsets": {
           "latin": {
@@ -74389,7 +76936,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 534,
         "xWidthAvg": 520,
         "subsets": {
           "latin": {
@@ -74410,7 +76957,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 538,
         "xWidthAvg": 530,
         "subsets": {
           "latin": {
@@ -74431,7 +76978,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 542,
         "xWidthAvg": 540,
         "subsets": {
           "latin": {
@@ -74452,7 +76999,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 547,
         "xWidthAvg": 551,
         "subsets": {
           "latin": {
@@ -74494,7 +77041,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 519,
         "xWidthAvg": 498,
         "subsets": {
           "latin": {
@@ -74515,7 +77062,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 522,
         "xWidthAvg": 503,
         "subsets": {
           "latin": {
@@ -74536,7 +77083,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 530,
         "xWidthAvg": 517,
         "subsets": {
           "latin": {
@@ -74557,7 +77104,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 534,
         "xWidthAvg": 525,
         "subsets": {
           "latin": {
@@ -74578,7 +77125,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 538,
         "xWidthAvg": 534,
         "subsets": {
           "latin": {
@@ -74599,7 +77146,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 542,
         "xWidthAvg": 544,
         "subsets": {
           "latin": {
@@ -74620,7 +77167,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 547,
         "xWidthAvg": 554,
         "subsets": {
           "latin": {
@@ -74641,7 +77188,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 525,
         "xWidthAvg": 509,
         "subsets": {
           "latin": {
@@ -74662,7 +77209,7 @@
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 517,
+        "xHeight": 525,
         "xWidthAvg": 503,
         "subsets": {
           "latin": {
@@ -77240,16 +79787,16 @@
         "familyName": "Nanum Brush Script",
         "fullName": "Nanum Brush Script",
         "postscriptName": "NanumBrush",
-        "capHeight": 700,
-        "ascent": 920,
-        "descent": -230,
-        "lineGap": 0,
+        "capHeight": 460,
+        "ascent": 630,
+        "descent": -370,
+        "lineGap": 250,
         "unitsPerEm": 1000,
-        "xHeight": 500,
-        "xWidthAvg": 335,
+        "xHeight": 300,
+        "xWidthAvg": 412,
         "subsets": {
           "latin": {
-            "xWidthAvg": 335
+            "xWidthAvg": 412
           },
           "thai": {
             "xWidthAvg": 940
@@ -79786,13 +82333,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 539,
-        "xWidthAvg": 483,
+        "xWidthAvg": 482,
         "subsets": {
           "latin": {
-            "xWidthAvg": 483
+            "xWidthAvg": 482
           },
           "thai": {
-            "xWidthAvg": 600
+            "xWidthAvg": 597
           }
         },
         "category": "sans-serif"
@@ -79807,13 +82354,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 542,
-        "xWidthAvg": 493,
+        "xWidthAvg": 492,
         "subsets": {
           "latin": {
-            "xWidthAvg": 493
+            "xWidthAvg": 492
           },
           "thai": {
-            "xWidthAvg": 600
+            "xWidthAvg": 593
           }
         },
         "category": "sans-serif"
@@ -79828,13 +82375,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 546,
-        "xWidthAvg": 504,
+        "xWidthAvg": 503,
         "subsets": {
           "latin": {
-            "xWidthAvg": 504
+            "xWidthAvg": 503
           },
           "thai": {
-            "xWidthAvg": 600
+            "xWidthAvg": 589
           }
         },
         "category": "sans-serif"
@@ -79849,13 +82396,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 549,
-        "xWidthAvg": 512,
+        "xWidthAvg": 511,
         "subsets": {
           "latin": {
-            "xWidthAvg": 512
+            "xWidthAvg": 511
           },
           "thai": {
-            "xWidthAvg": 592
+            "xWidthAvg": 586
           }
         },
         "category": "sans-serif"
@@ -87037,10 +89584,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 500,
-        "xWidthAvg": 547,
+        "xWidthAvg": 474,
         "subsets": {
           "latin": {
-            "xWidthAvg": 547
+            "xWidthAvg": 474
           },
           "thai": {
             "xWidthAvg": 600
@@ -127217,6 +129764,33 @@
     }
   },
   {
+    "familyName": "Sixtyfour Convergence",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Sixtyfour Convergence",
+        "fullName": "Sixtyfour Convergence Regular",
+        "postscriptName": "SixtyfourConvergence-Regular",
+        "capHeight": 896,
+        "ascent": 896,
+        "descent": -128,
+        "lineGap": 0,
+        "unitsPerEm": 1024,
+        "xHeight": 640,
+        "xWidthAvg": 1024,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1024
+          },
+          "thai": {
+            "xWidthAvg": 1024
+          }
+        },
+        "category": "monospace"
+      }
+    }
+  },
+  {
     "familyName": "Skranji",
     "defaultVariant": "regular",
     "variants": {
@@ -130082,6 +132656,390 @@
     }
   },
   {
+    "familyName": "Sour Gummy",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Thin",
+        "postscriptName": "SourGummy-Thin",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 458,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 458
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy ExtraLight",
+        "postscriptName": "SourGummy-ExtraLight",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 463,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 463
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Light",
+        "postscriptName": "SourGummy-Light",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 469,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 469
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Medium",
+        "postscriptName": "SourGummy-Medium",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 481,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 481
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy SemiBold",
+        "postscriptName": "SourGummy-SemiBold",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 486,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 486
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Bold",
+        "postscriptName": "SourGummy-Bold",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 492,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 492
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy ExtraBold",
+        "postscriptName": "SourGummy-ExtraBold",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 498,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 498
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Black",
+        "postscriptName": "SourGummy-Black",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 503,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 503
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      },
+      "100italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Thin Italic",
+        "postscriptName": "SourGummy-ThinItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 458,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 458
+          },
+          "thai": {
+            "xWidthAvg": 679
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy ExtraLight Italic",
+        "postscriptName": "SourGummy-ExtraLightItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 464,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 464
+          },
+          "thai": {
+            "xWidthAvg": 679
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Light Italic",
+        "postscriptName": "SourGummy-LightItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 469,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 469
+          },
+          "thai": {
+            "xWidthAvg": 679
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Medium Italic",
+        "postscriptName": "SourGummy-MediumItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 481,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 481
+          },
+          "thai": {
+            "xWidthAvg": 680
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy SemiBold Italic",
+        "postscriptName": "SourGummy-SemiBoldItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 486,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 486
+          },
+          "thai": {
+            "xWidthAvg": 680
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Bold Italic",
+        "postscriptName": "SourGummy-BoldItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 492,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 492
+          },
+          "thai": {
+            "xWidthAvg": 680
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy ExtraBold Italic",
+        "postscriptName": "SourGummy-ExtraBoldItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 498,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 498
+          },
+          "thai": {
+            "xWidthAvg": 680
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Black Italic",
+        "postscriptName": "SourGummy-BlackItalic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 503,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 503
+          },
+          "thai": {
+            "xWidthAvg": 680
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Italic",
+        "postscriptName": "SourGummy-Italic",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 475,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 475
+          },
+          "thai": {
+            "xWidthAvg": 679
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Sour Gummy",
+        "fullName": "Sour Gummy Regular",
+        "postscriptName": "SourGummy-Regular",
+        "capHeight": 700,
+        "ascent": 996,
+        "descent": -296,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 475,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 475
+          },
+          "thai": {
+            "xWidthAvg": 620
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Source Code Pro",
     "defaultVariant": "regular",
     "variants": {
@@ -131649,10 +134607,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 527,
+        "xWidthAvg": 426,
         "subsets": {
           "latin": {
-            "xWidthAvg": 527
+            "xWidthAvg": 426
           },
           "thai": {
             "xWidthAvg": 500
@@ -131670,10 +134628,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 545,
+        "xWidthAvg": 438,
         "subsets": {
           "latin": {
-            "xWidthAvg": 545
+            "xWidthAvg": 438
           },
           "thai": {
             "xWidthAvg": 500
@@ -131691,10 +134649,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 451,
-        "xWidthAvg": 560,
+        "xWidthAvg": 450,
         "subsets": {
           "latin": {
-            "xWidthAvg": 560
+            "xWidthAvg": 450
           },
           "thai": {
             "xWidthAvg": 500
@@ -131712,10 +134670,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 454,
-        "xWidthAvg": 565,
+        "xWidthAvg": 457,
         "subsets": {
           "latin": {
-            "xWidthAvg": 565
+            "xWidthAvg": 457
           },
           "thai": {
             "xWidthAvg": 500
@@ -131733,10 +134691,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 456,
-        "xWidthAvg": 572,
+        "xWidthAvg": 464,
         "subsets": {
           "latin": {
-            "xWidthAvg": 572
+            "xWidthAvg": 464
           },
           "thai": {
             "xWidthAvg": 500
@@ -131754,10 +134712,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 460,
-        "xWidthAvg": 581,
+        "xWidthAvg": 476,
         "subsets": {
           "latin": {
-            "xWidthAvg": 581
+            "xWidthAvg": 476
           },
           "thai": {
             "xWidthAvg": 500
@@ -131775,10 +134733,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 488,
+        "xWidthAvg": 394,
         "subsets": {
           "latin": {
-            "xWidthAvg": 488
+            "xWidthAvg": 394
           },
           "thai": {
             "xWidthAvg": 500
@@ -131796,10 +134754,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 505,
+        "xWidthAvg": 401,
         "subsets": {
           "latin": {
-            "xWidthAvg": 505
+            "xWidthAvg": 401
           },
           "thai": {
             "xWidthAvg": 489
@@ -131817,10 +134775,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 452,
-        "xWidthAvg": 526,
+        "xWidthAvg": 416,
         "subsets": {
           "latin": {
-            "xWidthAvg": 526
+            "xWidthAvg": 416
           },
           "thai": {
             "xWidthAvg": 479
@@ -131838,10 +134796,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 454,
-        "xWidthAvg": 526,
+        "xWidthAvg": 424,
         "subsets": {
           "latin": {
-            "xWidthAvg": 526
+            "xWidthAvg": 424
           },
           "thai": {
             "xWidthAvg": 486
@@ -131859,10 +134817,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 456,
-        "xWidthAvg": 527,
+        "xWidthAvg": 429,
         "subsets": {
           "latin": {
-            "xWidthAvg": 527
+            "xWidthAvg": 429
           },
           "thai": {
             "xWidthAvg": 490
@@ -131880,10 +134838,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 460,
-        "xWidthAvg": 529,
+        "xWidthAvg": 442,
         "subsets": {
           "latin": {
-            "xWidthAvg": 529
+            "xWidthAvg": 442
           },
           "thai": {
             "xWidthAvg": 500
@@ -131901,10 +134859,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 525,
+        "xWidthAvg": 410,
         "subsets": {
           "latin": {
-            "xWidthAvg": 525
+            "xWidthAvg": 410
           },
           "thai": {
             "xWidthAvg": 475
@@ -131922,10 +134880,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 450,
-        "xWidthAvg": 556,
+        "xWidthAvg": 446,
         "subsets": {
           "latin": {
-            "xWidthAvg": 556
+            "xWidthAvg": 446
           },
           "thai": {
             "xWidthAvg": 500

--- a/packages/metrics/scripts/source-data/googleFontsData.json
+++ b/packages/metrics/scripts/source-data/googleFontsData.json
@@ -324,6 +324,41 @@
       "menu": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfhXtamE-9g.ttf"
     },
     {
+      "family": "Afacad Flux",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "vietnamese"
+      ],
+      "version": "v2",
+      "lastModified": "2024-11-07",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsUwWZaRqQsJr67E.ttf",
+        "200": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edscwXZaRqQsJr67E.ttf",
+        "300": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsRIXZaRqQsJr67E.ttf",
+        "500": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsX4XZaRqQsJr67E.ttf",
+        "600": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsZIQZaRqQsJr67E.ttf",
+        "700": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsasQZaRqQsJr67E.ttf",
+        "800": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edscwQZaRqQsJr67E.ttf",
+        "900": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edseUQZaRqQsJr67E.ttf",
+        "regular": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsUwXZaRqQsJr67E.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/afacadflux/v2/9oRgNYYQryMlneUPykRmTuH4ET0fri4I5rJVT_CWHKDZnskVK5edsUwXVaVgRg.ttf"
+    },
+    {
       "family": "Agbalumo",
       "variants": [
         "regular"
@@ -521,14 +556,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2024-09-30",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/alata/v10/PbytFmztEwbIofe6xKcRQEOX.ttf"
+        "regular": "https://fonts.gstatic.com/s/alata/v11/PbytFmztEwbIofe6xKcRQEOX.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/alata/v10/PbytFmztEwbIoce7zqM.ttf"
+      "menu": "https://fonts.gstatic.com/s/alata/v11/PbytFmztEwbIoce7zqM.ttf"
     },
     {
       "family": "Alatsi",
@@ -664,25 +699,25 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v35",
-      "lastModified": "2024-09-04",
+      "version": "v36",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGxBUI_KCisSGVrw.ttf",
-        "600": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGKBII_KCisSGVrw.ttf",
-        "700": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGERII_KCisSGVrw.ttf",
-        "800": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGdhII_KCisSGVrw.ttf",
-        "900": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGXxII_KCisSGVrw.ttf",
-        "regular": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNG9hUI_KCisSGVrw.ttf",
-        "italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlbgv6qmkySFr9V9.ttf",
-        "500italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlbSv6qmkySFr9V9.ttf",
-        "600italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlY-uKqmkySFr9V9.ttf",
-        "700italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlYHuKqmkySFr9V9.ttf",
-        "800italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlZguKqmkySFr9V9.ttf",
-        "900italic": "https://fonts.gstatic.com/s/alegreya/v35/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlZJuKqmkySFr9V9.ttf"
+        "500": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGxBUI_KCisSGVrw.ttf",
+        "600": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGKBII_KCisSGVrw.ttf",
+        "700": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGERII_KCisSGVrw.ttf",
+        "800": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGdhII_KCisSGVrw.ttf",
+        "900": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNGXxII_KCisSGVrw.ttf",
+        "regular": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNG9hUI_KCisSGVrw.ttf",
+        "italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlbgv6qmkySFr9V9.ttf",
+        "500italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlbSv6qmkySFr9V9.ttf",
+        "600italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlY-uKqmkySFr9V9.ttf",
+        "700italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlYHuKqmkySFr9V9.ttf",
+        "800italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlZguKqmkySFr9V9.ttf",
+        "900italic": "https://fonts.gstatic.com/s/alegreya/v36/4UaSrEBBsBhlBjvfkSLk3abBFkvpkARTPlZJuKqmkySFr9V9.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/alegreya/v35/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNG9hU4_aqm.ttf"
+      "menu": "https://fonts.gstatic.com/s/alegreya/v36/4UacrEBBsBhlBjvfkQjt71kZfyBzPgNG9hU4_aqm.ttf"
     },
     {
       "family": "Alegreya SC",
@@ -752,27 +787,27 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUt9_-1phKLFgshYDvh6Vwt5TltuGdShm5bsg.ttf",
-        "300": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUu9_-1phKLFgshYDvh6Vwt5fFPmE18imdCqxI.ttf",
-        "500": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUu9_-1phKLFgshYDvh6Vwt5alOmE18imdCqxI.ttf",
-        "700": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUu9_-1phKLFgshYDvh6Vwt5eFImE18imdCqxI.ttf",
-        "800": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUu9_-1phKLFgshYDvh6Vwt5f1LmE18imdCqxI.ttf",
-        "900": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUu9_-1phKLFgshYDvh6Vwt5dlKmE18imdCqxI.ttf",
-        "100italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUv9_-1phKLFgshYDvh6Vwt7V9V3G1WpGtLsgu7.ttf",
-        "300italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUo9_-1phKLFgshYDvh6Vwt7V9VFE92jkVHuxKiBA.ttf",
-        "regular": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUz9_-1phKLFgshYDvh6Vwt3V1nvEVXlm4.ttf",
-        "italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUt9_-1phKLFgshYDvh6Vwt7V9tuGdShm5bsg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUo9_-1phKLFgshYDvh6Vwt7V9VTE52jkVHuxKiBA.ttf",
-        "700italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUo9_-1phKLFgshYDvh6Vwt7V9VBEh2jkVHuxKiBA.ttf",
-        "800italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUo9_-1phKLFgshYDvh6Vwt7V9VGEt2jkVHuxKiBA.ttf",
-        "900italic": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUo9_-1phKLFgshYDvh6Vwt7V9VPEp2jkVHuxKiBA.ttf"
+        "100": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUt9_-1phKLFgshYDvh6Vwt5TltuGdShm5bsg.ttf",
+        "300": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUu9_-1phKLFgshYDvh6Vwt5fFPmE18imdCqxI.ttf",
+        "500": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUu9_-1phKLFgshYDvh6Vwt5alOmE18imdCqxI.ttf",
+        "700": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUu9_-1phKLFgshYDvh6Vwt5eFImE18imdCqxI.ttf",
+        "800": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUu9_-1phKLFgshYDvh6Vwt5f1LmE18imdCqxI.ttf",
+        "900": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUu9_-1phKLFgshYDvh6Vwt5dlKmE18imdCqxI.ttf",
+        "100italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUv9_-1phKLFgshYDvh6Vwt7V9V3G1WpGtLsgu7.ttf",
+        "300italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUo9_-1phKLFgshYDvh6Vwt7V9VFE92jkVHuxKiBA.ttf",
+        "regular": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUz9_-1phKLFgshYDvh6Vwt3V1nvEVXlm4.ttf",
+        "italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUt9_-1phKLFgshYDvh6Vwt7V9tuGdShm5bsg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUo9_-1phKLFgshYDvh6Vwt7V9VTE52jkVHuxKiBA.ttf",
+        "700italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUo9_-1phKLFgshYDvh6Vwt7V9VBEh2jkVHuxKiBA.ttf",
+        "800italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUo9_-1phKLFgshYDvh6Vwt7V9VGEt2jkVHuxKiBA.ttf",
+        "900italic": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUo9_-1phKLFgshYDvh6Vwt7V9VPEp2jkVHuxKiBA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/alegreyasans/v24/5aUz9_-1phKLFgshYDvh6Vwt7VxtuA.ttf"
+      "menu": "https://fonts.gstatic.com/s/alegreyasans/v25/5aUz9_-1phKLFgshYDvh6Vwt7VxtuA.ttf"
     },
     {
       "family": "Alegreya Sans SC",
@@ -1570,23 +1605,23 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DP7BY8cFLzvIt2S.ttf",
-        "600": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DMXAo8cFLzvIt2S.ttf",
-        "700": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DMuAo8cFLzvIt2S.ttf",
-        "800": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DNJAo8cFLzvIt2S.ttf",
-        "regular": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DPJBY8cFLzvIt2S.ttf",
-        "italic": "https://fonts.gstatic.com/s/andadapro/v20/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRmdfHrjNJ82Stjw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/andadapro/v20/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRlVfHrjNJ82Stjw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/andadapro/v20/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRrlYHrjNJ82Stjw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/andadapro/v20/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRoBYHrjNJ82Stjw.ttf",
-        "800italic": "https://fonts.gstatic.com/s/andadapro/v20/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRudYHrjNJ82Stjw.ttf"
+        "500": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DP7BY8cFLzvIt2S.ttf",
+        "600": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DMXAo8cFLzvIt2S.ttf",
+        "700": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DMuAo8cFLzvIt2S.ttf",
+        "800": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DNJAo8cFLzvIt2S.ttf",
+        "regular": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DPJBY8cFLzvIt2S.ttf",
+        "italic": "https://fonts.gstatic.com/s/andadapro/v21/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRmdfHrjNJ82Stjw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/andadapro/v21/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRlVfHrjNJ82Stjw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/andadapro/v21/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRrlYHrjNJ82Stjw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/andadapro/v21/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRoBYHrjNJ82Stjw.ttf",
+        "800italic": "https://fonts.gstatic.com/s/andadapro/v21/HhyGU5Qi9-SuOEhPe4LtAIxwRrn9L22O2yYBRudYHrjNJ82Stjw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/andadapro/v20/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DPJBb8dHrg.ttf"
+      "menu": "https://fonts.gstatic.com/s/andadapro/v21/HhyEU5Qi9-SuOEhPe4LtKoVCuWGURPcg3DPJBb8dHrg.ttf"
     },
     {
       "family": "Andika",
@@ -4627,25 +4662,25 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fYTBSdRoFPOl8-E.ttf",
-        "600": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fWjGSdRoFPOl8-E.ttf",
-        "700": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fVHGSdRoFPOl8-E.ttf",
-        "800": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fTbGSdRoFPOl8-E.ttf",
-        "900": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fR_GSdRoFPOl8-E.ttf",
-        "regular": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fbbBSdRoFPOl8-E.ttf",
-        "italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CoZdiENGg4-E04A.ttf",
-        "500italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6Ck5diENGg4-E04A.ttf",
-        "600italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6Cf5BiENGg4-E04A.ttf",
-        "700italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CRpBiENGg4-E04A.ttf",
-        "800italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CIZBiENGg4-E04A.ttf",
-        "900italic": "https://fonts.gstatic.com/s/besley/v19/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CCJBiENGg4-E04A.ttf"
+        "500": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fYTBSdRoFPOl8-E.ttf",
+        "600": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fWjGSdRoFPOl8-E.ttf",
+        "700": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fVHGSdRoFPOl8-E.ttf",
+        "800": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fTbGSdRoFPOl8-E.ttf",
+        "900": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fR_GSdRoFPOl8-E.ttf",
+        "regular": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fbbBSdRoFPOl8-E.ttf",
+        "italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CoZdiENGg4-E04A.ttf",
+        "500italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6Ck5diENGg4-E04A.ttf",
+        "600italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6Cf5BiENGg4-E04A.ttf",
+        "700italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CRpBiENGg4-E04A.ttf",
+        "800italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CIZBiENGg4-E04A.ttf",
+        "900italic": "https://fonts.gstatic.com/s/besley/v20/PlIjFlO1MaNwaNG8WR2J-IiUAH-_aH6CCJBiENGg4-E04A.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/besley/v19/PlIhFlO1MaNwaNGWUC92IOH_mtG4fbbBedViEA.ttf"
+      "menu": "https://fonts.gstatic.com/s/besley/v20/PlIhFlO1MaNwaNGWUC92IOH_mtG4fbbBedViEA.ttf"
     },
     {
       "family": "Beth Ellen",
@@ -5435,16 +5470,16 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2024-09-30",
       "files": {
-        "700": "https://fonts.gstatic.com/s/bonanova/v10/B50IF7ZCpX7fcHfvIUBxN4dOFISeJY8GgQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/bonanova/v10/B50NF7ZCpX7fcHfvIUBJi6hqHK-CLA.ttf",
-        "italic": "https://fonts.gstatic.com/s/bonanova/v10/B50LF7ZCpX7fcHfvIUB5iaJuPqqSLJYf.ttf"
+        "700": "https://fonts.gstatic.com/s/bonanova/v11/B50IF7ZCpX7fcHfvIUBxN4dOFISeJY8GgQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/bonanova/v11/B50NF7ZCpX7fcHfvIUBJi6hqHK-CLA.ttf",
+        "italic": "https://fonts.gstatic.com/s/bonanova/v11/B50LF7ZCpX7fcHfvIUB5iaJuPqqSLJYf.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bonanova/v10/B50NF7ZCpX7fcHfvIUB5iqJu.ttf"
+      "menu": "https://fonts.gstatic.com/s/bonanova/v11/B50NF7ZCpX7fcHfvIUB5iqJu.ttf"
     },
     {
       "family": "Bona Nova SC",
@@ -5726,21 +5761,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/brygada1918/v22/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y12f-V8Wu5O3gbo.ttf",
-        "600": "https://fonts.gstatic.com/s/brygada1918/v22/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y7GY-V8Wu5O3gbo.ttf",
-        "700": "https://fonts.gstatic.com/s/brygada1918/v22/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y4iY-V8Wu5O3gbo.ttf",
-        "regular": "https://fonts.gstatic.com/s/brygada1918/v22/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y2-f-V8Wu5O3gbo.ttf",
-        "italic": "https://fonts.gstatic.com/s/brygada1918/v22/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfcERwcv7GykboaLg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/brygada1918/v22/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfcIxwcv7GykboaLg.ttf",
-        "600italic": "https://fonts.gstatic.com/s/brygada1918/v22/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfczxscv7GykboaLg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/brygada1918/v22/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfc9hscv7GykboaLg.ttf"
+        "500": "https://fonts.gstatic.com/s/brygada1918/v25/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y12f-V8Wu5O3gbo.ttf",
+        "600": "https://fonts.gstatic.com/s/brygada1918/v25/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y7GY-V8Wu5O3gbo.ttf",
+        "700": "https://fonts.gstatic.com/s/brygada1918/v25/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y4iY-V8Wu5O3gbo.ttf",
+        "regular": "https://fonts.gstatic.com/s/brygada1918/v25/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y2-f-V8Wu5O3gbo.ttf",
+        "italic": "https://fonts.gstatic.com/s/brygada1918/v25/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfcERwcv7GykboaLg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/brygada1918/v25/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfcIxwcv7GykboaLg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/brygada1918/v25/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfczxscv7GykboaLg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/brygada1918/v25/pe06MI6eKpdGqlF5LANrM--qAeRhe6D4yip43qfc9hscv7GykboaLg.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/brygada1918/v22/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y2-fyV4cvw.ttf"
+      "menu": "https://fonts.gstatic.com/s/brygada1918/v25/pe08MI6eKpdGqlF5LANrM--ACNaeo8mTUIR_y2-fyV4cvw.ttf"
     },
     {
       "family": "Bubblegum Sans",
@@ -6286,14 +6321,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-09-30",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/cambo/v17/IFSqHeNEk8FJk416ok7xkPm8.ttf"
+        "regular": "https://fonts.gstatic.com/s/cambo/v18/IFSqHeNEk8FJk416ok7xkPm8.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cambo/v17/IFSqHeNEk8FJk717qEo.ttf"
+      "menu": "https://fonts.gstatic.com/s/cambo/v18/IFSqHeNEk8FJk717qEo.ttf"
     },
     {
       "family": "Candal",
@@ -9196,6 +9231,40 @@
       "menu": "https://fonts.gstatic.com/s/dotgothic16/v18/v6-QGYjBJFKgyw5nSoDAGH7K6Xo.ttf"
     },
     {
+      "family": "Doto",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOOez0WSvrlpgw.ttf",
+        "200": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOKez0WSvrlpgw.ttf",
+        "300": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFZuKez0WSvrlpgw.ttf",
+        "500": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFCuKez0WSvrlpgw.ttf",
+        "600": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF5uWez0WSvrlpgw.ttf",
+        "700": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF3-Wez0WSvrlpgw.ttf",
+        "800": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOWez0WSvrlpgw.ttf",
+        "900": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFkeWez0WSvrlpgw.ttf",
+        "regular": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKez0WSvrlpgw.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKuzk-W.ttf"
+    },
+    {
       "family": "Dr Sugiyama",
       "variants": [
         "regular"
@@ -9297,23 +9366,23 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-04",
+      "version": "v30",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-2fRUA4V-e6yHgQ.ttf",
-        "600": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-NfNUA4V-e6yHgQ.ttf",
-        "700": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUA4V-e6yHgQ.ttf",
-        "800": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-a_NUA4V-e6yHgQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RUA4V-e6yHgQ.ttf",
-        "italic": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7e8QI96WamXgXFI.ttf",
-        "500italic": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7eOQI96WamXgXFI.ttf",
-        "600italic": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7diR496WamXgXFI.ttf",
-        "700italic": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7dbR496WamXgXFI.ttf",
-        "800italic": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7c8R496WamXgXFI.ttf"
+        "500": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-2fRUA4V-e6yHgQ.ttf",
+        "600": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-NfNUA4V-e6yHgQ.ttf",
+        "700": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-DPNUA4V-e6yHgQ.ttf",
+        "800": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-a_NUA4V-e6yHgQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RUA4V-e6yHgQ.ttf",
+        "italic": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7e8QI96WamXgXFI.ttf",
+        "500italic": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7eOQI96WamXgXFI.ttf",
+        "600italic": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7diR496WamXgXFI.ttf",
+        "700italic": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7dbR496WamXgXFI.ttf",
+        "800italic": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGFmQSNjdsmc35JDF1K5GRwUjcdlttVFm-rI7c8R496WamXgXFI.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ebgaramond/v27/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RkAo96.ttf"
+      "menu": "https://fonts.gstatic.com/s/ebgaramond/v30/SlGDmQSNjdsmc35JDF1K5E55YMjF_7DPuGi-6_RkAo96.ttf"
     },
     {
       "family": "Eagle Lake",
@@ -9423,6 +9492,54 @@
       "menu": "https://fonts.gstatic.com/s/eczar/v22/BXR2vF3Pi-DLmxcpJB-qbNTyTMDXHd6mqDgR.ttf"
     },
     {
+      "family": "Edu AU VIC WA NT Dots",
+      "variants": [
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-09-23",
+      "files": {
+        "500": "https://fonts.gstatic.com/s/eduauvicwantdots/v1/S6uQw5FFVDKI3kwwDUbsPHCpzZNhzrA3or3_B4dZ6MmTX8QNLslYEtmT2SB3_5U.ttf",
+        "600": "https://fonts.gstatic.com/s/eduauvicwantdots/v1/S6uQw5FFVDKI3kwwDUbsPHCpzZNhzrA3or3_B4dZ6MmTX8QNLiVfEtmT2SB3_5U.ttf",
+        "700": "https://fonts.gstatic.com/s/eduauvicwantdots/v1/S6uQw5FFVDKI3kwwDUbsPHCpzZNhzrA3or3_B4dZ6MmTX8QNLhxfEtmT2SB3_5U.ttf",
+        "regular": "https://fonts.gstatic.com/s/eduauvicwantdots/v1/S6uQw5FFVDKI3kwwDUbsPHCpzZNhzrA3or3_B4dZ6MmTX8QNLvtYEtmT2SB3_5U.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/eduauvicwantdots/v1/S6uQw5FFVDKI3kwwDUbsPHCpzZNhzrA3or3_B4dZ6MmTX8QNLvtYItiZ3Q.ttf"
+    },
+    {
+      "family": "Edu AU VIC WA NT Guides",
+      "variants": [
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-09-23",
+      "files": {
+        "500": "https://fonts.gstatic.com/s/eduauvicwantguides/v1/TuG-UUJ4V48KZ9Nr3ZV46JQkJxtkFIKnvy00LCZuAcLMeb8FnyPdGVZazoF08FsYlA.ttf",
+        "600": "https://fonts.gstatic.com/s/eduauvicwantguides/v1/TuG-UUJ4V48KZ9Nr3ZV46JQkJxtkFIKnvy00LCZuAcLMeb8FnyPd9VFazoF08FsYlA.ttf",
+        "700": "https://fonts.gstatic.com/s/eduauvicwantguides/v1/TuG-UUJ4V48KZ9Nr3ZV46JQkJxtkFIKnvy00LCZuAcLMeb8FnyPdzFFazoF08FsYlA.ttf",
+        "regular": "https://fonts.gstatic.com/s/eduauvicwantguides/v1/TuG-UUJ4V48KZ9Nr3ZV46JQkJxtkFIKnvy00LCZuAcLMeb8FnyPdK1ZazoF08FsYlA.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/eduauvicwantguides/v1/TuG-UUJ4V48KZ9Nr3ZV46JQkJxtkFIKnvy00LCZuAcLMeb8FnyPdK1Zqz4tw.ttf"
+    },
+    {
       "family": "Edu AU VIC WA NT Hand",
       "variants": [
         "regular",
@@ -9445,6 +9562,30 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/eduauvicwanthand/v1/C8cO4dY1tX2x0uuiUHFS4y7ERV-jfqJ6x063HfvcsxiYKifhtCJ1pKpPaQ.ttf"
+    },
+    {
+      "family": "Edu AU VIC WA NT Pre",
+      "variants": [
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "500": "https://fonts.gstatic.com/s/eduauvicwantpre/v1/f0Xc0fWk-t0rbG8Ycr-t55aG0elTWbFeXaYI98CnuNLeosIyFGkwr6MhKkg6nw.ttf",
+        "600": "https://fonts.gstatic.com/s/eduauvicwantpre/v1/f0Xc0fWk-t0rbG8Ycr-t55aG0elTWbFeXaYI98CnuNLeosIy-G4wr6MhKkg6nw.ttf",
+        "700": "https://fonts.gstatic.com/s/eduauvicwantpre/v1/f0Xc0fWk-t0rbG8Ycr-t55aG0elTWbFeXaYI98CnuNLeosIywW4wr6MhKkg6nw.ttf",
+        "regular": "https://fonts.gstatic.com/s/eduauvicwantpre/v1/f0Xc0fWk-t0rbG8Ycr-t55aG0elTWbFeXaYI98CnuNLeosIyJmkwr6MhKkg6nw.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/eduauvicwantpre/v1/f0Xc0fWk-t0rbG8Ycr-t55aG0elTWbFeXaYI98CnuNLeosIyJmkArqkl.ttf"
     },
     {
       "family": "Edu NSW ACT Foundation",
@@ -10194,31 +10335,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvOcPtq-rpvLpQ.ttf",
-        "200": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jPvKcPtq-rpvLpQ.ttf",
-        "300": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8j4PKcPtq-rpvLpQ.ttf",
-        "500": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jjPKcPtq-rpvLpQ.ttf",
-        "600": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jYPWcPtq-rpvLpQ.ttf",
-        "700": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jWfWcPtq-rpvLpQ.ttf",
-        "800": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jPvWcPtq-rpvLpQ.ttf",
-        "900": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jF_WcPtq-rpvLpQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvKcPtq-rpvLpQ.ttf",
-        "100italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drF0fNC6jJ7bpQBL.ttf",
-        "200italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drH0fdC6jJ7bpQBL.ttf",
-        "300italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drEqfdC6jJ7bpQBL.ttf",
-        "italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drF0fdC6jJ7bpQBL.ttf",
-        "500italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drFGfdC6jJ7bpQBL.ttf",
-        "600italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drGqetC6jJ7bpQBL.ttf",
-        "700italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drGTetC6jJ7bpQBL.ttf",
-        "800italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drH0etC6jJ7bpQBL.ttf",
-        "900italic": "https://fonts.gstatic.com/s/exo2/v21/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drHdetC6jJ7bpQBL.ttf"
+        "100": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvOcPtq-rpvLpQ.ttf",
+        "200": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jPvKcPtq-rpvLpQ.ttf",
+        "300": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8j4PKcPtq-rpvLpQ.ttf",
+        "500": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jjPKcPtq-rpvLpQ.ttf",
+        "600": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jYPWcPtq-rpvLpQ.ttf",
+        "700": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jWfWcPtq-rpvLpQ.ttf",
+        "800": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jPvWcPtq-rpvLpQ.ttf",
+        "900": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jF_WcPtq-rpvLpQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvKcPtq-rpvLpQ.ttf",
+        "100italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drF0fNC6jJ7bpQBL.ttf",
+        "200italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drH0fdC6jJ7bpQBL.ttf",
+        "300italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drEqfdC6jJ7bpQBL.ttf",
+        "italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drF0fdC6jJ7bpQBL.ttf",
+        "500italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drFGfdC6jJ7bpQBL.ttf",
+        "600italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drGqetC6jJ7bpQBL.ttf",
+        "700italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drGTetC6jJ7bpQBL.ttf",
+        "800italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drH0etC6jJ7bpQBL.ttf",
+        "900italic": "https://fonts.gstatic.com/s/exo2/v24/7cH3v4okm5zmbtYtMeA0FKq0Jjg2drHdetC6jJ7bpQBL.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/exo2/v21/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvKsP9C6.ttf"
+      "menu": "https://fonts.gstatic.com/s/exo2/v24/7cH1v4okm5zmbvwkAx_sfcEuiD8jvvKsP9C6.ttf"
     },
     {
       "family": "Expletus Sans",
@@ -10271,6 +10412,24 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/explora/v9/tsstApxFfjUH4wrvQ1uFpg.ttf"
+    },
+    {
+      "family": "Faculty Glyphic",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/facultyglyphic/v1/RrQIbot2-iBvI2mYSyKIrcgoBuQIG-eFNVmULg.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/facultyglyphic/v1/RrQIbot2-iBvI2mYSyKIrcgoBuQ4Gu2B.ttf"
     },
     {
       "family": "Fahkwang",
@@ -10471,14 +10630,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v30",
-      "lastModified": "2024-08-12",
+      "version": "v31",
+      "lastModified": "2024-10-29",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/fasthand/v30/0yb9GDohyKTYn_ZEESkuYkw2rQg1.ttf"
+        "regular": "https://fonts.gstatic.com/s/fasthand/v31/0yb9GDohyKTYn_ZEESkuYkw2rQg1.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fasthand/v30/0yb9GDohyKTYn_ZEERkvaEg.ttf"
+      "menu": "https://fonts.gstatic.com/s/fasthand/v31/0yb9GDohyKTYn_ZEERkvaEg.ttf"
     },
     {
       "family": "Fauna One",
@@ -10650,27 +10809,27 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v6",
+      "lastModified": "2024-09-30",
       "files": {
-        "300": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_chQF5ewkEU4HTy.ttf",
-        "500": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_dNQF5ewkEU4HTy.ttf",
-        "600": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_ehR15ewkEU4HTy.ttf",
-        "700": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_eYR15ewkEU4HTy.ttf",
-        "800": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_f_R15ewkEU4HTy.ttf",
-        "900": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_fWR15ewkEU4HTy.ttf",
-        "regular": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QF5ewkEU4HTy.ttf",
-        "300italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A-gdyEU25WTybO8.ttf",
-        "italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A7YdyEU25WTybO8.ttf",
-        "500italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A4QdyEU25WTybO8.ttf",
-        "600italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A2gayEU25WTybO8.ttf",
-        "700italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A1EayEU25WTybO8.ttf",
-        "800italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3AzYayEU25WTybO8.ttf",
-        "900italic": "https://fonts.gstatic.com/s/figtree/v5/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3Ax8ayEU25WTybO8.ttf"
+        "300": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_chQF5ewkEU4HTy.ttf",
+        "500": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_dNQF5ewkEU4HTy.ttf",
+        "600": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_ehR15ewkEU4HTy.ttf",
+        "700": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_eYR15ewkEU4HTy.ttf",
+        "800": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_f_R15ewkEU4HTy.ttf",
+        "900": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_fWR15ewkEU4HTy.ttf",
+        "regular": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QF5ewkEU4HTy.ttf",
+        "300italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A-gdyEU25WTybO8.ttf",
+        "italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A7YdyEU25WTybO8.ttf",
+        "500italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A4QdyEU25WTybO8.ttf",
+        "600italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A2gayEU25WTybO8.ttf",
+        "700italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A1EayEU25WTybO8.ttf",
+        "800italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3AzYayEU25WTybO8.ttf",
+        "900italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3Ax8ayEU25WTybO8.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/figtree/v5/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QG5fyEU.ttf"
+      "menu": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QG5fyEU.ttf"
     },
     {
       "family": "Finger Paint",
@@ -11519,6 +11678,74 @@
       "menu": "https://fonts.gstatic.com/s/fuggles/v12/k3kQo8UEJOlD1hpOfd_oKw.ttf"
     },
     {
+      "family": "Funnel Display",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYxGPXWMVwIZDKFA.ttf",
+        "500": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYqGPXWMVwIZDKFA.ttf",
+        "600": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYRGTXWMVwIZDKFA.ttf",
+        "700": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYfWTXWMVwIZDKFA.ttf",
+        "800": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYGmTXWMVwIZDKFA.ttf",
+        "regular": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYmmPXWMVwIZDKFA.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/funneldisplay/v1/B50bF7FGv37QNVWgE0ga--4PbZSRJXrOHcLHLoAYmmPnWc90.ttf"
+    },
+    {
+      "family": "Funnel Sans",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAy3mEfm9NnDyL7w.ttf",
+        "500": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAp3mEfm9NnDyL7w.ttf",
+        "600": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAS36Efm9NnDyL7w.ttf",
+        "700": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAcn6Efm9NnDyL7w.ttf",
+        "800": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAFX6Efm9NnDyL7w.ttf",
+        "regular": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAlXmEfm9NnDyL7w.ttf",
+        "300italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXToyPWVJvjmb76XZ.ttf",
+        "italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXTpsPWVJvjmb76XZ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXTpePWVJvjmb76XZ.ttf",
+        "600italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXTqyOmVJvjmb76XZ.ttf",
+        "700italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXTqLOmVJvjmb76XZ.ttf",
+        "800italic": "https://fonts.gstatic.com/s/funnelsans/v1/OpNZno8Dg9bX6Bsp3Wq69Tp3ZBbKP5ZAjyZVXTrsOmVJvjmb76XZ.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/funnelsans/v1/OpNfno8Dg9bX6Bsp3Wq69RB-VukSVv3aISFAlXm0f2VJ.ttf"
+    },
+    {
       "family": "Fustat",
       "variants": [
         "200",
@@ -11899,6 +12126,74 @@
       "category": "sans-serif",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/gayathri/v17/MCoQzAb429DbBilWLLA5-ps.ttf"
+    },
+    {
+      "family": "Geist",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RnOI4nZPby1QNtA.ttf",
+        "200": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RHOM4nZPby1QNtA.ttf",
+        "300": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RwuM4nZPby1QNtA.ttf",
+        "500": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RruM4nZPby1QNtA.ttf",
+        "600": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RQuQ4nZPby1QNtA.ttf",
+        "700": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_Re-Q4nZPby1QNtA.ttf",
+        "800": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RHOQ4nZPby1QNtA.ttf",
+        "900": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RNeQ4nZPby1QNtA.ttf",
+        "regular": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RnOM4nZPby1QNtA.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/geist/v1/gyBhhwUxId8gMGYQMKR3pzfaWI_RnOMInJnf.ttf"
+    },
+    {
+      "family": "Geist Mono",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeE9KZ5T7ihaO_CS.ttf",
+        "200": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeG9KJ5T7ihaO_CS.ttf",
+        "300": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeFjKJ5T7ihaO_CS.ttf",
+        "500": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeEPKJ5T7ihaO_CS.ttf",
+        "600": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeHjL55T7ihaO_CS.ttf",
+        "700": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeHaL55T7ihaO_CS.ttf",
+        "800": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeG9L55T7ihaO_CS.ttf",
+        "900": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeGUL55T7ihaO_CS.ttf",
+        "regular": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeE9KJ5T7ihaO_CS.ttf"
+      },
+      "category": "monospace",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/geistmono/v1/or3yQ6H-1_WfwkMZI_qYPLs1a-t7PU0AbeE9KK5S5Cw.ttf"
     },
     {
       "family": "Gelasio",
@@ -12784,31 +13079,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1-_D3jWttFGmQk.ttf",
-        "200": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD9--D3jWttFGmQk.ttf",
-        "300": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQDwG-D3jWttFGmQk.ttf",
-        "500": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD22-D3jWttFGmQk.ttf",
-        "600": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD4G5D3jWttFGmQk.ttf",
-        "700": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD7i5D3jWttFGmQk.ttf",
-        "800": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD9-5D3jWttFGmQk.ttf",
-        "900": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD_a5D3jWttFGmQk.ttf",
-        "regular": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1--D3jWttFGmQk.ttf",
-        "100italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf95zrcsvNDiQlBYQ.ttf",
-        "200italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ZzvcsvNDiQlBYQ.ttf",
-        "300italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9uTvcsvNDiQlBYQ.ttf",
-        "italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf95zvcsvNDiQlBYQ.ttf",
-        "500italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf91TvcsvNDiQlBYQ.ttf",
-        "600italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9OTzcsvNDiQlBYQ.ttf",
-        "700italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ADzcsvNDiQlBYQ.ttf",
-        "800italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ZzzcsvNDiQlBYQ.ttf",
-        "900italic": "https://fonts.gstatic.com/s/grandstander/v17/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9TjzcsvNDiQlBYQ.ttf"
+        "100": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1-_D3jWttFGmQk.ttf",
+        "200": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD9--D3jWttFGmQk.ttf",
+        "300": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQDwG-D3jWttFGmQk.ttf",
+        "500": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD22-D3jWttFGmQk.ttf",
+        "600": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD4G5D3jWttFGmQk.ttf",
+        "700": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD7i5D3jWttFGmQk.ttf",
+        "800": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD9-5D3jWttFGmQk.ttf",
+        "900": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD_a5D3jWttFGmQk.ttf",
+        "regular": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1--D3jWttFGmQk.ttf",
+        "100italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf95zrcsvNDiQlBYQ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ZzvcsvNDiQlBYQ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9uTvcsvNDiQlBYQ.ttf",
+        "italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf95zvcsvNDiQlBYQ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf91TvcsvNDiQlBYQ.ttf",
+        "600italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9OTzcsvNDiQlBYQ.ttf",
+        "700italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ADzcsvNDiQlBYQ.ttf",
+        "800italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9ZzzcsvNDiQlBYQ.ttf",
+        "900italic": "https://fonts.gstatic.com/s/grandstander/v18/ga6ZawtA-GpSsTWrnNHPCSImbyq1fDGZrzwXGpf9TjzcsvNDiQlBYQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/grandstander/v17/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1--P3ncsg.ttf"
+      "menu": "https://fonts.gstatic.com/s/grandstander/v18/ga6fawtA-GpSsTWrnNHPCSIMZhhKpFjyNZIQD1--P3ncsg.ttf"
     },
     {
       "family": "Grape Nuts",
@@ -13099,16 +13394,16 @@
       "subsets": [
         "latin"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-10-17",
       "files": {
-        "500": "https://fonts.gstatic.com/s/gupter/v14/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf",
-        "700": "https://fonts.gstatic.com/s/gupter/v14/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf",
-        "regular": "https://fonts.gstatic.com/s/gupter/v14/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf"
+        "500": "https://fonts.gstatic.com/s/gupter/v15/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf",
+        "700": "https://fonts.gstatic.com/s/gupter/v15/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf",
+        "regular": "https://fonts.gstatic.com/s/gupter/v15/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gupter/v14/2-cm9JNmxJqPO1QkYJy7.ttf"
+      "menu": "https://fonts.gstatic.com/s/gupter/v15/2-cm9JNmxJqPO1QkYJy7.ttf"
     },
     {
       "family": "Gurajada",
@@ -13901,6 +14196,46 @@
       ]
     },
     {
+      "family": "Host Grotesk",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PubnOzhap-j94InI.ttf",
+        "500": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PudXOzhap-j94InI.ttf",
+        "600": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuTnJzhap-j94InI.ttf",
+        "700": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuQDJzhap-j94InI.ttf",
+        "800": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuWfJzhap-j94InI.ttf",
+        "regular": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefOzhap-j94InI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NeFWj_h19MnL2jg.ttf",
+        "italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NJlWj_h19MnL2jg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NFFWj_h19MnL2jg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-N-FKj_h19MnL2jg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NwVKj_h19MnL2jg.ttf",
+        "800italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NplKj_h19MnL2jg.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefO_hej_g.ttf"
+    },
+    {
       "family": "Hubballi",
       "variants": [
         "regular"
@@ -13918,6 +14253,55 @@
       "category": "sans-serif",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/hubballi/v7/o-0JIpUj3WIZ1RFN55B6whQ.ttf"
+    },
+    {
+      "family": "Hubot Sans",
+      "variants": [
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
+        "900italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "vietnamese"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-05",
+      "files": {
+        "200": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7ZdgLDVwVqcXQ.ttf",
+        "300": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCubZdgLDVwVqcXQ.ttf",
+        "500": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC1bZdgLDVwVqcXQ.ttf",
+        "600": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCObFdgLDVwVqcXQ.ttf",
+        "700": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCALFdgLDVwVqcXQ.ttf",
+        "800": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7FdgLDVwVqcXQ.ttf",
+        "900": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCTrFdgLDVwVqcXQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZdgLDVwVqcXQ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1w7rR41-MXUss.ttf",
+        "300italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_Xrw7rR41-MXUss.ttf",
+        "italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_W1w7rR41-MXUss.ttf",
+        "500italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_WHw7rR41-MXUss.ttf",
+        "600italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VrxLrR41-MXUss.ttf",
+        "700italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VSxLrR41-MXUss.ttf",
+        "800italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1xLrR41-MXUss.ttf",
+        "900italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_UcxLrR41-MXUss.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZtgbrR.ttf"
     },
     {
       "family": "Hurricane",
@@ -15585,29 +15969,29 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yK1jPVmUsaaDhw.ttf",
-        "200": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8SKxjPVmUsaaDhw.ttf",
-        "300": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8lqxjPVmUsaaDhw.ttf",
-        "500": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8-qxjPVmUsaaDhw.ttf",
-        "600": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8FqtjPVmUsaaDhw.ttf",
-        "700": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8L6tjPVmUsaaDhw.ttf",
-        "800": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8SKtjPVmUsaaDhw.ttf",
-        "regular": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.ttf",
-        "100italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-Lf1OQk6OThxPA.ttf",
-        "200italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO8LflOQk6OThxPA.ttf",
-        "300italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO_VflOQk6OThxPA.ttf",
-        "italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-LflOQk6OThxPA.ttf",
-        "500italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-5flOQk6OThxPA.ttf",
-        "600italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO9VeVOQk6OThxPA.ttf",
-        "700italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO9seVOQk6OThxPA.ttf",
-        "800italic": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO8LeVOQk6OThxPA.ttf"
+        "100": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yK1jPVmUsaaDhw.ttf",
+        "200": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8SKxjPVmUsaaDhw.ttf",
+        "300": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8lqxjPVmUsaaDhw.ttf",
+        "500": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8-qxjPVmUsaaDhw.ttf",
+        "600": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8FqtjPVmUsaaDhw.ttf",
+        "700": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8L6tjPVmUsaaDhw.ttf",
+        "800": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8SKtjPVmUsaaDhw.ttf",
+        "regular": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxjPVmUsaaDhw.ttf",
+        "100italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-Lf1OQk6OThxPA.ttf",
+        "200italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO8LflOQk6OThxPA.ttf",
+        "300italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO_VflOQk6OThxPA.ttf",
+        "italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-LflOQk6OThxPA.ttf",
+        "500italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO-5flOQk6OThxPA.ttf",
+        "600italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO9VeVOQk6OThxPA.ttf",
+        "700italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO9seVOQk6OThxPA.ttf",
+        "800italic": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDba2o-flEEny0FZhsfKu5WU4xD-IQ-PuZJJXxfpAO8LeVOQk6OThxPA.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jetbrainsmono/v18/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxTPFOQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/jetbrainsmono/v20/tDbY2o-flEEny0FZhsfKu5WU4zr3E_BX0PnT8RD8yKxTPFOQ.ttf"
     },
     {
       "family": "Jim Nightshade",
@@ -15833,31 +16217,31 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7myjJAVGPokMmuHL.ttf",
-        "200": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mwjJQVGPokMmuHL.ttf",
-        "300": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mz9JQVGPokMmuHL.ttf",
-        "500": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7myRJQVGPokMmuHL.ttf",
-        "600": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mx9IgVGPokMmuHL.ttf",
-        "700": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mxEIgVGPokMmuHL.ttf",
-        "800": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mwjIgVGPokMmuHL.ttf",
-        "900": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7mwKIgVGPokMmuHL.ttf",
-        "regular": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7myjJQVGPokMmuHL.ttf",
-        "100italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZu0ENI0un_HLMEo.ttf",
-        "200italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZm0FNI0un_HLMEo.ttf",
-        "300italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZrMFNI0un_HLMEo.ttf",
-        "italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZu0FNI0un_HLMEo.ttf",
-        "500italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZt8FNI0un_HLMEo.ttf",
-        "600italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZjMCNI0un_HLMEo.ttf",
-        "700italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZgoCNI0un_HLMEo.ttf",
-        "800italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZm0CNI0un_HLMEo.ttf",
-        "900italic": "https://fonts.gstatic.com/s/jost/v15/92zJtBhPNqw73oHH7BbQp4-B6XlrZkQCNI0un_HLMEo.ttf"
+        "100": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7myjJAVGPokMmuHL.ttf",
+        "200": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mwjJQVGPokMmuHL.ttf",
+        "300": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mz9JQVGPokMmuHL.ttf",
+        "500": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7myRJQVGPokMmuHL.ttf",
+        "600": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mx9IgVGPokMmuHL.ttf",
+        "700": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mxEIgVGPokMmuHL.ttf",
+        "800": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mwjIgVGPokMmuHL.ttf",
+        "900": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7mwKIgVGPokMmuHL.ttf",
+        "regular": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7myjJQVGPokMmuHL.ttf",
+        "100italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZu0ENI0un_HLMEo.ttf",
+        "200italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZm0FNI0un_HLMEo.ttf",
+        "300italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZrMFNI0un_HLMEo.ttf",
+        "italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZu0FNI0un_HLMEo.ttf",
+        "500italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZt8FNI0un_HLMEo.ttf",
+        "600italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZjMCNI0un_HLMEo.ttf",
+        "700italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZgoCNI0un_HLMEo.ttf",
+        "800italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZm0CNI0un_HLMEo.ttf",
+        "900italic": "https://fonts.gstatic.com/s/jost/v18/92zJtBhPNqw73oHH7BbQp4-B6XlrZkQCNI0un_HLMEo.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jost/v15/92zPtBhPNqw79Ij1E865zBUv7myjJTVHNI0.ttf"
+      "menu": "https://fonts.gstatic.com/s/jost/v18/92zPtBhPNqw79Ij1E865zBUv7myjJTVHNI0.ttf"
     },
     {
       "family": "Joti One",
@@ -16166,16 +16550,16 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2024-10-29",
       "files": {
-        "500": "https://fonts.gstatic.com/s/kaiseiharunoumi/v9/HI_WiZQSLqBQoAHhK_C6N_nzy_jcIj_QlMcFwmC9FAU.ttf",
-        "700": "https://fonts.gstatic.com/s/kaiseiharunoumi/v9/HI_WiZQSLqBQoAHhK_C6N_nzy_jcInfWlMcFwmC9FAU.ttf",
-        "regular": "https://fonts.gstatic.com/s/kaiseiharunoumi/v9/HI_RiZQSLqBQoAHhK_C6N_nzy_jcGsv5sM8u3mk.ttf"
+        "500": "https://fonts.gstatic.com/s/kaiseiharunoumi/v10/HI_WiZQSLqBQoAHhK_C6N_nzy_jcIj_QlMcFwmC9FAU.ttf",
+        "700": "https://fonts.gstatic.com/s/kaiseiharunoumi/v10/HI_WiZQSLqBQoAHhK_C6N_nzy_jcInfWlMcFwmC9FAU.ttf",
+        "regular": "https://fonts.gstatic.com/s/kaiseiharunoumi/v10/HI_RiZQSLqBQoAHhK_C6N_nzy_jcGsv5sM8u3mk.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kaiseiharunoumi/v9/HI_RiZQSLqBQoAHhK_C6N_nzy_jcKsrztA.ttf"
+      "menu": "https://fonts.gstatic.com/s/kaiseiharunoumi/v10/HI_RiZQSLqBQoAHhK_C6N_nzy_jcKsrztA.ttf"
     },
     {
       "family": "Kaisei Opti",
@@ -16190,16 +16574,16 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2024-10-29",
       "files": {
-        "500": "https://fonts.gstatic.com/s/kaiseiopti/v9/QldXNThJphYb8_g6c2nlIGGqxY1u7f34DYwn.ttf",
-        "700": "https://fonts.gstatic.com/s/kaiseiopti/v9/QldXNThJphYb8_g6c2nlIGHiw41u7f34DYwn.ttf",
-        "regular": "https://fonts.gstatic.com/s/kaiseiopti/v9/QldKNThJphYb8_g6c2nlIFle7KlmxuHx.ttf"
+        "500": "https://fonts.gstatic.com/s/kaiseiopti/v10/QldXNThJphYb8_g6c2nlIGGqxY1u7f34DYwn.ttf",
+        "700": "https://fonts.gstatic.com/s/kaiseiopti/v10/QldXNThJphYb8_g6c2nlIGHiw41u7f34DYwn.ttf",
+        "regular": "https://fonts.gstatic.com/s/kaiseiopti/v10/QldKNThJphYb8_g6c2nlIFle7KlmxuHx.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kaiseiopti/v9/QldKNThJphYb8_g6c2nlIGlf5q0.ttf"
+      "menu": "https://fonts.gstatic.com/s/kaiseiopti/v10/QldKNThJphYb8_g6c2nlIGlf5q0.ttf"
     },
     {
       "family": "Kaisei Tokumin",
@@ -16215,17 +16599,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2024-10-29",
       "files": {
-        "500": "https://fonts.gstatic.com/s/kaiseitokumin/v9/Gg8vN5wdZg7xCwuMsylww2ZiQnqr_3khpMIzeI6v.ttf",
-        "700": "https://fonts.gstatic.com/s/kaiseitokumin/v9/Gg8vN5wdZg7xCwuMsylww2ZiQnrj-XkhpMIzeI6v.ttf",
-        "800": "https://fonts.gstatic.com/s/kaiseitokumin/v9/Gg8vN5wdZg7xCwuMsylww2ZiQnr_-nkhpMIzeI6v.ttf",
-        "regular": "https://fonts.gstatic.com/s/kaiseitokumin/v9/Gg8sN5wdZg7xCwuMsylww2ZiQkJf1l0pj946.ttf"
+        "500": "https://fonts.gstatic.com/s/kaiseitokumin/v10/Gg8vN5wdZg7xCwuMsylww2ZiQnqr_3khpMIzeI6v.ttf",
+        "700": "https://fonts.gstatic.com/s/kaiseitokumin/v10/Gg8vN5wdZg7xCwuMsylww2ZiQnrj-XkhpMIzeI6v.ttf",
+        "800": "https://fonts.gstatic.com/s/kaiseitokumin/v10/Gg8vN5wdZg7xCwuMsylww2ZiQnr_-nkhpMIzeI6v.ttf",
+        "regular": "https://fonts.gstatic.com/s/kaiseitokumin/v10/Gg8sN5wdZg7xCwuMsylww2ZiQkJf1l0pj946.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kaiseitokumin/v9/Gg8sN5wdZg7xCwuMsylww2ZiQnJe3Fk.ttf"
+      "menu": "https://fonts.gstatic.com/s/kaiseitokumin/v10/Gg8sN5wdZg7xCwuMsylww2ZiQnJe3Fk.ttf"
     },
     {
       "family": "Kalam",
@@ -16239,16 +16623,16 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-10-29",
       "files": {
-        "300": "https://fonts.gstatic.com/s/kalam/v16/YA9Qr0Wd4kDdMtD6GgLLmCUItqGt.ttf",
-        "700": "https://fonts.gstatic.com/s/kalam/v16/YA9Qr0Wd4kDdMtDqHQLLmCUItqGt.ttf",
-        "regular": "https://fonts.gstatic.com/s/kalam/v16/YA9dr0Wd4kDdMuhWMibDszkB.ttf"
+        "300": "https://fonts.gstatic.com/s/kalam/v17/YA9Qr0Wd4kDdMtD6GgLLmCUItqGt.ttf",
+        "700": "https://fonts.gstatic.com/s/kalam/v17/YA9Qr0Wd4kDdMtDqHQLLmCUItqGt.ttf",
+        "regular": "https://fonts.gstatic.com/s/kalam/v17/YA9dr0Wd4kDdMuhWMibDszkB.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kalam/v16/YA9dr0Wd4kDdMthXOCI.ttf"
+      "menu": "https://fonts.gstatic.com/s/kalam/v17/YA9dr0Wd4kDdMthXOCI.ttf"
     },
     {
       "family": "Kalnia",
@@ -16415,27 +16799,27 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v9",
+      "lastModified": "2024-10-29",
       "files": {
-        "100": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urUs0M34dR6dW.ttf",
-        "200": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg3urEs0M34dR6dW.ttf",
-        "300": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg0wrEs0M34dR6dW.ttf",
-        "500": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1crEs0M34dR6dW.ttf",
-        "600": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg2wq0s0M34dR6dW.ttf",
-        "700": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg2Jq0s0M34dR6dW.ttf",
-        "regular": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urEs0M34dR6dW.ttf",
-        "100italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim76N2OXo_QrdWlcU.ttf",
-        "200italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim7yN3OXo_QrdWlcU.ttf",
-        "300italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim7_13OXo_QrdWlcU.ttf",
-        "italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim76N3OXo_QrdWlcU.ttf",
-        "500italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim75F3OXo_QrdWlcU.ttf",
-        "600italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim731wOXo_QrdWlcU.ttf",
-        "700italic": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim70RwOXo_QrdWlcU.ttf"
+        "100": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urUs0M34dR6dW.ttf",
+        "200": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg3urEs0M34dR6dW.ttf",
+        "300": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg0wrEs0M34dR6dW.ttf",
+        "500": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1crEs0M34dR6dW.ttf",
+        "600": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg2wq0s0M34dR6dW.ttf",
+        "700": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg2Jq0s0M34dR6dW.ttf",
+        "regular": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urEs0M34dR6dW.ttf",
+        "100italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim76N2OXo_QrdWlcU.ttf",
+        "200italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim7yN3OXo_QrdWlcU.ttf",
+        "300italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim7_13OXo_QrdWlcU.ttf",
+        "italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim76N3OXo_QrdWlcU.ttf",
+        "500italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim75F3OXo_QrdWlcU.ttf",
+        "600italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim731wOXo_QrdWlcU.ttf",
+        "700italic": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2RY5aECkp34vEBSPFOmJxwlEbbdY1VU_nxzRim70RwOXo_QrdWlcU.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kantumruypro/v8/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urHs1OXo.ttf"
+      "menu": "https://fonts.gstatic.com/s/kantumruypro/v9/1q2TY5aECkp34vEBSPFOmJxwvk_pilU8OGNfyg1urHs1OXo.ttf"
     },
     {
       "family": "Karantina",
@@ -16505,6 +16889,44 @@
       "menu": "https://fonts.gstatic.com/s/karla/v31/qkBIXvYC6trAT55ZBi1ueQVIjQTD-JqaFUlP.ttf"
     },
     {
+      "family": "Karla Tamil Inclined",
+      "variants": [
+        "regular",
+        "700"
+      ],
+      "subsets": [
+        "tamil"
+      ],
+      "version": "v2",
+      "lastModified": "2024-10-29",
+      "files": {
+        "700": "https://fonts.gstatic.com/s/karlatamilinclined/v2/vm8mdQ3vXFXZ1aPd8dNzR82AFh2TibkaVo-nkrf5Iy7YGkI1.ttf",
+        "regular": "https://fonts.gstatic.com/s/karlatamilinclined/v2/vm8pdQ3vXFXZ1aPd8dNzR82AFh2TibkaVrcbvZPxCDLR.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/karlatamilinclined/v2/vm8pdQ3vXFXZ1aPd8dNzR82AFh2TibkaVocat5c.ttf"
+    },
+    {
+      "family": "Karla Tamil Upright",
+      "variants": [
+        "regular",
+        "700"
+      ],
+      "subsets": [
+        "tamil"
+      ],
+      "version": "v2",
+      "lastModified": "2024-10-29",
+      "files": {
+        "700": "https://fonts.gstatic.com/s/karlatamilupright/v2/IFS1HfVMk95HnY0u6SeQ_cHoozW_3U5XmK5SoKcPLKclE4o.ttf",
+        "regular": "https://fonts.gstatic.com/s/karlatamilupright/v2/IFS4HfVMk95HnY0u6SeQ_cHoozW_3U5XoBJ9hK8kMK4.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/karlatamilupright/v2/IFS4HfVMk95HnY0u6SeQ_cHoozW_3U5XkBN3gA.ttf"
+    },
+    {
       "family": "Karma",
       "variants": [
         "300",
@@ -16518,18 +16940,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-10-29",
       "files": {
-        "300": "https://fonts.gstatic.com/s/karma/v16/va9F4kzAzMZRGLjDY8Z_uqzGQC_-.ttf",
-        "500": "https://fonts.gstatic.com/s/karma/v16/va9F4kzAzMZRGLibYsZ_uqzGQC_-.ttf",
-        "600": "https://fonts.gstatic.com/s/karma/v16/va9F4kzAzMZRGLi3ZcZ_uqzGQC_-.ttf",
-        "700": "https://fonts.gstatic.com/s/karma/v16/va9F4kzAzMZRGLjTZMZ_uqzGQC_-.ttf",
-        "regular": "https://fonts.gstatic.com/s/karma/v16/va9I4kzAzMZRGIBvS-J3kbDP.ttf"
+        "300": "https://fonts.gstatic.com/s/karma/v17/va9F4kzAzMZRGLjDY8Z_uqzGQC_-.ttf",
+        "500": "https://fonts.gstatic.com/s/karma/v17/va9F4kzAzMZRGLibYsZ_uqzGQC_-.ttf",
+        "600": "https://fonts.gstatic.com/s/karma/v17/va9F4kzAzMZRGLi3ZcZ_uqzGQC_-.ttf",
+        "700": "https://fonts.gstatic.com/s/karma/v17/va9F4kzAzMZRGLjTZMZ_uqzGQC_-.ttf",
+        "regular": "https://fonts.gstatic.com/s/karma/v17/va9I4kzAzMZRGIBvS-J3kbDP.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/karma/v16/va9I4kzAzMZRGLBuQeY.ttf"
+      "menu": "https://fonts.gstatic.com/s/karma/v17/va9I4kzAzMZRGLBuQeY.ttf"
     },
     {
       "family": "Katibeh",
@@ -16541,14 +16963,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-10-29",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/katibeh/v19/ZGjXol5MQJog4bxDaC1RVDNdGDs.ttf"
+        "regular": "https://fonts.gstatic.com/s/katibeh/v20/ZGjXol5MQJog4bxDaC1RVDNdGDs.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/katibeh/v19/ZGjXol5MQJog4bxDWCxbUA.ttf"
+      "menu": "https://fonts.gstatic.com/s/katibeh/v20/ZGjXol5MQJog4bxDWCxbUA.ttf"
     },
     {
       "family": "Kaushan Script",
@@ -16640,14 +17062,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v4",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2024-10-29",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/kdamthmorpro/v4/EJRPQgAzVdcI-Qdvt34jzurnGA7_j89I8ZWb.ttf"
+        "regular": "https://fonts.gstatic.com/s/kdamthmorpro/v5/EJRPQgAzVdcI-Qdvt34jzurnGA7_j89I8ZWb.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kdamthmorpro/v4/EJRPQgAzVdcI-Qdvt34jzurnGD7-hcs.ttf"
+      "menu": "https://fonts.gstatic.com/s/kdamthmorpro/v5/EJRPQgAzVdcI-Qdvt34jzurnGD7-hcs.ttf"
     },
     {
       "family": "Keania One",
@@ -17961,22 +18383,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsX_LBte6KuGEo.ttf",
-        "200": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sW_LBte6KuGEo.ttf",
-        "300": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
-        "500": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
-        "600": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
-        "700": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC9wR_LBte6KuGEo.ttf",
-        "800": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sR_LBte6KuGEo.ttf",
-        "900": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WC5IR_LBte6KuGEo.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsW_LBte6KuGEo.ttf"
+        "100": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsX_LBte6KuGEo.ttf",
+        "200": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sW_LBte6KuGEo.ttf",
+        "300": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
+        "500": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
+        "600": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
+        "700": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC9wR_LBte6KuGEo.ttf",
+        "800": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sR_LBte6KuGEo.ttf",
+        "900": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC5IR_LBte6KuGEo.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsW_LBte6KuGEo.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexend/v19/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsWzLFnfw.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsWzLFnfw.ttf"
     },
     {
       "family": "Lexend Deca",
@@ -18460,35 +18882,37 @@
         "900italic"
       ],
       "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
         "latin",
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsSUB9rIb-JH1g.ttf",
-        "200": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhrsWUB9rIb-JH1g.ttf",
-        "300": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhcMWUB9rIb-JH1g.ttf",
-        "500": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhHMWUB9rIb-JH1g.ttf",
-        "600": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduh8MKUB9rIb-JH1g.ttf",
-        "700": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhycKUB9rIb-JH1g.ttf",
-        "800": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhrsKUB9rIb-JH1g.ttf",
-        "900": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhh8KUB9rIb-JH1g.ttf",
-        "regular": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWUB9rIb-JH1g.ttf",
-        "100italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZ8RdDMTedX1sGE.ttf",
-        "200italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05ob8RNDMTedX1sGE.ttf",
-        "300italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oYiRNDMTedX1sGE.ttf",
-        "italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZ8RNDMTedX1sGE.ttf",
-        "500italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZORNDMTedX1sGE.ttf",
-        "600italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oaiQ9DMTedX1sGE.ttf",
-        "700italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oabQ9DMTedX1sGE.ttf",
-        "800italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05ob8Q9DMTedX1sGE.ttf",
-        "900italic": "https://fonts.gstatic.com/s/librefranklin/v14/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05obVQ9DMTedX1sGE.ttf"
+        "100": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsSUB9rIb-JH1g.ttf",
+        "200": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhrsWUB9rIb-JH1g.ttf",
+        "300": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhcMWUB9rIb-JH1g.ttf",
+        "500": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhHMWUB9rIb-JH1g.ttf",
+        "600": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduh8MKUB9rIb-JH1g.ttf",
+        "700": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhycKUB9rIb-JH1g.ttf",
+        "800": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhrsKUB9rIb-JH1g.ttf",
+        "900": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhh8KUB9rIb-JH1g.ttf",
+        "regular": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWUB9rIb-JH1g.ttf",
+        "100italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZ8RdDMTedX1sGE.ttf",
+        "200italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05ob8RNDMTedX1sGE.ttf",
+        "300italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oYiRNDMTedX1sGE.ttf",
+        "italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZ8RNDMTedX1sGE.ttf",
+        "500italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oZORNDMTedX1sGE.ttf",
+        "600italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oaiQ9DMTedX1sGE.ttf",
+        "700italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05oabQ9DMTedX1sGE.ttf",
+        "800italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05ob8Q9DMTedX1sGE.ttf",
+        "900italic": "https://fonts.gstatic.com/s/librefranklin/v18/jizMREVItHgc8qDIbSTKq4XkRiUawTk7f45UM9y05obVQ9DMTedX1sGE.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librefranklin/v14/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkBtDM.ttf"
+      "menu": "https://fonts.gstatic.com/s/librefranklin/v18/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkBtDM.ttf"
     },
     {
       "family": "Licorice",
@@ -19224,22 +19648,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v11",
-      "lastModified": "2024-08-07",
+      "version": "v12",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSe78nZcsGGycA.ttf",
-        "200": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW51Sa78nZcsGGycA.ttf",
-        "300": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5Cya78nZcsGGycA.ttf",
-        "500": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5Zya78nZcsGGycA.ttf",
-        "600": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5iyG78nZcsGGycA.ttf",
-        "700": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5siG78nZcsGGycA.ttf",
-        "800": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW51SG78nZcsGGycA.ttf",
-        "900": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5_CG78nZcsGGycA.ttf",
-        "regular": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSa78nZcsGGycA.ttf"
+        "100": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSe78nZcsGGycA.ttf",
+        "200": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW51Sa78nZcsGGycA.ttf",
+        "300": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5Cya78nZcsGGycA.ttf",
+        "500": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5Zya78nZcsGGycA.ttf",
+        "600": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5iyG78nZcsGGycA.ttf",
+        "700": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5siG78nZcsGGycA.ttf",
+        "800": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW51SG78nZcsGGycA.ttf",
+        "900": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5_CG78nZcsGGycA.ttf",
+        "regular": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSa78nZcsGGycA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mplus1/v11/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSaL83xY.ttf"
+      "menu": "https://fonts.gstatic.com/s/mplus1/v12/R70EjygA28ymD4HgBUGzkN5Eyoj-WpW5VSaL83xY.ttf"
     },
     {
       "family": "M PLUS 1 Code",
@@ -19258,20 +19682,20 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-08-07",
+      "version": "v14",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0XHpapwmdZhY.ttf",
-        "200": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7gN0HHpapwmdZhY.ttf",
-        "300": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7jT0HHpapwmdZhY.ttf",
-        "500": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7i_0HHpapwmdZhY.ttf",
-        "600": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7hT13HpapwmdZhY.ttf",
-        "700": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7hq13HpapwmdZhY.ttf",
-        "regular": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0HHpapwmdZhY.ttf"
+        "100": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0XHpapwmdZhY.ttf",
+        "200": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7gN0HHpapwmdZhY.ttf",
+        "300": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7jT0HHpapwmdZhY.ttf",
+        "500": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7i_0HHpapwmdZhY.ttf",
+        "600": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7hT13HpapwmdZhY.ttf",
+        "700": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7hq13HpapwmdZhY.ttf",
+        "regular": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0HHpapwmdZhY.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mplus1code/v13/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0EHoYJg.ttf"
+      "menu": "https://fonts.gstatic.com/s/mplus1code/v14/ypvMbXOOx2xFpzmYJS3N2_J2hBN6RZ5oIp8m_7iN0EHoYJg.ttf"
     },
     {
       "family": "M PLUS 1p",
@@ -19295,20 +19719,20 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v30",
-      "lastModified": "2024-09-04",
+      "version": "v31",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/mplus1p/v30/e3tleuShHdiFyPFzBRrQnDQAUW3aq-5N.ttf",
-        "300": "https://fonts.gstatic.com/s/mplus1p/v30/e3tmeuShHdiFyPFzBRrQVBYge0PWovdU4w.ttf",
-        "500": "https://fonts.gstatic.com/s/mplus1p/v30/e3tmeuShHdiFyPFzBRrQDBcge0PWovdU4w.ttf",
-        "700": "https://fonts.gstatic.com/s/mplus1p/v30/e3tmeuShHdiFyPFzBRrQRBEge0PWovdU4w.ttf",
-        "800": "https://fonts.gstatic.com/s/mplus1p/v30/e3tmeuShHdiFyPFzBRrQWBIge0PWovdU4w.ttf",
-        "900": "https://fonts.gstatic.com/s/mplus1p/v30/e3tmeuShHdiFyPFzBRrQfBMge0PWovdU4w.ttf",
-        "regular": "https://fonts.gstatic.com/s/mplus1p/v30/e3tjeuShHdiFyPFzBRro-D4Ec2jKqw.ttf"
+        "100": "https://fonts.gstatic.com/s/mplus1p/v31/e3tleuShHdiFyPFzBRrQnDQAUW3aq-5N.ttf",
+        "300": "https://fonts.gstatic.com/s/mplus1p/v31/e3tmeuShHdiFyPFzBRrQVBYge0PWovdU4w.ttf",
+        "500": "https://fonts.gstatic.com/s/mplus1p/v31/e3tmeuShHdiFyPFzBRrQDBcge0PWovdU4w.ttf",
+        "700": "https://fonts.gstatic.com/s/mplus1p/v31/e3tmeuShHdiFyPFzBRrQRBEge0PWovdU4w.ttf",
+        "800": "https://fonts.gstatic.com/s/mplus1p/v31/e3tmeuShHdiFyPFzBRrQWBIge0PWovdU4w.ttf",
+        "900": "https://fonts.gstatic.com/s/mplus1p/v31/e3tmeuShHdiFyPFzBRrQfBMge0PWovdU4w.ttf",
+        "regular": "https://fonts.gstatic.com/s/mplus1p/v31/e3tjeuShHdiFyPFzBRro-D4Ec2jKqw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mplus1p/v30/e3tjeuShHdiFyPFzBRrY-TQA.ttf"
+      "menu": "https://fonts.gstatic.com/s/mplus1p/v31/e3tjeuShHdiFyPFzBRrY-TQA.ttf"
     },
     {
       "family": "M PLUS 2",
@@ -19329,22 +19753,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v10",
-      "lastModified": "2024-08-07",
+      "version": "v12",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa-VxlqHrzNgAw.ttf",
-        "200": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwua6VxlqHrzNgAw.ttf",
-        "300": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwZ66VxlqHrzNgAw.ttf",
-        "500": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwC66VxlqHrzNgAw.ttf",
-        "600": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkw56mVxlqHrzNgAw.ttf",
-        "700": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkw3qmVxlqHrzNgAw.ttf",
-        "800": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwuamVxlqHrzNgAw.ttf",
-        "900": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwkKmVxlqHrzNgAw.ttf",
-        "regular": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa6VxlqHrzNgAw.ttf"
+        "100": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa-VxlqHrzNgAw.ttf",
+        "200": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwua6VxlqHrzNgAw.ttf",
+        "300": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwZ66VxlqHrzNgAw.ttf",
+        "500": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwC66VxlqHrzNgAw.ttf",
+        "600": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkw56mVxlqHrzNgAw.ttf",
+        "700": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkw3qmVxlqHrzNgAw.ttf",
+        "800": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwuamVxlqHrzNgAw.ttf",
+        "900": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwkKmVxlqHrzNgAw.ttf",
+        "regular": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa6VxlqHrzNgAw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mplus2/v10/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa6lx1CD.ttf"
+      "menu": "https://fonts.gstatic.com/s/mplus2/v12/7Auhp_Eq3gO_OGbGGhjdwrDdpeIBxlkwOa6lx1CD.ttf"
     },
     {
       "family": "M PLUS Code Latin",
@@ -20169,14 +20593,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2024-11-07",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/matemasie/v2/OD5BuMCN3ne3Gmr7dlL3rEq4DL6w2w.ttf"
+        "regular": "https://fonts.gstatic.com/s/matemasie/v3/OD5BuMCN3ne3Gmr7dlL3rEq4DL6w2w.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/matemasie/v2/OD5BuMCN3ne3Gmr7dlLHrUC8.ttf"
+      "menu": "https://fonts.gstatic.com/s/matemasie/v3/OD5BuMCN3ne3Gmr7dlLHrUC8.ttf"
     },
     {
       "family": "Material Icons",
@@ -20280,20 +20704,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v207",
-      "lastModified": "2024-09-05",
+      "version": "v215",
+      "lastModified": "2024-11-01",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeembd5zrTgt.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOembd5zrTgt.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOembd5zrTgt.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOembd5zrTgt.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-embd5zrTgt.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-embd5zrTgt.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOembd5zrTgt.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeembd5zrTgt.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOembd5zrTgt.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOembd5zrTgt.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOembd5zrTgt.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-embd5zrTgt.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-embd5zrTgt.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOembd5zrTgt.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v207/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHNenZ9o.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHNenZ9o.ttf"
     },
     {
       "family": "Material Symbols Rounded",
@@ -20309,20 +20733,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v206",
-      "lastModified": "2024-09-05",
+      "version": "v214",
+      "lastModified": "2024-11-01",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxKJKJBjAa8.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxKJKJBjAa8.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxKJKJBjAa8.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxKJKJBjAa8.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxKJKJBjAa8.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxKJKJBjAa8.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxKJKJBjAa8.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxKJKJBjAa8.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxKJKJBjAa8.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxKJKJBjAa8.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxKJKJBjAa8.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxKJKJBjAa8.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxKJKJBjAa8.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxKJKJBjAa8.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolsrounded/v206/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelbxODLA.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelbxODLA.ttf"
     },
     {
       "family": "Material Symbols Sharp",
@@ -20338,20 +20762,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v203",
-      "lastModified": "2024-09-05",
+      "version": "v211",
+      "lastModified": "2024-11-01",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCOJ1H7-knk.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCOJ1H7-knk.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCOJ1H7-knk.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCOJ1H7-knk.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCOJ1H7-knk.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCOJ1H7-knk.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCOJ1H7-knk.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCOJ1H7-knk.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCOJ1H7-knk.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCOJ1H7-knk.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCOJ1H7-knk.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCOJ1H7-knk.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCOJ1H7-knk.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCOJ1H7-knk.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolssharp/v203/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLogCPLVU.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLogCPLVU.ttf"
     },
     {
       "family": "Maven Pro",
@@ -20895,6 +21319,8 @@
       "family": "Miriam Libre",
       "variants": [
         "regular",
+        "500",
+        "600",
         "700"
       ],
       "subsets": [
@@ -20902,15 +21328,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-10-29",
       "files": {
-        "700": "https://fonts.gstatic.com/s/miriamlibre/v14/DdT-798HsHwubBAqfkcBTL_X3LbbRcC7_-Z7Hg.ttf",
-        "regular": "https://fonts.gstatic.com/s/miriamlibre/v14/DdTh798HsHwubBAqfkcBTL_vYJn_Teun9g.ttf"
+        "500": "https://fonts.gstatic.com/s/miriamlibre/v16/DdT0798HsHwubBAqfkcBTL_1a7sPlXcE8PJjH-H3k9vGL-8tY7Q.ttf",
+        "600": "https://fonts.gstatic.com/s/miriamlibre/v16/DdT0798HsHwubBAqfkcBTL_1a7sPlXcE8PJjHw3wk9vGL-8tY7Q.ttf",
+        "700": "https://fonts.gstatic.com/s/miriamlibre/v16/DdT0798HsHwubBAqfkcBTL_1a7sPlXcE8PJjHzTwk9vGL-8tY7Q.ttf",
+        "regular": "https://fonts.gstatic.com/s/miriamlibre/v16/DdT0798HsHwubBAqfkcBTL_1a7sPlXcE8PJjH9P3k9vGL-8tY7Q.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/miriamlibre/v14/DdTh798HsHwubBAqfkcBTL_fYZP7.ttf"
+      "menu": "https://fonts.gstatic.com/s/miriamlibre/v16/DdT0798HsHwubBAqfkcBTL_1a7sPlXcE8PJjH9P3o9rMKw.ttf"
     },
     {
       "family": "Mirza",
@@ -21200,6 +21628,55 @@
       "menu": "https://fonts.gstatic.com/s/molle/v23/E21n_dL5hOXFhWEsbzksUw.ttf"
     },
     {
+      "family": "Mona Sans",
+      "variants": [
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
+        "900italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "vietnamese"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-05",
+      "files": {
+        "200": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
+        "300": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
+        "500": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
+        "600": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
+        "700": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
+        "800": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
+        "900": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
+        "regular": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
+        "200italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
+        "italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
+        "500italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
+        "600italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
+        "700italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
+        "800italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
+        "900italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
+    },
+    {
       "family": "Monda",
       "variants": [
         "regular",
@@ -21409,31 +21886,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v29",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Uw-Y3tcoqK5.ttf",
-        "200": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvr6Ew-Y3tcoqK5.ttf",
-        "300": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCs16Ew-Y3tcoqK5.ttf",
-        "500": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Ew-Y3tcoqK5.ttf",
-        "600": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu170w-Y3tcoqK5.ttf",
-        "700": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM70w-Y3tcoqK5.ttf",
-        "800": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvr70w-Y3tcoqK5.ttf",
-        "900": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvC70w-Y3tcoqK5.ttf",
-        "regular": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Ew-Y3tcoqK5.ttf",
-        "100italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq6R8aX9-p7K5ILg.ttf",
-        "200italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqyR9aX9-p7K5ILg.ttf",
-        "300italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq_p9aX9-p7K5ILg.ttf",
-        "italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq6R9aX9-p7K5ILg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9aX9-p7K5ILg.ttf",
-        "600italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6aX9-p7K5ILg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq0N6aX9-p7K5ILg.ttf",
-        "800italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqyR6aX9-p7K5ILg.ttf",
-        "900italic": "https://fonts.gstatic.com/s/montserrat/v26/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqw16aX9-p7K5ILg.ttf"
+        "100": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Uw-Y3tcoqK5.ttf",
+        "200": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvr6Ew-Y3tcoqK5.ttf",
+        "300": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCs16Ew-Y3tcoqK5.ttf",
+        "500": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtZ6Ew-Y3tcoqK5.ttf",
+        "600": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCu170w-Y3tcoqK5.ttf",
+        "700": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM70w-Y3tcoqK5.ttf",
+        "800": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvr70w-Y3tcoqK5.ttf",
+        "900": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCvC70w-Y3tcoqK5.ttf",
+        "regular": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Ew-Y3tcoqK5.ttf",
+        "100italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq6R8aX9-p7K5ILg.ttf",
+        "200italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqyR9aX9-p7K5ILg.ttf",
+        "300italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq_p9aX9-p7K5ILg.ttf",
+        "italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq6R9aX9-p7K5ILg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq5Z9aX9-p7K5ILg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq3p6aX9-p7K5ILg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jq0N6aX9-p7K5ILg.ttf",
+        "800italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqyR6aX9-p7K5ILg.ttf",
+        "900italic": "https://fonts.gstatic.com/s/montserrat/v29/JTUFjIg1_i6t8kCHKm459Wx7xQYXK0vOoz6jqw16aX9-p7K5ILg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/montserrat/v26/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Hw_aX8.ttf"
+      "menu": "https://fonts.gstatic.com/s/montserrat/v29/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCtr6Hw_aX8.ttf"
     },
     {
       "family": "Montserrat Alternates",
@@ -21574,14 +22051,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v27",
-      "lastModified": "2024-08-12",
+      "version": "v28",
+      "lastModified": "2024-11-07",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/moul/v27/nuF2D__FSo_3E-RYiJCy-00.ttf"
+        "regular": "https://fonts.gstatic.com/s/moul/v28/nuF2D__FSo_3E-RYiJCy-00.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/moul/v27/nuF2D__FSo_3I-VSjA.ttf"
+      "menu": "https://fonts.gstatic.com/s/moul/v28/nuF2D__FSo_3I-VSjA.ttf"
     },
     {
       "family": "Moulpali",
@@ -21592,14 +22069,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v30",
-      "lastModified": "2024-08-12",
+      "version": "v31",
+      "lastModified": "2024-11-07",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/moulpali/v30/H4ckBXKMl9HagUWymyY6wr-wg763.ttf"
+        "regular": "https://fonts.gstatic.com/s/moulpali/v31/H4ckBXKMl9HagUWymyY6wr-wg763.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/moulpali/v30/H4ckBXKMl9HagUWymxY7yLs.ttf"
+      "menu": "https://fonts.gstatic.com/s/moulpali/v31/H4ckBXKMl9HagUWymxY7yLs.ttf"
     },
     {
       "family": "Mountains of Christmas",
@@ -21763,20 +22240,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-07",
       "files": {
-        "200": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbEOjFma-2HW7ZB_.ttf",
-        "300": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbFqj1ma-2HW7ZB_.ttf",
-        "500": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbEyjlma-2HW7ZB_.ttf",
-        "600": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbEeiVma-2HW7ZB_.ttf",
-        "700": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbF6iFma-2HW7ZB_.ttf",
-        "800": "https://fonts.gstatic.com/s/mukta/v14/iJWHBXyXfDDVXbFmi1ma-2HW7ZB_.ttf",
-        "regular": "https://fonts.gstatic.com/s/mukta/v14/iJWKBXyXfDDVXYnGp32S0H3f.ttf"
+        "200": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbEOjFma-2HW7ZB_.ttf",
+        "300": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbFqj1ma-2HW7ZB_.ttf",
+        "500": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbEyjlma-2HW7ZB_.ttf",
+        "600": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbEeiVma-2HW7ZB_.ttf",
+        "700": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbF6iFma-2HW7ZB_.ttf",
+        "800": "https://fonts.gstatic.com/s/mukta/v16/iJWHBXyXfDDVXbFmi1ma-2HW7ZB_.ttf",
+        "regular": "https://fonts.gstatic.com/s/mukta/v16/iJWKBXyXfDDVXYnGp32S0H3f.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mukta/v14/iJWKBXyXfDDVXbnHrXk.ttf"
+      "menu": "https://fonts.gstatic.com/s/mukta/v16/iJWKBXyXfDDVXbnHrXk.ttf"
     },
     {
       "family": "Mukta Mahee",
@@ -21856,20 +22333,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-11-07",
       "files": {
-        "200": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGXNV8BD-u97MW1a.ttf",
-        "300": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGWpVMBD-u97MW1a.ttf",
-        "500": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGXxVcBD-u97MW1a.ttf",
-        "600": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGXdUsBD-u97MW1a.ttf",
-        "700": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGW5U8BD-u97MW1a.ttf",
-        "800": "https://fonts.gstatic.com/s/muktavaani/v13/3JnkSD_-ynaxmxnEfVHPIGWlUMBD-u97MW1a.ttf",
-        "regular": "https://fonts.gstatic.com/s/muktavaani/v13/3Jn5SD_-ynaxmxnEfVHPIF0FfORL0fNy.ttf"
+        "200": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGXNV8BD-u97MW1a.ttf",
+        "300": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGWpVMBD-u97MW1a.ttf",
+        "500": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGXxVcBD-u97MW1a.ttf",
+        "600": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGXdUsBD-u97MW1a.ttf",
+        "700": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGW5U8BD-u97MW1a.ttf",
+        "800": "https://fonts.gstatic.com/s/muktavaani/v14/3JnkSD_-ynaxmxnEfVHPIGWlUMBD-u97MW1a.ttf",
+        "regular": "https://fonts.gstatic.com/s/muktavaani/v14/3Jn5SD_-ynaxmxnEfVHPIF0FfORL0fNy.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/muktavaani/v13/3Jn5SD_-ynaxmxnEfVHPIG0EduA.ttf"
+      "menu": "https://fonts.gstatic.com/s/muktavaani/v14/3Jn5SD_-ynaxmxnEfVHPIG0EduA.ttf"
     },
     {
       "family": "Mulish",
@@ -22149,14 +22626,14 @@
         "korean",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v24",
+      "lastModified": "2024-11-07",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/nanumbrushscript/v22/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/nanumbrushscript/v24/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanumbrushscript/v22/wXK2E2wfpokopxzthSqPbcR5_gVaxazCj6pv.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanumbrushscript/v24/wXK2E2wfpokopxzthSqPbcR5_gVaxazCj6pv.ttf"
     },
     {
       "family": "Nanum Gothic",
@@ -22920,31 +23397,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v36",
-      "lastModified": "2024-02-16",
+      "version": "v37",
+      "lastModified": "2024-11-07",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9At9d41P6zHtY.ttf",
-        "200": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
-        "300": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
-        "500": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
-        "600": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
-        "700": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
-        "800": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
-        "900": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDcf6VfYyWtY1rI.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
-        "italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notosans/v36/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
+        "100": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9At9d41P6zHtY.ttf",
+        "200": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
+        "300": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
+        "500": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
+        "600": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
+        "700": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
+        "800": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
+        "900": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDcf6VfYyWtY1rI.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
+        "italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosans/v36/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
     },
     {
       "family": "Noto Sans Adlam",
@@ -25021,14 +25498,14 @@
         "mongolian",
         "symbols"
       ],
-      "version": "v21",
-      "lastModified": "2024-05-02",
+      "version": "v22",
+      "lastModified": "2024-09-30",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notosansmongolian/v21/VdGCAYADGIwE0EopZx8xQfHlgEAMsrToxLsg6-av1x0.ttf"
+        "regular": "https://fonts.gstatic.com/s/notosansmongolian/v22/VdGCAYADGIwE0EopZx8xQfHlgEAMsrToxLsg6-av1x0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansmongolian/v21/VdGCAYADGIwE0EopZx8xQfHlgEAMsrTo9Loq7w.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansmongolian/v22/VdGCAYADGIwE0EopZx8xQfHlgEAMsrTo9Loq7w.ttf"
     },
     {
       "family": "Noto Sans Mono",
@@ -26071,14 +26548,14 @@
         "mayan-numerals",
         "symbols"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-09-30",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notosanssymbols2/v23/I_uyMoGduATTei9eI8daxVHDyfisHr71ypPqfX71-AI.ttf"
+        "regular": "https://fonts.gstatic.com/s/notosanssymbols2/v24/I_uyMoGduATTei9eI8daxVHDyfisHr71ypPqfX71-AI.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanssymbols2/v23/I_uyMoGduATTei9eI8daxVHDyfisHr71-pLgeQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanssymbols2/v24/I_uyMoGduATTei9eI8daxVHDyfisHr71-pLgeQ.ttf"
     },
     {
       "family": "Noto Sans Syriac",
@@ -27159,21 +27636,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v8",
-      "lastModified": "2024-07-30",
+      "version": "v9",
+      "lastModified": "2024-09-23",
       "files": {
-        "200": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMf-K2RmV9Su1M6i.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMcgK2RmV9Su1M6i.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMdMK2RmV9Su1M6i.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMegLGRmV9Su1M6i.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMeZLGRmV9Su1M6i.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMf-LGRmV9Su1M6i.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMfXLGRmV9Su1M6i.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMd-K2RmV9Su1M6i.ttf"
+        "200": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMf-K2RmV9Su1M6i.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMcgK2RmV9Su1M6i.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMdMK2RmV9Su1M6i.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMegLGRmV9Su1M6i.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMeZLGRmV9Su1M6i.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMf-LGRmV9Su1M6i.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMfXLGRmV9Su1M6i.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMd-K2RmV9Su1M6i.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifhk/v8/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMd-K1RnXdA.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifhk/v9/BngdUXBETWXI6LwlBZGcqL-B_KuJFcgfwP_9RMd-K1RnXdA.ttf"
     },
     {
       "family": "Noto Serif Hebrew",
@@ -27229,21 +27706,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v29",
-      "lastModified": "2024-08-07",
+      "version": "v30",
+      "lastModified": "2024-09-23",
       "files": {
-        "200": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byxOubAILO5wBCU.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bxvOubAILO5wBCU.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwDOubAILO5wBCU.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bzvPebAILO5wBCU.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bzWPebAILO5wBCU.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byxPebAILO5wBCU.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byYPebAILO5wBCU.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOubAILO5wBCU.ttf"
+        "200": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byxOubAILO5wBCU.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bxvOubAILO5wBCU.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwDOubAILO5wBCU.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bzvPebAILO5wBCU.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bzWPebAILO5wBCU.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byxPebAILO5wBCU.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2byYPebAILO5wBCU.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOubAILO5wBCU.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifjp/v29/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOtbBKrc.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifjp/v30/xn71YHs72GKoTvER4Gn3b5eMRtWGkp6o7MjQ2bwxOtbBKrc.ttf"
     },
     {
       "family": "Noto Serif KR",
@@ -27264,21 +27741,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-05-14",
+      "version": "v28",
+      "lastModified": "2024-09-23",
       "files": {
-        "200": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchmeM524ZvTePRu.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnci4eM524ZvTePRu.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjUeM524ZvTePRu.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncg4f8524ZvTePRu.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncgBf8524ZvTePRu.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchmf8524ZvTePRu.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchPf8524ZvTePRu.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjmeM524ZvTePRu.ttf"
+        "200": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchmeM524ZvTePRu.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnci4eM524ZvTePRu.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjUeM524ZvTePRu.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncg4f8524ZvTePRu.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncgBf8524ZvTePRu.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchmf8524ZvTePRu.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOnchPf8524ZvTePRu.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjmeM524ZvTePRu.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifkr/v27/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjmeP53658.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifkr/v28/3JnoSDn90Gmq2mr3blnHaTZXbOtLJDvui3JOncjmeP53658.ttf"
     },
     {
       "family": "Noto Serif Kannada",
@@ -27550,14 +28027,14 @@
         "latin-ext",
         "old-uyghur"
       ],
-      "version": "v3",
-      "lastModified": "2023-10-25",
+      "version": "v4",
+      "lastModified": "2024-09-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notoserifolduyghur/v3/v6-KGZbLJFKIhClqUYqXDiGnrVoFRCW6JdwnKumeF2yVgA.ttf"
+        "regular": "https://fonts.gstatic.com/s/notoserifolduyghur/v4/v6-KGZbLJFKIhClqUYqXDiGnrVoFRCW6JdwnKumeF2yVgA.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifolduyghur/v3/v6-KGZbLJFKIhClqUYqXDiGnrVoFRCW6JdwXK-Oa.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifolduyghur/v4/v6-KGZbLJFKIhClqUYqXDiGnrVoFRCW6JdwXK-Oa.ttf"
     },
     {
       "family": "Noto Serif Oriya",
@@ -27692,21 +28169,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v31",
-      "lastModified": "2024-07-30",
+      "version": "v32",
+      "lastModified": "2024-09-23",
       "files": {
-        "200": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_aMOpDOWYMr2OM.ttf",
-        "300": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX8EMOpDOWYMr2OM.ttf",
-        "500": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9oMOpDOWYMr2OM.ttf",
-        "600": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX-EN-pDOWYMr2OM.ttf",
-        "700": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX-9N-pDOWYMr2OM.ttf",
-        "800": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_aN-pDOWYMr2OM.ttf",
-        "900": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_zN-pDOWYMr2OM.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9aMOpDOWYMr2OM.ttf"
+        "200": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_aMOpDOWYMr2OM.ttf",
+        "300": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX8EMOpDOWYMr2OM.ttf",
+        "500": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9oMOpDOWYMr2OM.ttf",
+        "600": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX-EN-pDOWYMr2OM.ttf",
+        "700": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX-9N-pDOWYMr2OM.ttf",
+        "800": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_aN-pDOWYMr2OM.ttf",
+        "900": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX_zN-pDOWYMr2OM.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9aMOpDOWYMr2OM.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoseriftc/v31/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9aMNpCM2I.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoseriftc/v32/XLYzIZb5bJNDGYxLBibeHZ0BnHwmuanx8cUaGX9aMNpCM2I.ttf"
     },
     {
       "family": "Noto Serif Tamil",
@@ -28898,31 +29375,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PLrOZCLtce-og.ttf",
-        "200": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6fPPrOZCLtce-og.ttf",
-        "300": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6ovPrOZCLtce-og.ttf",
-        "500": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6zvPrOZCLtce-og.ttf",
-        "600": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6IvTrOZCLtce-og.ttf",
-        "700": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6G_TrOZCLtce-og.ttf",
-        "800": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6fPTrOZCLtce-og.ttf",
-        "900": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6VfTrOZCLtce-og.ttf",
-        "regular": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOZCLtce-og.ttf",
-        "100italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLADe5qPl8Kuosgz.ttf",
-        "200italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCDepqPl8Kuosgz.ttf",
-        "300italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLBdepqPl8Kuosgz.ttf",
-        "italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLADepqPl8Kuosgz.ttf",
-        "500italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLAxepqPl8Kuosgz.ttf",
-        "600italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLDdfZqPl8Kuosgz.ttf",
-        "700italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLDkfZqPl8Kuosgz.ttf",
-        "800italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCDfZqPl8Kuosgz.ttf",
-        "900italic": "https://fonts.gstatic.com/s/overpass/v13/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCqfZqPl8Kuosgz.ttf"
+        "100": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PLrOZCLtce-og.ttf",
+        "200": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6fPPrOZCLtce-og.ttf",
+        "300": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6ovPrOZCLtce-og.ttf",
+        "500": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6zvPrOZCLtce-og.ttf",
+        "600": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6IvTrOZCLtce-og.ttf",
+        "700": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6G_TrOZCLtce-og.ttf",
+        "800": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6fPTrOZCLtce-og.ttf",
+        "900": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6VfTrOZCLtce-og.ttf",
+        "regular": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPrOZCLtce-og.ttf",
+        "100italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLADe5qPl8Kuosgz.ttf",
+        "200italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCDepqPl8Kuosgz.ttf",
+        "300italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLBdepqPl8Kuosgz.ttf",
+        "italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLADepqPl8Kuosgz.ttf",
+        "500italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLAxepqPl8Kuosgz.ttf",
+        "600italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLDdfZqPl8Kuosgz.ttf",
+        "700italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLDkfZqPl8Kuosgz.ttf",
+        "800italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCDfZqPl8Kuosgz.ttf",
+        "900italic": "https://fonts.gstatic.com/s/overpass/v16/qFdU35WCmI96Ajtm81GgSdXCNs-VMF0vNLCqfZqPl8Kuosgz.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/overpass/v13/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPbOJqP.ttf"
+      "menu": "https://fonts.gstatic.com/s/overpass/v16/qFda35WCmI96Ajtm83upeyoaX6QPnlo6_PPbOJqP.ttf"
     },
     {
       "family": "Overpass Mono",
@@ -29847,31 +30324,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v35",
-      "lastModified": "2024-09-04",
+      "version": "v36",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYx3Ly1AHfAAy5.ttf",
-        "200": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JYxnLy1AHfAAy5.ttf",
-        "300": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7KGxnLy1AHfAAy5.ttf",
-        "500": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LqxnLy1AHfAAy5.ttf",
-        "600": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7IGwXLy1AHfAAy5.ttf",
-        "700": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7I_wXLy1AHfAAy5.ttf",
-        "800": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JYwXLy1AHfAAy5.ttf",
-        "900": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JxwXLy1AHfAAy5.ttf",
-        "regular": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYxnLy1AHfAAy5.ttf",
-        "100italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqw3gX9BRy5m5M.ttf",
-        "200italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhRqx3gX9BRy5m5M.ttf",
-        "300italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhcSx3gX9BRy5m5M.ttf",
-        "italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqx3gX9BRy5m5M.ttf",
-        "500italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhaix3gX9BRy5m5M.ttf",
-        "600italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhUS23gX9BRy5m5M.ttf",
-        "700italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhX223gX9BRy5m5M.ttf",
-        "800italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhRq23gX9BRy5m5M.ttf",
-        "900italic": "https://fonts.gstatic.com/s/piazzolla/v35/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhTO23gX9BRy5m5M.ttf"
+        "100": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYx3Ly1AHfAAy5.ttf",
+        "200": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JYxnLy1AHfAAy5.ttf",
+        "300": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7KGxnLy1AHfAAy5.ttf",
+        "500": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LqxnLy1AHfAAy5.ttf",
+        "600": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7IGwXLy1AHfAAy5.ttf",
+        "700": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7I_wXLy1AHfAAy5.ttf",
+        "800": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JYwXLy1AHfAAy5.ttf",
+        "900": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JxwXLy1AHfAAy5.ttf",
+        "regular": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYxnLy1AHfAAy5.ttf",
+        "100italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqw3gX9BRy5m5M.ttf",
+        "200italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhRqx3gX9BRy5m5M.ttf",
+        "300italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhcSx3gX9BRy5m5M.ttf",
+        "italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhZqx3gX9BRy5m5M.ttf",
+        "500italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhaix3gX9BRy5m5M.ttf",
+        "600italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhUS23gX9BRy5m5M.ttf",
+        "700italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhX223gX9BRy5m5M.ttf",
+        "800italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhRq23gX9BRy5m5M.ttf",
+        "900italic": "https://fonts.gstatic.com/s/piazzolla/v36/N0b72SlTPu5rIkWIZjVgI-TckS03oGpPETyEJ88Rbvi0_TzOzKcQhTO23gX9BRy5m5M.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/piazzolla/v35/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYxkLz3gU.ttf"
+      "menu": "https://fonts.gstatic.com/s/piazzolla/v36/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYxkLz3gU.ttf"
     },
     {
       "family": "Piedra",
@@ -32138,31 +32615,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v15",
-      "lastModified": "2023-09-14",
+      "version": "v18",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpi5ww0pX189fg.ttf",
-        "200": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulpm5ww0pX189fg.ttf",
-        "300": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuSJm5ww0pX189fg.ttf",
-        "500": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuJJm5ww0pX189fg.ttf",
-        "600": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuyJ65ww0pX189fg.ttf",
-        "700": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z65ww0pX189fg.ttf",
-        "800": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulp65ww0pX189fg.ttf",
-        "900": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuv565ww0pX189fg.ttf",
-        "regular": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpm5ww0pX189fg.ttf",
-        "100italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgQctfVotfj7j.ttf",
-        "200italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRgActfVotfj7j.ttf",
-        "300italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673toPgActfVotfj7j.ttf",
-        "italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgActfVotfj7j.ttf",
-        "500italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpjgActfVotfj7j.ttf",
-        "600italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tqPhwctfVotfj7j.ttf",
-        "700italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tq2hwctfVotfj7j.ttf",
-        "800italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRhwctfVotfj7j.ttf",
-        "900italic": "https://fonts.gstatic.com/s/publicsans/v15/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tr4hwctfVotfj7j.ttf"
+        "100": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpi5ww0pX189fg.ttf",
+        "200": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulpm5ww0pX189fg.ttf",
+        "300": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuSJm5ww0pX189fg.ttf",
+        "500": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuJJm5ww0pX189fg.ttf",
+        "600": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuyJ65ww0pX189fg.ttf",
+        "700": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymu8Z65ww0pX189fg.ttf",
+        "800": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymulp65ww0pX189fg.ttf",
+        "900": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuv565ww0pX189fg.ttf",
+        "regular": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpm5ww0pX189fg.ttf",
+        "100italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgQctfVotfj7j.ttf",
+        "200italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRgActfVotfj7j.ttf",
+        "300italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673toPgActfVotfj7j.ttf",
+        "italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpRgActfVotfj7j.ttf",
+        "500italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tpjgActfVotfj7j.ttf",
+        "600italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tqPhwctfVotfj7j.ttf",
+        "700italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tq2hwctfVotfj7j.ttf",
+        "800italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673trRhwctfVotfj7j.ttf",
+        "900italic": "https://fonts.gstatic.com/s/publicsans/v18/ijwAs572Xtc6ZYQws9YVwnNDZpDyNjGolS673tr4hwctfVotfj7j.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/publicsans/v15/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpmJwgct.ttf"
+      "menu": "https://fonts.gstatic.com/s/publicsans/v18/ijwGs572Xtc6ZYQws9YVwllKVG8qX1oyOymuFpmJwgct.ttf"
     },
     {
       "family": "Puppies Play",
@@ -33796,31 +34273,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-09-30",
       "files": {
-        "100": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliosp6d2Af5fR4k.ttf",
-        "200": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElqotp6d2Af5fR4k.ttf",
-        "300": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElnQtp6d2Af5fR4k.ttf",
-        "500": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElhgtp6d2Af5fR4k.ttf",
-        "600": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElvQqp6d2Af5fR4k.ttf",
-        "700": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEls0qp6d2Af5fR4k.ttf",
-        "800": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElqoqp6d2Af5fR4k.ttf",
-        "900": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEloMqp6d2Af5fR4k.ttf",
-        "regular": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliotp6d2Af5fR4k.ttf",
-        "100italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuT-V8BdxaV4nUFw.ttf",
-        "200italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Juz-R8BdxaV4nUFw.ttf",
-        "300italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuEeR8BdxaV4nUFw.ttf",
-        "italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuT-R8BdxaV4nUFw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JufeR8BdxaV4nUFw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JukeN8BdxaV4nUFw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuqON8BdxaV4nUFw.ttf",
-        "800italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Juz-N8BdxaV4nUFw.ttf",
-        "900italic": "https://fonts.gstatic.com/s/robotoserif/v13/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Ju5uN8BdxaV4nUFw.ttf"
+        "100": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliosp6d2Af5fR4k.ttf",
+        "200": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElqotp6d2Af5fR4k.ttf",
+        "300": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElnQtp6d2Af5fR4k.ttf",
+        "500": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElhgtp6d2Af5fR4k.ttf",
+        "600": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElvQqp6d2Af5fR4k.ttf",
+        "700": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEls0qp6d2Af5fR4k.ttf",
+        "800": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcElqoqp6d2Af5fR4k.ttf",
+        "900": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEloMqp6d2Af5fR4k.ttf",
+        "regular": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliotp6d2Af5fR4k.ttf",
+        "100italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuT-V8BdxaV4nUFw.ttf",
+        "200italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Juz-R8BdxaV4nUFw.ttf",
+        "300italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuEeR8BdxaV4nUFw.ttf",
+        "italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuT-R8BdxaV4nUFw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JufeR8BdxaV4nUFw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JukeN8BdxaV4nUFw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-JuqON8BdxaV4nUFw.ttf",
+        "800italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Juz-N8BdxaV4nUFw.ttf",
+        "900italic": "https://fonts.gstatic.com/s/robotoserif/v15/R71XjywflP6FLr3gZx7K8UyEVQnyR1E7VN-f51xYuGCQepOvB0KLc2v0wKKB0Q4MSZxyqf2CgAchbDJ69BcVZxkDg-Ju5uN8BdxaV4nUFw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/robotoserif/v13/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliotl6Z8BQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/robotoserif/v15/R71RjywflP6FLr3gZx7K8UyuXDs9zVwDmXCb8lxYgmuii32UGoVldX6UgfjL4-3sMM_kB_qXSEXTJQCFLH5-_bcEliotl6Z8BQ.ttf"
     },
     {
       "family": "Roboto Slab",
@@ -36508,6 +36985,29 @@
       "menu": "https://fonts.gstatic.com/s/sixtyfour/v1/OD5vuMCT1numDm3nakXtp2h4jg463t9haG_3mBkVsV20uFT3BAE5f43ZlSA.ttf"
     },
     {
+      "family": "Sixtyfour Convergence",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "math",
+        "symbols"
+      ],
+      "version": "v1",
+      "lastModified": "2024-09-30",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/sixtyfourconvergence/v1/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102hotkk3grz3g.ttf"
+      },
+      "category": "monospace",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/sixtyfourconvergence/v1/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102topulw.ttf",
+      "colorCapabilities": [
+        "COLRv1"
+      ]
+    },
+    {
       "family": "Skranji",
       "variants": [
         "regular",
@@ -37192,6 +37692,58 @@
       "menu": "https://fonts.gstatic.com/s/sortsmillgoudy/v15/Qw3GZR9MED_6PSuS_50nEaVrfzgEbHwEig.ttf"
     },
     {
+      "family": "Sour Gummy",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "100italic",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
+        "900italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-07",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1N88JU91CMD2tcoQ.ttf",
+        "200": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1Nc8NU91CMD2tcoQ.ttf",
+        "300": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1NrcNU91CMD2tcoQ.ttf",
+        "500": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1NwcNU91CMD2tcoQ.ttf",
+        "600": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1NLcRU91CMD2tcoQ.ttf",
+        "700": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1NFMRU91CMD2tcoQ.ttf",
+        "800": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1Nc8RU91CMD2tcoQ.ttf",
+        "900": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1NWsRU91CMD2tcoQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1N88NU91CMD2tcoQ.ttf",
+        "100italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4C8tVqILW5MobGa.ttf",
+        "200italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4A8tFqILW5MobGa.ttf",
+        "300italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4DitFqILW5MobGa.ttf",
+        "italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4C8tFqILW5MobGa.ttf",
+        "500italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4COtFqILW5MobGa.ttf",
+        "600italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4Bis1qILW5MobGa.ttf",
+        "700italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4Bbs1qILW5MobGa.ttf",
+        "800italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4A8s1qILW5MobGa.ttf",
+        "900italic": "https://fonts.gstatic.com/s/sourgummy/v1/8AtIGs2gPYuNDii97MjjLLvpghcw76OXBoIHpHgGZt9gyUXamxpYO4AVs1qILW5MobGa.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/sourgummy/v1/8AtGGs2gPYuNDii97MjjBrLbYfdJvDU5AZfP5opPVCC4oC5ANR1N88Nk9lqI.ttf"
+    },
+    {
       "family": "Source Code Pro",
       "variants": [
         "200",
@@ -37389,17 +37941,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-08-12",
+      "version": "v14",
+      "lastModified": "2024-09-30",
       "files": {
-        "700": "https://fonts.gstatic.com/s/spacemono/v13/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf",
-        "regular": "https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf",
-        "italic": "https://fonts.gstatic.com/s/spacemono/v13/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/spacemono/v13/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf"
+        "700": "https://fonts.gstatic.com/s/spacemono/v14/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf",
+        "regular": "https://fonts.gstatic.com/s/spacemono/v14/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf",
+        "italic": "https://fonts.gstatic.com/s/spacemono/v14/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/spacemono/v14/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spacemono/v13/i7dPIFZifjKcF5UAWdDRYEd8QA.ttf"
+      "menu": "https://fonts.gstatic.com/s/spacemono/v14/i7dPIFZifjKcF5UAWdDRYEd8QA.ttf"
     },
     {
       "family": "Special Elite",
@@ -37438,31 +37990,32 @@
       ],
       "subsets": [
         "cyrillic",
+        "cyrillic-ext",
         "latin",
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-11-05",
       "files": {
-        "200": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9v2s13GY_etWWIJ.ttf",
-        "300": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9uSsF3GY_etWWIJ.ttf",
-        "500": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9vKsV3GY_etWWIJ.ttf",
-        "600": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9vmtl3GY_etWWIJ.ttf",
-        "700": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9uCt13GY_etWWIJ.ttf",
-        "800": "https://fonts.gstatic.com/s/spectral/v13/rnCs-xNNww_2s0amA9uetF3GY_etWWIJ.ttf",
-        "200italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qrXHafOPXHIJErY.ttf",
-        "300italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qtHEafOPXHIJErY.ttf",
-        "regular": "https://fonts.gstatic.com/s/spectral/v13/rnCr-xNNww_2s0amA-M-mHnOSOuk.ttf",
-        "italic": "https://fonts.gstatic.com/s/spectral/v13/rnCt-xNNww_2s0amA9M8kn3sTfukQHs.ttf",
-        "500italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qonFafOPXHIJErY.ttf",
-        "600italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qqXCafOPXHIJErY.ttf",
-        "700italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qsHDafOPXHIJErY.ttf",
-        "800italic": "https://fonts.gstatic.com/s/spectral/v13/rnCu-xNNww_2s0amA9M8qt3AafOPXHIJErY.ttf"
+        "200": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9v2s13GY_etWWIJ.ttf",
+        "300": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9uSsF3GY_etWWIJ.ttf",
+        "500": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9vKsV3GY_etWWIJ.ttf",
+        "600": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9vmtl3GY_etWWIJ.ttf",
+        "700": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9uCt13GY_etWWIJ.ttf",
+        "800": "https://fonts.gstatic.com/s/spectral/v14/rnCs-xNNww_2s0amA9uetF3GY_etWWIJ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qrXHafOPXHIJErY.ttf",
+        "300italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qtHEafOPXHIJErY.ttf",
+        "regular": "https://fonts.gstatic.com/s/spectral/v14/rnCr-xNNww_2s0amA-M-mHnOSOuk.ttf",
+        "italic": "https://fonts.gstatic.com/s/spectral/v14/rnCt-xNNww_2s0amA9M8kn3sTfukQHs.ttf",
+        "500italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qonFafOPXHIJErY.ttf",
+        "600italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qqXCafOPXHIJErY.ttf",
+        "700italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qsHDafOPXHIJErY.ttf",
+        "800italic": "https://fonts.gstatic.com/s/spectral/v14/rnCu-xNNww_2s0amA9M8qt3AafOPXHIJErY.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spectral/v13/rnCr-xNNww_2s0amA9M_kn0.ttf"
+      "menu": "https://fonts.gstatic.com/s/spectral/v14/rnCr-xNNww_2s0amA9M_kn0.ttf"
     },
     {
       "family": "Spectral SC",
@@ -37484,31 +38037,32 @@
       ],
       "subsets": [
         "cyrillic",
+        "cyrillic-ext",
         "latin",
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-11-05",
       "files": {
-        "200": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs1qwkTXPYeVXJZB.ttf",
-        "300": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs0OwUTXPYeVXJZB.ttf",
-        "500": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs1WwETXPYeVXJZB.ttf",
-        "600": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs16x0TXPYeVXJZB.ttf",
-        "700": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs0exkTXPYeVXJZB.ttf",
-        "800": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk0ALCRZonmalTgyPmRfs0CxUTXPYeVXJZB.ttf",
-        "200italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg26zWN4O3WYZB_sU.ttf",
-        "300italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg28jVN4O3WYZB_sU.ttf",
-        "regular": "https://fonts.gstatic.com/s/spectralsc/v12/KtkpALCRZonmalTgyPmRfvWi6WDfFpuc.ttf",
-        "italic": "https://fonts.gstatic.com/s/spectralsc/v12/KtkrALCRZonmalTgyPmRfsWg42T9E4ucRY8.ttf",
-        "500italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg25DUN4O3WYZB_sU.ttf",
-        "600italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg27zTN4O3WYZB_sU.ttf",
-        "700italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg29jSN4O3WYZB_sU.ttf",
-        "800italic": "https://fonts.gstatic.com/s/spectralsc/v12/Ktk2ALCRZonmalTgyPmRfsWg28TRN4O3WYZB_sU.ttf"
+        "200": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs1qwkTXPYeVXJZB.ttf",
+        "300": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs0OwUTXPYeVXJZB.ttf",
+        "500": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs1WwETXPYeVXJZB.ttf",
+        "600": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs16x0TXPYeVXJZB.ttf",
+        "700": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs0exkTXPYeVXJZB.ttf",
+        "800": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk0ALCRZonmalTgyPmRfs0CxUTXPYeVXJZB.ttf",
+        "200italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg26zWN4O3WYZB_sU.ttf",
+        "300italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg28jVN4O3WYZB_sU.ttf",
+        "regular": "https://fonts.gstatic.com/s/spectralsc/v14/KtkpALCRZonmalTgyPmRfvWi6WDfFpuc.ttf",
+        "italic": "https://fonts.gstatic.com/s/spectralsc/v14/KtkrALCRZonmalTgyPmRfsWg42T9E4ucRY8.ttf",
+        "500italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg25DUN4O3WYZB_sU.ttf",
+        "600italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg27zTN4O3WYZB_sU.ttf",
+        "700italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg29jSN4O3WYZB_sU.ttf",
+        "800italic": "https://fonts.gstatic.com/s/spectralsc/v14/Ktk2ALCRZonmalTgyPmRfsWg28TRN4O3WYZB_sU.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spectralsc/v12/KtkpALCRZonmalTgyPmRfsWj42Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/spectralsc/v14/KtkpALCRZonmalTgyPmRfsWj42Q.ttf"
     },
     {
       "family": "Spicy Rice",
@@ -39817,21 +40371,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v7",
-      "lastModified": "2024-09-04",
+      "version": "v8",
+      "lastModified": "2024-09-30",
       "files": {
-        "200": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG65jx043HgP6LR0Y.ttf",
-        "300": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG60bx043HgP6LR0Y.ttf",
-        "500": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6yrx043HgP6LR0Y.ttf",
-        "600": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG68b2043HgP6LR0Y.ttf",
-        "700": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6__2043HgP6LR0Y.ttf",
-        "800": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG65j2043HgP6LR0Y.ttf",
-        "900": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG67H2043HgP6LR0Y.ttf",
-        "regular": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6xjx043HgP6LR0Y.ttf"
+        "200": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG65jx043HgP6LR0Y.ttf",
+        "300": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG60bx043HgP6LR0Y.ttf",
+        "500": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6yrx043HgP6LR0Y.ttf",
+        "600": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG68b2043HgP6LR0Y.ttf",
+        "700": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6__2043HgP6LR0Y.ttf",
+        "800": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG65j2043HgP6LR0Y.ttf",
+        "900": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG67H2043HgP6LR0Y.ttf",
+        "regular": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6xjx043HgP6LR0Y.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/unbounded/v7/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6xjx44zNhA.ttf"
+      "menu": "https://fonts.gstatic.com/s/unbounded/v8/Yq6F-LOTXCb04q32xlpat-6uR42XTqtG6xjx44zNhA.ttf"
     },
     {
       "family": "Uncial Antiqua",
@@ -40456,25 +41010,25 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2024-09-30",
       "files": {
-        "500": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2AnGuGWOdEbD63w.ttf",
-        "600": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df27nauGWOdEbD63w.ttf",
-        "700": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df213auGWOdEbD63w.ttf",
-        "800": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2sHauGWOdEbD63w.ttf",
-        "900": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2mXauGWOdEbD63w.ttf",
-        "regular": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGuGWOdEbD63w.ttf",
-        "italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJGWmmZM7Xq34g9.ttf",
-        "500italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJ0WmmZM7Xq34g9.ttf",
-        "600italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKYXWmZM7Xq34g9.ttf",
-        "700italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKhXWmZM7Xq34g9.ttf",
-        "800italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLGXWmZM7Xq34g9.ttf",
-        "900italic": "https://fonts.gstatic.com/s/vollkorn/v23/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLvXWmZM7Xq34g9.ttf"
+        "500": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2AnGuGWOdEbD63w.ttf",
+        "600": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df27nauGWOdEbD63w.ttf",
+        "700": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df213auGWOdEbD63w.ttf",
+        "800": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2sHauGWOdEbD63w.ttf",
+        "900": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2mXauGWOdEbD63w.ttf",
+        "regular": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGuGWOdEbD63w.ttf",
+        "italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJGWmmZM7Xq34g9.ttf",
+        "500italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJ0WmmZM7Xq34g9.ttf",
+        "600italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKYXWmZM7Xq34g9.ttf",
+        "700italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKhXWmZM7Xq34g9.ttf",
+        "800italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLGXWmZM7Xq34g9.ttf",
+        "900italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLvXWmZM7Xq34g9.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/vollkorn/v23/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGeGGmZ.ttf"
+      "menu": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGeGGmZ.ttf"
     },
     {
       "family": "Vollkorn SC",


### PR DESCRIPTION
### Why?

The New Google Font `Geist` is out, and it would be great to add support for it in `@capsize/metrics` as Next.js `next/font` is currently depending on it. 😌