### PR TITLE
Rewrite relative links when copying README

### DIFF
--- a/scripts/copy-readme.js
+++ b/scripts/copy-readme.js
@@ -1,9 +1,20 @@
 const fs = require('fs').promises;
 const path = require('path');
 
+// Copy README.md from root to packages/core and rewrite relative links
 (async () => {
-  await fs.copyFile(
-    path.join(__dirname, '../README.md'),
-    path.join('packages/core', 'README.md'),
+  const sourceDir = path.join(__dirname, '..');
+  const targetDir = path.join(__dirname, '../packages/core');
+  const relativePath = path.relative(targetDir, sourceDir);
+  const content = await fs.readFile(path.join(sourceDir, 'README.md'), {
+    encoding: 'utf-8',
+  });
+
+  // Assume that everything not starting with # or http(s): is a relative link
+  const transformed = content.replace(
+    /]\((?!(#|https?:))/g,
+    `](${relativePath}/`,
   );
+
+  await fs.writeFile(path.join(targetDir, 'README.md'), transformed);
 })();

--- a/scripts/copy-readme.js
+++ b/scripts/copy-readme.js
@@ -10,10 +10,12 @@ const path = require('path');
     encoding: 'utf-8',
   });
 
-  // Assume that everything not starting with # or http(s): is a relative link
+  // Rewrite all occurences of `packages/EXISTING_PACKAGE/` to relative path
+  const packages = await fs.readdir(path.join(sourceDir, 'packages'));
+  const regExp = new RegExp(`packages\/(${packages.join('|')})\/`, 'g');
   const transformed = content.replace(
-    /]\((?!(#|https?:))/g,
-    `](${relativePath}/`,
+    regExp,
+    (match) => `${relativePath}/${match}`,
   );
 
   await fs.writeFile(path.join(targetDir, 'README.md'), transformed);


### PR DESCRIPTION
Following links from https://www.npmjs.com/package/@capsizecss/core sends me to 404 pages like https://github.com/seek-oss/capsize/blob/HEAD/packages/core/packages/metrics/README.md.

This PR extends the script copying the root's README to `packages/core` to rewrite relative links.

A local diff of the copied file (left: before, right: after):
<img width="1552" alt="image" src="https://github.com/user-attachments/assets/172b2771-b1c0-4e6e-afec-a91c549aad3c" />
