### PR TITLE
metrics: Update Google Fonts

### DIFF
--- a/.changeset/kind-dingos-protect.md
+++ b/.changeset/kind-dingos-protect.md
@@ -1,0 +1,5 @@
+---
+'@capsizecss/metrics': minor
+---
+
+Update Google Fonts

--- a/packages/metrics/scripts/generate.ts
+++ b/packages/metrics/scripts/generate.ts
@@ -76,9 +76,12 @@ const buildMetricsTypeInterface = (
 
 const getTypeName = (familyName: string) => {
   const camelCaseFamilyName = fontFamilyToCamelCase(familyName);
-  return `${camelCaseFamilyName
+  const formattedName = `${camelCaseFamilyName
     .charAt(0)
     .toUpperCase()}${camelCaseFamilyName.slice(1)}Metrics`;
+
+  // Ensure type does not start with a number
+  return /^[0-9]/.test(formattedName) ? `_${formattedName}` : formattedName;
 };
 
 interface Options {
@@ -217,8 +220,12 @@ const buildFiles = async ({ metrics, variant, isDefaultImport }: Options) => {
           '};\n\n',
         ].join('\n');
 
+        // Ensure key is quoted if starts with a number
+        const formattedName = fontFamilyToCamelCase(data.familyName);
         entireCollectionEntries.push({
-          name: fontFamilyToCamelCase(data.familyName),
+          name: /^[0-9]/.test(formattedName)
+            ? `"${formattedName}"`
+            : formattedName,
           type: typeName,
         });
 

--- a/packages/metrics/scripts/googleFonts.json
+++ b/packages/metrics/scripts/googleFonts.json
@@ -1,5 +1,137 @@
 [
   {
+    "familyName": "42dot Sans",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans Light",
+        "postscriptName": "42dotSans-Light",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 447,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 447
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans Medium",
+        "postscriptName": "42dotSans-Medium",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 459,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 459
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans SemiBold",
+        "postscriptName": "42dotSans-SemiBold",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 465,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 465
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans Bold",
+        "postscriptName": "42dotSans-Bold",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 471,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 471
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans ExtraBold",
+        "postscriptName": "42dotSans-ExtraBold",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 477,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 477
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "42dot Sans",
+        "fullName": "42dot Sans Regular",
+        "postscriptName": "42dotSans-Regular",
+        "capHeight": 707,
+        "ascent": 952,
+        "descent": -241,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 455,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 455
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "ABeeZee",
     "defaultVariant": "regular",
     "variants": {
@@ -1216,6 +1348,33 @@
           }
         },
         "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Agu Display",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Agu Display",
+        "fullName": "Agu Display Regular",
+        "postscriptName": "AguDisplay-Regular",
+        "capHeight": 700,
+        "ascent": 1190,
+        "descent": -310,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 487,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 487
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "display"
       }
     }
   },
@@ -11490,6 +11649,606 @@
     }
   },
   {
+    "familyName": "Atkinson Hyperlegible Mono",
+    "defaultVariant": "regular",
+    "variants": {
+      "200": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono ExtraLight",
+        "postscriptName": "AtkinsonHyperlegibleMono-ExtraLight",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Light",
+        "postscriptName": "AtkinsonHyperlegibleMono-Light",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Medium",
+        "postscriptName": "AtkinsonHyperlegibleMono-Medium",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono SemiBold",
+        "postscriptName": "AtkinsonHyperlegibleMono-SemiBold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Bold",
+        "postscriptName": "AtkinsonHyperlegibleMono-Bold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono ExtraBold",
+        "postscriptName": "AtkinsonHyperlegibleMono-ExtraBold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono ExtraLight Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-ExtraLightItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Light Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-LightItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Medium Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-MediumItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono SemiBold Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-SemiBoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Bold Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-BoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono ExtraBold Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-ExtraBoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Italic",
+        "postscriptName": "AtkinsonHyperlegibleMono-Italic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Atkinson Hyperlegible Mono",
+        "fullName": "Atkinson Hyperlegible Mono Regular",
+        "postscriptName": "AtkinsonHyperlegibleMono-Regular",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 632,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 632
+          },
+          "thai": {
+            "xWidthAvg": 632
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Atkinson Hyperlegible Next",
+    "defaultVariant": "regular",
+    "variants": {
+      "200": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next ExtraLight",
+        "postscriptName": "AtkinsonHyperlegibleNext-ExtraLight",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 421,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 421
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Light",
+        "postscriptName": "AtkinsonHyperlegibleNext-Light",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 431,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 431
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Medium",
+        "postscriptName": "AtkinsonHyperlegibleNext-Medium",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 457,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 457
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next SemiBold",
+        "postscriptName": "AtkinsonHyperlegibleNext-SemiBold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 467,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 467
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Bold",
+        "postscriptName": "AtkinsonHyperlegibleNext-Bold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 478,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 478
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next ExtraBold",
+        "postscriptName": "AtkinsonHyperlegibleNext-ExtraBold",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 496,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 496
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next ExtraLight Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-ExtraLightItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 421,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 421
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Light Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-LightItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 431,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 431
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Medium Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-MediumItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 457,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 457
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next SemiBold Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-SemiBoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 467,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 467
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Bold Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-BoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 478,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 478
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next ExtraBold Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-ExtraBoldItalic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 496,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 496
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Italic",
+        "postscriptName": "AtkinsonHyperlegibleNext-Italic",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 444,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 444
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Atkinson Hyperlegible Next",
+        "fullName": "Atkinson Hyperlegible Next Regular",
+        "postscriptName": "AtkinsonHyperlegibleNext-Regular",
+        "capHeight": 668,
+        "ascent": 984,
+        "descent": -316,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 496,
+        "xWidthAvg": 444,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 444
+          },
+          "thai": {
+            "xWidthAvg": 527
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Atma",
     "defaultVariant": "regular",
     "variants": {
@@ -12773,22 +13532,49 @@
         "familyName": "Bad Script",
         "fullName": "Bad Script Regular",
         "postscriptName": "BadScript-Regular",
-        "capHeight": 1966,
-        "ascent": 2710,
-        "descent": -1327,
+        "capHeight": 960,
+        "ascent": 1324,
+        "descent": -648,
         "lineGap": 0,
-        "unitsPerEm": 2048,
-        "xHeight": 1034,
-        "xWidthAvg": 787,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 363,
         "subsets": {
           "latin": {
-            "xWidthAvg": 787
+            "xWidthAvg": 363
           },
           "thai": {
-            "xWidthAvg": 1976
+            "xWidthAvg": 965
           }
         },
         "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Badeen Display",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Badeen Display",
+        "fullName": "Badeen Display Regular",
+        "postscriptName": "BadeenDisplay-Regular",
+        "capHeight": 700,
+        "ascent": 1150,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 600,
+        "xWidthAvg": 507,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 507
+          },
+          "thai": {
+            "xWidthAvg": 550
+          }
+        },
+        "category": "display"
       }
     }
   },
@@ -16359,8 +17145,8 @@
         "fullName": "Beiruti ExtraLight",
         "postscriptName": "Beiruti-ExtraLight",
         "capHeight": 604,
-        "ascent": 850,
-        "descent": -350,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 381,
@@ -16380,8 +17166,8 @@
         "fullName": "Beiruti Light",
         "postscriptName": "Beiruti-Light",
         "capHeight": 605,
-        "ascent": 875,
-        "descent": -325,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 386,
@@ -16401,8 +17187,8 @@
         "fullName": "Beiruti Medium",
         "postscriptName": "Beiruti-Medium",
         "capHeight": 605,
-        "ascent": 890,
-        "descent": -310,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 394,
@@ -16422,8 +17208,8 @@
         "fullName": "Beiruti SemiBold",
         "postscriptName": "Beiruti-SemiBold",
         "capHeight": 606,
-        "ascent": 880,
-        "descent": -320,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 398,
@@ -16443,8 +17229,8 @@
         "fullName": "Beiruti Bold",
         "postscriptName": "Beiruti-Bold",
         "capHeight": 606,
-        "ascent": 870,
-        "descent": -330,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 403,
@@ -16464,8 +17250,8 @@
         "fullName": "Beiruti ExtraBold",
         "postscriptName": "Beiruti-ExtraBold",
         "capHeight": 607,
-        "ascent": 860,
-        "descent": -340,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 407,
@@ -16485,8 +17271,8 @@
         "fullName": "Beiruti Black",
         "postscriptName": "Beiruti-Black",
         "capHeight": 607,
-        "ascent": 850,
-        "descent": -350,
+        "ascent": 900,
+        "descent": -300,
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 411,
@@ -17445,194 +18231,194 @@
     }
   },
   {
-    "familyName": "Big Shoulders Display",
+    "familyName": "Big Shoulders",
     "defaultVariant": "regular",
     "variants": {
       "100": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Thin",
-        "postscriptName": "BigShouldersDisplay-Thin",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Thin",
+        "postscriptName": "BigShoulders-Thin",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 481,
+        "xWidthAvg": 565,
         "subsets": {
           "latin": {
-            "xWidthAvg": 481
+            "xWidthAvg": 565
           },
           "thai": {
-            "xWidthAvg": 814
+            "xWidthAvg": 1076
           }
         },
         "category": "display"
       },
       "200": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display ExtraLight",
-        "postscriptName": "BigShouldersDisplay-ExtraLight",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders ExtraLight",
+        "postscriptName": "BigShoulders-ExtraLight",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 508,
+        "xWidthAvg": 610,
         "subsets": {
           "latin": {
-            "xWidthAvg": 508
+            "xWidthAvg": 610
           },
           "thai": {
-            "xWidthAvg": 869
+            "xWidthAvg": 1173
           }
         },
         "category": "display"
       },
       "300": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Light",
-        "postscriptName": "BigShouldersDisplay-Light",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Light",
+        "postscriptName": "BigShoulders-Light",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 547,
+        "xWidthAvg": 642,
         "subsets": {
           "latin": {
-            "xWidthAvg": 547
+            "xWidthAvg": 642
           },
           "thai": {
-            "xWidthAvg": 947
+            "xWidthAvg": 1241
           }
         },
         "category": "display"
       },
       "500": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Medium",
-        "postscriptName": "BigShouldersDisplay-Medium",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Medium",
+        "postscriptName": "BigShoulders-Medium",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 624,
+        "xWidthAvg": 727,
         "subsets": {
           "latin": {
-            "xWidthAvg": 624
+            "xWidthAvg": 727
           },
           "thai": {
-            "xWidthAvg": 1111
+            "xWidthAvg": 1413
           }
         },
         "category": "display"
       },
       "600": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display SemiBold",
-        "postscriptName": "BigShouldersDisplay-SemiBold",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders SemiBold",
+        "postscriptName": "BigShoulders-SemiBold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 649,
+        "xWidthAvg": 758,
         "subsets": {
           "latin": {
-            "xWidthAvg": 649
+            "xWidthAvg": 758
           },
           "thai": {
-            "xWidthAvg": 1164
+            "xWidthAvg": 1476
           }
         },
         "category": "display"
       },
       "700": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Bold",
-        "postscriptName": "BigShouldersDisplay-Bold",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Bold",
+        "postscriptName": "BigShoulders-Bold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 699,
+        "xWidthAvg": 785,
         "subsets": {
           "latin": {
-            "xWidthAvg": 699
+            "xWidthAvg": 785
           },
           "thai": {
-            "xWidthAvg": 1272
+            "xWidthAvg": 1530
           }
         },
         "category": "display"
       },
       "800": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display ExtraBold",
-        "postscriptName": "BigShouldersDisplay-ExtraBold",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders ExtraBold",
+        "postscriptName": "BigShoulders-ExtraBold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 750,
+        "xWidthAvg": 812,
         "subsets": {
           "latin": {
-            "xWidthAvg": 750
+            "xWidthAvg": 812
           },
           "thai": {
-            "xWidthAvg": 1381
+            "xWidthAvg": 1585
           }
         },
         "category": "display"
       },
       "900": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Black",
-        "postscriptName": "BigShouldersDisplay-Black",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Black",
+        "postscriptName": "BigShoulders-Black",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 800,
+        "xWidthAvg": 839,
         "subsets": {
           "latin": {
-            "xWidthAvg": 800
+            "xWidthAvg": 839
           },
           "thai": {
-            "xWidthAvg": 1490
+            "xWidthAvg": 1640
           }
         },
         "category": "display"
       },
       "regular": {
-        "familyName": "Big Shoulders Display",
-        "fullName": "Big Shoulders Display Regular",
-        "postscriptName": "BigShouldersDisplay-Regular",
+        "familyName": "Big Shoulders",
+        "fullName": "Big Shoulders Regular",
+        "postscriptName": "BigShoulders-Regular",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 598,
+        "xWidthAvg": 673,
         "subsets": {
           "latin": {
-            "xWidthAvg": 598
+            "xWidthAvg": 673
           },
           "thai": {
-            "xWidthAvg": 1056
+            "xWidthAvg": 1304
           }
         },
         "category": "display"
@@ -17640,779 +18426,194 @@
     }
   },
   {
-    "familyName": "Big Shoulders Inline Display",
+    "familyName": "Big Shoulders Inline",
     "defaultVariant": "regular",
     "variants": {
       "100": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Thin",
-        "postscriptName": "BigShouldersInlineDisplay-Thin",
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Thin",
+        "postscriptName": "BigShouldersInline-Thin",
         "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
         "unitsPerEm": 4000,
         "xHeight": 2400,
-        "xWidthAvg": 962,
+        "xWidthAvg": 1139,
         "subsets": {
           "latin": {
-            "xWidthAvg": 962
-          },
-          "thai": {
-            "xWidthAvg": 1628
-          }
-        },
-        "category": "display"
-      },
-      "200": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display ExtraLight",
-        "postscriptName": "BigShouldersInlineDisplay-ExtraLight",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1019,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1019
-          },
-          "thai": {
-            "xWidthAvg": 1738
-          }
-        },
-        "category": "display"
-      },
-      "300": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Light",
-        "postscriptName": "BigShouldersInlineDisplay-Light",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1100,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1100
-          },
-          "thai": {
-            "xWidthAvg": 1895
-          }
-        },
-        "category": "display"
-      },
-      "500": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Medium",
-        "postscriptName": "BigShouldersInlineDisplay-Medium",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1257,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1257
-          },
-          "thai": {
-            "xWidthAvg": 2221
-          }
-        },
-        "category": "display"
-      },
-      "600": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display SemiBold",
-        "postscriptName": "BigShouldersInlineDisplay-SemiBold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1307,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1307
-          },
-          "thai": {
-            "xWidthAvg": 2329
-          }
-        },
-        "category": "display"
-      },
-      "700": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Bold",
-        "postscriptName": "BigShouldersInlineDisplay-Bold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1409,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1409
-          },
-          "thai": {
-            "xWidthAvg": 2545
-          }
-        },
-        "category": "display"
-      },
-      "800": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display ExtraBold",
-        "postscriptName": "BigShouldersInlineDisplay-ExtraBold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1512,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1512
-          },
-          "thai": {
-            "xWidthAvg": 2762
-          }
-        },
-        "category": "display"
-      },
-      "900": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Black",
-        "postscriptName": "BigShouldersInlineDisplay-Black",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1615,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1615
-          },
-          "thai": {
-            "xWidthAvg": 2980
-          }
-        },
-        "category": "display"
-      },
-      "regular": {
-        "familyName": "Big Shoulders Inline Display",
-        "fullName": "Big Shoulders Inline Display Regular",
-        "postscriptName": "BigShouldersInlineDisplay-Regular",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1205,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1205
-          },
-          "thai": {
-            "xWidthAvg": 2111
-          }
-        },
-        "category": "display"
-      }
-    }
-  },
-  {
-    "familyName": "Big Shoulders Inline Text",
-    "defaultVariant": "regular",
-    "variants": {
-      "100": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Thin",
-        "postscriptName": "BigShouldersInlineText-Thin",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1151,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1151
-          },
-          "thai": {
-            "xWidthAvg": 2188
-          }
-        },
-        "category": "display"
-      },
-      "200": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text ExtraLight",
-        "postscriptName": "BigShouldersInlineText-ExtraLight",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1191,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1191
-          },
-          "thai": {
-            "xWidthAvg": 2278
-          }
-        },
-        "category": "display"
-      },
-      "300": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Light",
-        "postscriptName": "BigShouldersInlineText-Light",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1248,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1248
-          },
-          "thai": {
-            "xWidthAvg": 2406
-          }
-        },
-        "category": "display"
-      },
-      "500": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Medium",
-        "postscriptName": "BigShouldersInlineText-Medium",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1379,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1379
-          },
-          "thai": {
-            "xWidthAvg": 2675
-          }
-        },
-        "category": "display"
-      },
-      "600": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text SemiBold",
-        "postscriptName": "BigShouldersInlineText-SemiBold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1423,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1423
-          },
-          "thai": {
-            "xWidthAvg": 2763
-          }
-        },
-        "category": "display"
-      },
-      "700": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Bold",
-        "postscriptName": "BigShouldersInlineText-Bold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1512,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1512
-          },
-          "thai": {
-            "xWidthAvg": 2941
-          }
-        },
-        "category": "display"
-      },
-      "800": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text ExtraBold",
-        "postscriptName": "BigShouldersInlineText-ExtraBold",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1601,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1601
-          },
-          "thai": {
-            "xWidthAvg": 3121
-          }
-        },
-        "category": "display"
-      },
-      "900": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Black",
-        "postscriptName": "BigShouldersInlineText-Black",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1691,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1691
-          },
-          "thai": {
-            "xWidthAvg": 3300
-          }
-        },
-        "category": "display"
-      },
-      "regular": {
-        "familyName": "Big Shoulders Inline Text",
-        "fullName": "Big Shoulders Inline Text Regular",
-        "postscriptName": "BigShouldersInlineText-Regular",
-        "capHeight": 3200,
-        "ascent": 3936,
-        "descent": -852,
-        "lineGap": 0,
-        "unitsPerEm": 4000,
-        "xHeight": 2400,
-        "xWidthAvg": 1333,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 1333
-          },
-          "thai": {
-            "xWidthAvg": 2584
-          }
-        },
-        "category": "display"
-      }
-    }
-  },
-  {
-    "familyName": "Big Shoulders Stencil Display",
-    "defaultVariant": "regular",
-    "variants": {
-      "100": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Thin",
-        "postscriptName": "BigShouldersStencilDisplay-Thin",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 482,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 482
-          },
-          "thai": {
-            "xWidthAvg": 814
-          }
-        },
-        "category": "display"
-      },
-      "200": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display ExtraLight",
-        "postscriptName": "BigShouldersStencilDisplay-ExtraLight",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 509,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 509
-          },
-          "thai": {
-            "xWidthAvg": 869
-          }
-        },
-        "category": "display"
-      },
-      "300": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Light",
-        "postscriptName": "BigShouldersStencilDisplay-Light",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 548,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 548
-          },
-          "thai": {
-            "xWidthAvg": 947
-          }
-        },
-        "category": "display"
-      },
-      "500": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Medium",
-        "postscriptName": "BigShouldersStencilDisplay-Medium",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 625,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 625
-          },
-          "thai": {
-            "xWidthAvg": 1111
-          }
-        },
-        "category": "display"
-      },
-      "600": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display SemiBold",
-        "postscriptName": "BigShouldersStencilDisplay-SemiBold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 650,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 650
-          },
-          "thai": {
-            "xWidthAvg": 1164
-          }
-        },
-        "category": "display"
-      },
-      "700": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Bold",
-        "postscriptName": "BigShouldersStencilDisplay-Bold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 699,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 699
-          },
-          "thai": {
-            "xWidthAvg": 1272
-          }
-        },
-        "category": "display"
-      },
-      "800": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display ExtraBold",
-        "postscriptName": "BigShouldersStencilDisplay-ExtraBold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 750,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 750
-          },
-          "thai": {
-            "xWidthAvg": 1381
-          }
-        },
-        "category": "display"
-      },
-      "900": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Black",
-        "postscriptName": "BigShouldersStencilDisplay-Black",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 800,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 800
-          },
-          "thai": {
-            "xWidthAvg": 1490
-          }
-        },
-        "category": "display"
-      },
-      "regular": {
-        "familyName": "Big Shoulders Stencil Display",
-        "fullName": "Big Shoulders Stencil Display Regular",
-        "postscriptName": "BigShouldersStencilDisplay-Regular",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 599,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 599
-          },
-          "thai": {
-            "xWidthAvg": 1056
-          }
-        },
-        "category": "display"
-      }
-    }
-  },
-  {
-    "familyName": "Big Shoulders Stencil Text",
-    "defaultVariant": "regular",
-    "variants": {
-      "100": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Thin",
-        "postscriptName": "BigShouldersStencilText-Thin",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 573,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 573
-          },
-          "thai": {
-            "xWidthAvg": 1094
-          }
-        },
-        "category": "display"
-      },
-      "200": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text ExtraLight",
-        "postscriptName": "BigShouldersStencilText-ExtraLight",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
-        "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 593,
-        "subsets": {
-          "latin": {
-            "xWidthAvg": 593
-          },
-          "thai": {
             "xWidthAvg": 1139
+          },
+          "thai": {
+            "xWidthAvg": 2152
+          }
+        },
+        "category": "display"
+      },
+      "200": {
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline ExtraLight",
+        "postscriptName": "BigShouldersInline-ExtraLight",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
+        "lineGap": 0,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1226,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1226
+          },
+          "thai": {
+            "xWidthAvg": 2347
           }
         },
         "category": "display"
       },
       "300": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Light",
-        "postscriptName": "BigShouldersStencilText-Light",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Light",
+        "postscriptName": "BigShouldersInline-Light",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 623,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1289,
         "subsets": {
           "latin": {
-            "xWidthAvg": 623
+            "xWidthAvg": 1289
           },
           "thai": {
-            "xWidthAvg": 1203
+            "xWidthAvg": 2481
           }
         },
         "category": "display"
       },
       "500": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Medium",
-        "postscriptName": "BigShouldersStencilText-Medium",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Medium",
+        "postscriptName": "BigShouldersInline-Medium",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 689,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1460,
         "subsets": {
           "latin": {
-            "xWidthAvg": 689
+            "xWidthAvg": 1460
           },
           "thai": {
-            "xWidthAvg": 1347
+            "xWidthAvg": 2826
           }
         },
         "category": "display"
       },
       "600": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text SemiBold",
-        "postscriptName": "BigShouldersStencilText-SemiBold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline SemiBold",
+        "postscriptName": "BigShouldersInline-SemiBold",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 711,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1523,
         "subsets": {
           "latin": {
-            "xWidthAvg": 711
+            "xWidthAvg": 1523
           },
           "thai": {
-            "xWidthAvg": 1396
+            "xWidthAvg": 2951
           }
         },
         "category": "display"
       },
       "700": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Bold",
-        "postscriptName": "BigShouldersStencilText-Bold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Bold",
+        "postscriptName": "BigShouldersInline-Bold",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 755,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1577,
         "subsets": {
           "latin": {
-            "xWidthAvg": 755
+            "xWidthAvg": 1577
           },
           "thai": {
-            "xWidthAvg": 1493
+            "xWidthAvg": 3061
           }
         },
         "category": "display"
       },
       "800": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text ExtraBold",
-        "postscriptName": "BigShouldersStencilText-ExtraBold",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline ExtraBold",
+        "postscriptName": "BigShouldersInline-ExtraBold",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 800,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1631,
         "subsets": {
           "latin": {
-            "xWidthAvg": 800
+            "xWidthAvg": 1631
           },
           "thai": {
-            "xWidthAvg": 1592
+            "xWidthAvg": 3170
           }
         },
         "category": "display"
       },
       "900": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Black",
-        "postscriptName": "BigShouldersStencilText-Black",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Black",
+        "postscriptName": "BigShouldersInline-Black",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 844,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1686,
         "subsets": {
           "latin": {
-            "xWidthAvg": 844
+            "xWidthAvg": 1686
           },
           "thai": {
-            "xWidthAvg": 1690
+            "xWidthAvg": 3279
           }
         },
         "category": "display"
       },
       "regular": {
-        "familyName": "Big Shoulders Stencil Text",
-        "fullName": "Big Shoulders Stencil Text Regular",
-        "postscriptName": "BigShouldersStencilText-Regular",
-        "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "familyName": "Big Shoulders Inline",
+        "fullName": "Big Shoulders Inline Regular",
+        "postscriptName": "BigShouldersInline-Regular",
+        "capHeight": 3200,
+        "ascent": 3942,
+        "descent": -858,
         "lineGap": 0,
-        "unitsPerEm": 2000,
-        "xHeight": 1200,
-        "xWidthAvg": 666,
+        "unitsPerEm": 4000,
+        "xHeight": 2400,
+        "xWidthAvg": 1352,
         "subsets": {
           "latin": {
-            "xWidthAvg": 666
+            "xWidthAvg": 1352
           },
           "thai": {
-            "xWidthAvg": 1298
+            "xWidthAvg": 2607
           }
         },
         "category": "display"
@@ -18420,194 +18621,194 @@
     }
   },
   {
-    "familyName": "Big Shoulders Text",
+    "familyName": "Big Shoulders Stencil",
     "defaultVariant": "regular",
     "variants": {
       "100": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Thin",
-        "postscriptName": "BigShouldersText-Thin",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Thin",
+        "postscriptName": "BigShouldersStencil-Thin",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 570,
+        "xWidthAvg": 567,
         "subsets": {
           "latin": {
-            "xWidthAvg": 570
+            "xWidthAvg": 567
           },
           "thai": {
-            "xWidthAvg": 1094
+            "xWidthAvg": 1076
           }
         },
         "category": "display"
       },
       "200": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text ExtraLight",
-        "postscriptName": "BigShouldersText-ExtraLight",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil ExtraLight",
+        "postscriptName": "BigShouldersStencil-ExtraLight",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 591,
+        "xWidthAvg": 612,
         "subsets": {
           "latin": {
-            "xWidthAvg": 591
+            "xWidthAvg": 612
           },
           "thai": {
-            "xWidthAvg": 1139
+            "xWidthAvg": 1173
           }
         },
         "category": "display"
       },
       "300": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Light",
-        "postscriptName": "BigShouldersText-Light",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Light",
+        "postscriptName": "BigShouldersStencil-Light",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 621,
+        "xWidthAvg": 644,
         "subsets": {
           "latin": {
-            "xWidthAvg": 621
+            "xWidthAvg": 644
           },
           "thai": {
-            "xWidthAvg": 1203
+            "xWidthAvg": 1243
           }
         },
         "category": "display"
       },
       "500": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Medium",
-        "postscriptName": "BigShouldersText-Medium",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Medium",
+        "postscriptName": "BigShouldersStencil-Medium",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 687,
+        "xWidthAvg": 729,
         "subsets": {
           "latin": {
-            "xWidthAvg": 687
+            "xWidthAvg": 729
           },
           "thai": {
-            "xWidthAvg": 1337
+            "xWidthAvg": 1430
           }
         },
         "category": "display"
       },
       "600": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text SemiBold",
-        "postscriptName": "BigShouldersText-SemiBold",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil SemiBold",
+        "postscriptName": "BigShouldersStencil-SemiBold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 709,
+        "xWidthAvg": 760,
         "subsets": {
           "latin": {
-            "xWidthAvg": 709
+            "xWidthAvg": 760
           },
           "thai": {
-            "xWidthAvg": 1382
+            "xWidthAvg": 1499
           }
         },
         "category": "display"
       },
       "700": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Bold",
-        "postscriptName": "BigShouldersText-Bold",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Bold",
+        "postscriptName": "BigShouldersStencil-Bold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 753,
+        "xWidthAvg": 787,
         "subsets": {
           "latin": {
-            "xWidthAvg": 753
+            "xWidthAvg": 787
           },
           "thai": {
-            "xWidthAvg": 1471
+            "xWidthAvg": 1558
           }
         },
         "category": "display"
       },
       "800": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text ExtraBold",
-        "postscriptName": "BigShouldersText-ExtraBold",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil ExtraBold",
+        "postscriptName": "BigShouldersStencil-ExtraBold",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 797,
+        "xWidthAvg": 814,
         "subsets": {
           "latin": {
-            "xWidthAvg": 797
+            "xWidthAvg": 814
           },
           "thai": {
-            "xWidthAvg": 1560
+            "xWidthAvg": 1618
           }
         },
         "category": "display"
       },
       "900": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Black",
-        "postscriptName": "BigShouldersText-Black",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Black",
+        "postscriptName": "BigShouldersStencil-Black",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 842,
+        "xWidthAvg": 841,
         "subsets": {
           "latin": {
-            "xWidthAvg": 842
+            "xWidthAvg": 841
           },
           "thai": {
-            "xWidthAvg": 1650
+            "xWidthAvg": 1677
           }
         },
         "category": "display"
       },
       "regular": {
-        "familyName": "Big Shoulders Text",
-        "fullName": "Big Shoulders Text Regular",
-        "postscriptName": "BigShouldersText-Regular",
+        "familyName": "Big Shoulders Stencil",
+        "fullName": "Big Shoulders Stencil Regular",
+        "postscriptName": "BigShouldersStencil-Regular",
         "capHeight": 1600,
-        "ascent": 1968,
-        "descent": -426,
+        "ascent": 1971,
+        "descent": -429,
         "lineGap": 0,
         "unitsPerEm": 2000,
         "xHeight": 1200,
-        "xWidthAvg": 664,
+        "xWidthAvg": 675,
         "subsets": {
           "latin": {
-            "xWidthAvg": 664
+            "xWidthAvg": 675
           },
           "thai": {
-            "xWidthAvg": 1292
+            "xWidthAvg": 1311
           }
         },
         "category": "display"
@@ -19354,10 +19555,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 537,
-        "xWidthAvg": 478,
+        "xWidthAvg": 479,
         "subsets": {
           "latin": {
-            "xWidthAvg": 478
+            "xWidthAvg": 479
           },
           "thai": {
             "xWidthAvg": 500
@@ -20670,6 +20871,33 @@
     }
   },
   {
+    "familyName": "Boldonse",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Boldonse",
+        "fullName": "Boldonse Regular",
+        "postscriptName": "Boldonse-Regular",
+        "capHeight": 1190,
+        "ascent": 1520,
+        "descent": -400,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 870,
+        "xWidthAvg": 603,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 603
+          },
+          "thai": {
+            "xWidthAvg": 1332
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
     "familyName": "Bona Nova",
     "defaultVariant": "regular",
     "variants": {
@@ -21535,23 +21763,65 @@
     "familyName": "Buenard",
     "defaultVariant": "regular",
     "variants": {
-      "700": {
+      "500": {
         "familyName": "Buenard",
-        "fullName": "Buenard Bold",
-        "postscriptName": "Buenard-Bold",
-        "capHeight": 153,
+        "fullName": "Buenard Medium",
+        "postscriptName": "Buenard-Medium",
+        "capHeight": 700,
         "ascent": 1031,
         "descent": -270,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 146,
+        "xHeight": 500,
+        "xWidthAvg": 417,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 417
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "600": {
+        "familyName": "Buenard",
+        "fullName": "Buenard SemiBold",
+        "postscriptName": "Buenard-SemiBold",
+        "capHeight": 700,
+        "ascent": 1031,
+        "descent": -270,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 419,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 419
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "700": {
+        "familyName": "Buenard",
+        "fullName": "Buenard Bold",
+        "postscriptName": "Buenard-Bold",
+        "capHeight": 700,
+        "ascent": 1031,
+        "descent": -270,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
         "xWidthAvg": 421,
         "subsets": {
           "latin": {
             "xWidthAvg": 421
           },
           "thai": {
-            "xWidthAvg": 218
+            "xWidthAvg": 500
           }
         },
         "category": "serif"
@@ -21560,19 +21830,19 @@
         "familyName": "Buenard",
         "fullName": "Buenard Regular",
         "postscriptName": "Buenard-Regular",
-        "capHeight": 178,
+        "capHeight": 700,
         "ascent": 1031,
         "descent": -270,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 95,
+        "xHeight": 500,
         "xWidthAvg": 415,
         "subsets": {
           "latin": {
             "xWidthAvg": 415
           },
           "thai": {
-            "xWidthAvg": 218
+            "xWidthAvg": 500
           }
         },
         "category": "serif"
@@ -21819,6 +22089,33 @@
           }
         },
         "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Bytesized",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Bytesized",
+        "fullName": "Bytesized Regular",
+        "postscriptName": "Bytesized-Regular",
+        "capHeight": 11,
+        "ascent": 12,
+        "descent": -8,
+        "lineGap": 0,
+        "unitsPerEm": 16,
+        "xHeight": 8,
+        "xWidthAvg": 8,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 8
+          },
+          "thai": {
+            "xWidthAvg": 8
+          }
+        },
+        "category": "sans-serif"
       }
     }
   },
@@ -32419,6 +32716,96 @@
     }
   },
   {
+    "familyName": "Edu AU VIC WA NT Arrows",
+    "defaultVariant": "regular",
+    "variants": {
+      "500": {
+        "familyName": "Edu AU VIC WA NT Arrows",
+        "fullName": "Edu AU VIC WA NT Arrows Medium",
+        "postscriptName": "EduAUVICWANTArrows-Medium",
+        "capHeight": 1841,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1026,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1026
+          },
+          "thai": {
+            "xWidthAvg": 1307
+          }
+        },
+        "category": "handwriting"
+      },
+      "600": {
+        "familyName": "Edu AU VIC WA NT Arrows",
+        "fullName": "Edu AU VIC WA NT Arrows SemiBold",
+        "postscriptName": "EduAUVICWANTArrows-SemiBold",
+        "capHeight": 1837,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1058,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1058
+          },
+          "thai": {
+            "xWidthAvg": 1351
+          }
+        },
+        "category": "handwriting"
+      },
+      "700": {
+        "familyName": "Edu AU VIC WA NT Arrows",
+        "fullName": "Edu AU VIC WA NT Arrows Bold",
+        "postscriptName": "EduAUVICWANTArrows-Bold",
+        "capHeight": 1835,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 1076,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1076
+          },
+          "thai": {
+            "xWidthAvg": 1378
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Edu AU VIC WA NT Arrows",
+        "fullName": "Edu AU VIC WA NT Arrows Regular",
+        "postscriptName": "EduAUVICWANTArrows-Regular",
+        "capHeight": 1847,
+        "ascent": 2576,
+        "descent": -903,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 995,
+        "xWidthAvg": 983,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 983
+          },
+          "thai": {
+            "xWidthAvg": 1245
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Edu AU VIC WA NT Dots",
     "defaultVariant": "regular",
     "variants": {
@@ -34701,8 +35088,8 @@
         "fullName": "Englebert",
         "postscriptName": "Englebert-Regular",
         "capHeight": 1466,
-        "ascent": 954,
-        "descent": -311,
+        "ascent": 2064,
+        "descent": -598,
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1077,
@@ -44452,6 +44839,33 @@
     }
   },
   {
+    "familyName": "Gidole",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Gidole",
+        "fullName": "Gidole Regular",
+        "postscriptName": "Gidole-Regular",
+        "capHeight": 0,
+        "ascent": 1960,
+        "descent": -560,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 0,
+        "xWidthAvg": 883,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 883
+          },
+          "thai": {
+            "xWidthAvg": 1024
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Gidugu",
     "defaultVariant": "regular",
     "variants": {
@@ -49513,6 +49927,117 @@
     }
   },
   {
+    "familyName": "Hind Mysuru",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Hind Mysuru",
+        "fullName": "Hind Mysuru Light",
+        "postscriptName": "HindMysuru-Light",
+        "capHeight": 680,
+        "ascent": 989,
+        "descent": -725,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 422,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 422
+          },
+          "thai": {
+            "xWidthAvg": 750
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Hind Mysuru",
+        "fullName": "Hind Mysuru Medium",
+        "postscriptName": "HindMysuru-Medium",
+        "capHeight": 679,
+        "ascent": 989,
+        "descent": -725,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 437,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 437
+          },
+          "thai": {
+            "xWidthAvg": 753
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Hind Mysuru",
+        "fullName": "Hind Mysuru SemiBold",
+        "postscriptName": "HindMysuru-SemiBold",
+        "capHeight": 679,
+        "ascent": 989,
+        "descent": -725,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 507,
+        "xWidthAvg": 445,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 445
+          },
+          "thai": {
+            "xWidthAvg": 754
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Hind Mysuru",
+        "fullName": "Hind Mysuru Bold",
+        "postscriptName": "HindMysuru-Bold",
+        "capHeight": 678,
+        "ascent": 989,
+        "descent": -725,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 507,
+        "xWidthAvg": 455,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 455
+          },
+          "thai": {
+            "xWidthAvg": 756
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Hind Mysuru",
+        "fullName": "Hind Mysuru",
+        "postscriptName": "HindMysuru-Regular",
+        "capHeight": 679,
+        "ascent": 989,
+        "descent": -725,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 429,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 429
+          },
+          "thai": {
+            "xWidthAvg": 751
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Hind Siliguri",
     "defaultVariant": "regular",
     "variants": {
@@ -50497,6 +51022,33 @@
     }
   },
   {
+    "familyName": "Iansui",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Iansui",
+        "fullName": "Iansui Regular",
+        "postscriptName": "Iansui-Regular",
+        "capHeight": 695,
+        "ascent": 940,
+        "descent": -180,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 468,
+        "xWidthAvg": 481,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 481
+          },
+          "thai": {
+            "xWidthAvg": 1000
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Ibarra Real Nova",
     "defaultVariant": "regular",
     "variants": {
@@ -51173,10 +51725,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 520,
-        "xWidthAvg": 450,
+        "xWidthAvg": 451,
         "subsets": {
           "latin": {
-            "xWidthAvg": 450
+            "xWidthAvg": 451
           },
           "thai": {
             "xWidthAvg": 472
@@ -53623,6 +54175,174 @@
     "familyName": "Inclusive Sans",
     "defaultVariant": "regular",
     "variants": {
+      "300": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Light",
+        "postscriptName": "InclusiveSans-Light",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 473,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 473
+          },
+          "thai": {
+            "xWidthAvg": 638
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Medium",
+        "postscriptName": "InclusiveSans-Medium",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 503,
+        "xWidthAvg": 489,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 489
+          },
+          "thai": {
+            "xWidthAvg": 615
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans SemiBold",
+        "postscriptName": "InclusiveSans-SemiBold",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 497,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 497
+          },
+          "thai": {
+            "xWidthAvg": 611
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Bold",
+        "postscriptName": "InclusiveSans-Bold",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 508,
+        "xWidthAvg": 506,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 506
+          },
+          "thai": {
+            "xWidthAvg": 608
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Light Italic",
+        "postscriptName": "InclusiveSans-LightItalic",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 473,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 473
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Medium Italic",
+        "postscriptName": "InclusiveSans-MediumItalic",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 503,
+        "xWidthAvg": 489,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 489
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans SemiBold Italic",
+        "postscriptName": "InclusiveSans-SemiBoldItalic",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 505,
+        "xWidthAvg": 498,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 498
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Inclusive Sans",
+        "fullName": "Inclusive Sans Bold Italic",
+        "postscriptName": "InclusiveSans-BoldItalic",
+        "capHeight": 700,
+        "ascent": 950,
+        "descent": -250,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 508,
+        "xWidthAvg": 506,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 506
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
       "italic": {
         "familyName": "Inclusive Sans",
         "fullName": "Inclusive Sans Italic",
@@ -53633,13 +54353,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 500,
-        "xWidthAvg": 477,
+        "xWidthAvg": 481,
         "subsets": {
           "latin": {
-            "xWidthAvg": 477
+            "xWidthAvg": 481
           },
           "thai": {
-            "xWidthAvg": 648
+            "xWidthAvg": 600
           }
         },
         "category": "sans-serif"
@@ -53654,13 +54374,13 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 500,
-        "xWidthAvg": 477,
+        "xWidthAvg": 481,
         "subsets": {
           "latin": {
-            "xWidthAvg": 477
+            "xWidthAvg": 481
           },
           "thai": {
-            "xWidthAvg": 648
+            "xWidthAvg": 618
           }
         },
         "category": "sans-serif"
@@ -55676,7 +56396,7 @@
             "xWidthAvg": 467
           },
           "thai": {
-            "xWidthAvg": 300
+            "xWidthAvg": 540
           }
         },
         "category": "display"
@@ -55784,7 +56504,7 @@
             "xWidthAvg": 512
           },
           "thai": {
-            "xWidthAvg": 400
+            "xWidthAvg": 560
           }
         },
         "category": "display"
@@ -55994,7 +56714,7 @@
             "xWidthAvg": 494
           },
           "thai": {
-            "xWidthAvg": 300
+            "xWidthAvg": 600
           }
         },
         "category": "display"
@@ -56021,7 +56741,7 @@
             "xWidthAvg": 494
           },
           "thai": {
-            "xWidthAvg": 300
+            "xWidthAvg": 600
           }
         },
         "category": "display"
@@ -56048,7 +56768,7 @@
             "xWidthAvg": 505
           },
           "thai": {
-            "xWidthAvg": 300
+            "xWidthAvg": 600
           }
         },
         "category": "display"
@@ -56075,7 +56795,7 @@
             "xWidthAvg": 505
           },
           "thai": {
-            "xWidthAvg": 300
+            "xWidthAvg": 600
           }
         },
         "category": "display"
@@ -56646,7 +57366,7 @@
     "variants": {
       "regular": {
         "familyName": "Jomhuria",
-        "fullName": "Jomhuria",
+        "fullName": "Jomhuria Regular",
         "postscriptName": "Jomhuria-Regular",
         "capHeight": 1172,
         "ascent": 1840,
@@ -57197,10 +57917,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 375,
-        "xWidthAvg": 429,
+        "xWidthAvg": 428,
         "subsets": {
           "latin": {
-            "xWidthAvg": 429
+            "xWidthAvg": 428
           },
           "thai": {
             "xWidthAvg": 300
@@ -57281,10 +58001,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 375,
-        "xWidthAvg": 425,
+        "xWidthAvg": 426,
         "subsets": {
           "latin": {
-            "xWidthAvg": 425
+            "xWidthAvg": 426
           },
           "thai": {
             "xWidthAvg": 300
@@ -63071,7 +63791,7 @@
     "variants": {
       "regular": {
         "familyName": "Kumar One",
-        "fullName": "Kumar One",
+        "fullName": "Kumar One Regular",
         "postscriptName": "KumarOne-Regular",
         "capHeight": 800,
         "ascent": 1137,
@@ -68135,6 +68855,33 @@
           }
         },
         "category": "serif"
+      }
+    }
+  },
+  {
+    "familyName": "Liter",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Liter",
+        "fullName": "Liter Regular",
+        "postscriptName": "Liter-Regular",
+        "capHeight": 700,
+        "ascent": 1030,
+        "descent": -396,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 520,
+        "xWidthAvg": 437,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 437
+          },
+          "thai": {
+            "xWidthAvg": 1078
+          }
+        },
+        "category": "sans-serif"
       }
     }
   },
@@ -73376,6 +74123,159 @@
     }
   },
   {
+    "familyName": "Material Symbols",
+    "defaultVariant": "regular",
+    "variants": {
+      "100": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols Thin",
+        "postscriptName": "MaterialSymbols-Thin",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "200": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols ExtraLight",
+        "postscriptName": "MaterialSymbols-ExtraLight",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "300": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols Light",
+        "postscriptName": "MaterialSymbols-Light",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "500": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols Medium",
+        "postscriptName": "MaterialSymbols-Medium",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "600": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols SemiBold",
+        "postscriptName": "MaterialSymbols-SemiBold",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "700": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols Bold",
+        "postscriptName": "MaterialSymbols-Bold",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      },
+      "regular": {
+        "familyName": "Material Symbols",
+        "fullName": "Material Symbols Regular",
+        "postscriptName": "MaterialSymbols-Regular",
+        "capHeight": 960,
+        "ascent": 1056,
+        "descent": -96,
+        "lineGap": 0,
+        "unitsPerEm": 960,
+        "xHeight": 960,
+        "xWidthAvg": 960,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 960
+          },
+          "thai": {
+            "xWidthAvg": 960
+          }
+        },
+        "category": "monospace"
+      }
+    }
+  },
+  {
     "familyName": "Material Symbols Outlined",
     "defaultVariant": "regular",
     "variants": {
@@ -74370,19 +75270,61 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Light",
         "postscriptName": "Merriweather-Light",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 491,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 952,
         "subsets": {
           "latin": {
-            "xWidthAvg": 491
+            "xWidthAvg": 952
           },
           "thai": {
-            "xWidthAvg": 864
+            "xWidthAvg": 1744
+          }
+        },
+        "category": "serif"
+      },
+      "500": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather Medium",
+        "postscriptName": "Merriweather-Medium",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1111,
+        "xWidthAvg": 974,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 974
+          },
+          "thai": {
+            "xWidthAvg": 1744
+          }
+        },
+        "category": "serif"
+      },
+      "600": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather SemiBold",
+        "postscriptName": "Merriweather-SemiBold",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1111,
+        "xWidthAvg": 981,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 981
+          },
+          "thai": {
+            "xWidthAvg": 1744
           }
         },
         "category": "serif"
@@ -74391,19 +75333,40 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Bold",
         "postscriptName": "Merriweather-Bold",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 556,
-        "xWidthAvg": 505,
+        "unitsPerEm": 2000,
+        "xHeight": 1111,
+        "xWidthAvg": 998,
         "subsets": {
           "latin": {
-            "xWidthAvg": 505
+            "xWidthAvg": 998
           },
           "thai": {
-            "xWidthAvg": 864
+            "xWidthAvg": 1744
+          }
+        },
+        "category": "serif"
+      },
+      "800": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather ExtraBold",
+        "postscriptName": "Merriweather-ExtraBold",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1112,
+        "xWidthAvg": 1007,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 1007
+          },
+          "thai": {
+            "xWidthAvg": 1744
           }
         },
         "category": "serif"
@@ -74412,19 +75375,19 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Black",
         "postscriptName": "Merriweather-Black",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 556,
-        "xWidthAvg": 510,
+        "unitsPerEm": 2000,
+        "xHeight": 1112,
+        "xWidthAvg": 1014,
         "subsets": {
           "latin": {
-            "xWidthAvg": 510
+            "xWidthAvg": 1014
           },
           "thai": {
-            "xWidthAvg": 864
+            "xWidthAvg": 1744
           }
         },
         "category": "serif"
@@ -74433,19 +75396,61 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Light Italic",
         "postscriptName": "Merriweather-LightItalic",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 460,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 902,
         "subsets": {
           "latin": {
-            "xWidthAvg": 460
+            "xWidthAvg": 902
           },
           "thai": {
-            "xWidthAvg": 902
+            "xWidthAvg": 1804
+          }
+        },
+        "category": "serif"
+      },
+      "500italic": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather Medium Italic",
+        "postscriptName": "Merriweather-MediumItalic",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 917,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 917
+          },
+          "thai": {
+            "xWidthAvg": 1813
+          }
+        },
+        "category": "serif"
+      },
+      "600italic": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather SemiBold Italic",
+        "postscriptName": "Merriweather-SemiBoldItalic",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 924,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 924
+          },
+          "thai": {
+            "xWidthAvg": 1817
           }
         },
         "category": "serif"
@@ -74454,19 +75459,40 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Bold Italic",
         "postscriptName": "Merriweather-BoldItalic",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 471,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 929,
         "subsets": {
           "latin": {
-            "xWidthAvg": 471
+            "xWidthAvg": 929
           },
           "thai": {
-            "xWidthAvg": 910
+            "xWidthAvg": 1820
+          }
+        },
+        "category": "serif"
+      },
+      "800italic": {
+        "familyName": "Merriweather",
+        "fullName": "Merriweather ExtraBold Italic",
+        "postscriptName": "Merriweather-ExtraBoldItalic",
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
+        "lineGap": 0,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 934,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 934
+          },
+          "thai": {
+            "xWidthAvg": 1824
           }
         },
         "category": "serif"
@@ -74475,19 +75501,19 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Black Italic",
         "postscriptName": "Merriweather-BlackItalic",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 477,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 940,
         "subsets": {
           "latin": {
-            "xWidthAvg": 477
+            "xWidthAvg": 940
           },
           "thai": {
-            "xWidthAvg": 914
+            "xWidthAvg": 1827
           }
         },
         "category": "serif"
@@ -74496,19 +75522,19 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Italic",
         "postscriptName": "Merriweather-Italic",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 466,
+        "unitsPerEm": 2000,
+        "xHeight": 1110,
+        "xWidthAvg": 913,
         "subsets": {
           "latin": {
-            "xWidthAvg": 466
+            "xWidthAvg": 913
           },
           "thai": {
-            "xWidthAvg": 906
+            "xWidthAvg": 1811
           }
         },
         "category": "serif"
@@ -74517,19 +75543,19 @@
         "familyName": "Merriweather",
         "fullName": "Merriweather Regular",
         "postscriptName": "Merriweather-Regular",
-        "capHeight": 743,
-        "ascent": 984,
-        "descent": -273,
+        "capHeight": 1486,
+        "ascent": 1968,
+        "descent": -546,
         "lineGap": 0,
-        "unitsPerEm": 1000,
-        "xHeight": 555,
-        "xWidthAvg": 496,
+        "unitsPerEm": 2000,
+        "xHeight": 1111,
+        "xWidthAvg": 970,
         "subsets": {
           "latin": {
-            "xWidthAvg": 496
+            "xWidthAvg": 970
           },
           "thai": {
-            "xWidthAvg": 864
+            "xWidthAvg": 1744
           }
         },
         "category": "serif"
@@ -76525,6 +77551,33 @@
     }
   },
   {
+    "familyName": "Monomakh",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Monomakh",
+        "fullName": "Monomakh Regular",
+        "postscriptName": "Monomakh-Regular",
+        "capHeight": 700,
+        "ascent": 932,
+        "descent": -341,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 482,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 482
+          },
+          "thai": {
+            "xWidthAvg": 570
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
     "familyName": "Monomaniac One",
     "defaultVariant": "regular",
     "variants": {
@@ -76638,8 +77691,8 @@
     "variants": {
       "100": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt Thin",
-        "postscriptName": "MontaguSlab144pt-Thin",
+        "fullName": "Montagu Slab Thin",
+        "postscriptName": "MontaguSlab-Thin",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76659,8 +77712,8 @@
       },
       "200": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt ExtraLight",
-        "postscriptName": "MontaguSlab144pt-ExtraLight",
+        "fullName": "Montagu Slab ExtraLight",
+        "postscriptName": "MontaguSlab-ExtraLight",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76680,8 +77733,8 @@
       },
       "300": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt Light",
-        "postscriptName": "MontaguSlab144pt-Light",
+        "fullName": "Montagu Slab Light",
+        "postscriptName": "MontaguSlab-Light",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76701,8 +77754,8 @@
       },
       "500": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt Medium",
-        "postscriptName": "MontaguSlab144pt-Medium",
+        "fullName": "Montagu Slab Medium",
+        "postscriptName": "MontaguSlab-Medium",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76722,8 +77775,8 @@
       },
       "600": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt SemiBold",
-        "postscriptName": "MontaguSlab144pt-SemiBold",
+        "fullName": "Montagu Slab SemiBold",
+        "postscriptName": "MontaguSlab-SemiBold",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76743,8 +77796,8 @@
       },
       "700": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt Bold",
-        "postscriptName": "MontaguSlab144pt-Bold",
+        "fullName": "Montagu Slab Bold",
+        "postscriptName": "MontaguSlab-Bold",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -76764,8 +77817,8 @@
       },
       "regular": {
         "familyName": "Montagu Slab",
-        "fullName": "Montagu Slab 144pt Regular",
-        "postscriptName": "MontaguSlab144pt-Regular",
+        "fullName": "Montagu Slab Regular",
+        "postscriptName": "MontaguSlab-Regular",
         "capHeight": 682,
         "ascent": 982,
         "descent": -300,
@@ -77608,47 +78661,383 @@
     }
   },
   {
-    "familyName": "Montserrat Subrayada",
+    "familyName": "Montserrat Underline",
     "defaultVariant": "regular",
     "variants": {
-      "700": {
-        "familyName": "Montserrat Subrayada",
-        "fullName": "MontserratSubrayada-Bold",
-        "postscriptName": "MontserratSubrayada-Bold",
-        "capHeight": 699,
+      "100": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Thin",
+        "postscriptName": "MontserratUnderline-Thin",
+        "capHeight": 700,
         "ascent": 968,
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 699,
-        "xWidthAvg": 612,
+        "xHeight": 517,
+        "xWidthAvg": 488,
         "subsets": {
           "latin": {
-            "xWidthAvg": 612
+            "xWidthAvg": 488
           },
           "thai": {
-            "xWidthAvg": 264
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline ExtraLight",
+        "postscriptName": "MontserratUnderline-ExtraLight",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 519,
+        "xWidthAvg": 492,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 492
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Light",
+        "postscriptName": "MontserratUnderline-Light",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 522,
+        "xWidthAvg": 497,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 497
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Medium",
+        "postscriptName": "MontserratUnderline-Medium",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 511,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 511
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline SemiBold",
+        "postscriptName": "MontserratUnderline-SemiBold",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 534,
+        "xWidthAvg": 520,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 520
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Bold",
+        "postscriptName": "MontserratUnderline-Bold",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 538,
+        "xWidthAvg": 530,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 530
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline ExtraBold",
+        "postscriptName": "MontserratUnderline-ExtraBold",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 542,
+        "xWidthAvg": 540,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 540
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Black",
+        "postscriptName": "MontserratUnderline-Black",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 547,
+        "xWidthAvg": 551,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 551
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "100italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Thin Italic",
+        "postscriptName": "MontserratUnderline-ThinItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 517,
+        "xWidthAvg": 494,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 494
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline ExtraLight Italic",
+        "postscriptName": "MontserratUnderline-ExtraLightItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 519,
+        "xWidthAvg": 498,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 498
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Light Italic",
+        "postscriptName": "MontserratUnderline-LightItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 522,
+        "xWidthAvg": 503,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 503
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Medium Italic",
+        "postscriptName": "MontserratUnderline-MediumItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 530,
+        "xWidthAvg": 517,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 517
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline SemiBold Italic",
+        "postscriptName": "MontserratUnderline-SemiBoldItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 534,
+        "xWidthAvg": 525,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 525
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Bold Italic",
+        "postscriptName": "MontserratUnderline-BoldItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 538,
+        "xWidthAvg": 534,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 534
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline ExtraBold Italic",
+        "postscriptName": "MontserratUnderline-ExtraBoldItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 542,
+        "xWidthAvg": 544,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 544
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Black Italic",
+        "postscriptName": "MontserratUnderline-BlackItalic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 547,
+        "xWidthAvg": 554,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 554
+          },
+          "thai": {
+            "xWidthAvg": 587
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Italic",
+        "postscriptName": "MontserratUnderline-Italic",
+        "capHeight": 700,
+        "ascent": 968,
+        "descent": -251,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 525,
+        "xWidthAvg": 509,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 509
+          },
+          "thai": {
+            "xWidthAvg": 587
           }
         },
         "category": "sans-serif"
       },
       "regular": {
-        "familyName": "Montserrat Subrayada",
-        "fullName": "MontserratSubrayada-Regular",
-        "postscriptName": "MontserratSubrayada-Regular",
-        "capHeight": 699,
+        "familyName": "Montserrat Underline",
+        "fullName": "Montserrat Underline Regular",
+        "postscriptName": "MontserratUnderline-Regular",
+        "capHeight": 700,
         "ascent": 968,
         "descent": -251,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 699,
-        "xWidthAvg": 615,
+        "xHeight": 525,
+        "xWidthAvg": 504,
         "subsets": {
           "latin": {
-            "xWidthAvg": 615
+            "xWidthAvg": 504
           },
           "thai": {
-            "xWidthAvg": 274
+            "xWidthAvg": 587
           }
         },
         "category": "sans-serif"
@@ -79814,16 +81203,16 @@
         "familyName": "Nanum Gothic",
         "fullName": "NanumGothicBold",
         "postscriptName": "NanumGothicBold",
-        "capHeight": 700,
-        "ascent": 920,
-        "descent": -230,
+        "capHeight": 755,
+        "ascent": 841,
+        "descent": -149,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 500,
-        "xWidthAvg": 466,
+        "xHeight": 555,
+        "xWidthAvg": 567,
         "subsets": {
           "latin": {
-            "xWidthAvg": 466
+            "xWidthAvg": 567
           },
           "thai": {
             "xWidthAvg": 940
@@ -79835,16 +81224,16 @@
         "familyName": "Nanum Gothic",
         "fullName": "NanumGothicExtraBold",
         "postscriptName": "NanumGothicExtraBold",
-        "capHeight": 700,
-        "ascent": 920,
-        "descent": -230,
+        "capHeight": 771,
+        "ascent": 856,
+        "descent": -144,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 500,
-        "xWidthAvg": 466,
+        "xHeight": 566,
+        "xWidthAvg": 567,
         "subsets": {
           "latin": {
-            "xWidthAvg": 466
+            "xWidthAvg": 567
           },
           "thai": {
             "xWidthAvg": 940
@@ -79856,16 +81245,16 @@
         "familyName": "Nanum Gothic",
         "fullName": "NanumGothic",
         "postscriptName": "NanumGothic",
-        "capHeight": 700,
-        "ascent": 920,
-        "descent": -230,
+        "capHeight": 743,
+        "ascent": 844,
+        "descent": -156,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 500,
-        "xWidthAvg": 466,
+        "xHeight": 542,
+        "xWidthAvg": 567,
         "subsets": {
           "latin": {
-            "xWidthAvg": 466
+            "xWidthAvg": 567
           },
           "thai": {
             "xWidthAvg": 940
@@ -79932,15 +81321,15 @@
         "fullName": "NanumMyeongjoBold",
         "postscriptName": "NanumMyeongjoBold",
         "capHeight": 758,
-        "ascent": 942,
-        "descent": -236,
-        "lineGap": 0,
+        "ascent": 819,
+        "descent": -205,
+        "lineGap": 256,
         "unitsPerEm": 1024,
         "xHeight": 486,
-        "xWidthAvg": 455,
+        "xWidthAvg": 557,
         "subsets": {
           "latin": {
-            "xWidthAvg": 455
+            "xWidthAvg": 557
           },
           "thai": {
             "xWidthAvg": 1024
@@ -79953,15 +81342,15 @@
         "fullName": "NanumMyeongjoExtraBold",
         "postscriptName": "NanumMyeongjoExtraBold",
         "capHeight": 758,
-        "ascent": 942,
-        "descent": -236,
-        "lineGap": 0,
+        "ascent": 819,
+        "descent": -205,
+        "lineGap": 256,
         "unitsPerEm": 1024,
         "xHeight": 486,
-        "xWidthAvg": 455,
+        "xWidthAvg": 556,
         "subsets": {
           "latin": {
-            "xWidthAvg": 455
+            "xWidthAvg": 556
           },
           "thai": {
             "xWidthAvg": 1024
@@ -79974,15 +81363,15 @@
         "fullName": "NanumMyeongjo",
         "postscriptName": "NanumMyeongjo",
         "capHeight": 755,
-        "ascent": 942,
-        "descent": -236,
-        "lineGap": 0,
+        "ascent": 819,
+        "descent": -205,
+        "lineGap": 256,
         "unitsPerEm": 1024,
         "xHeight": 480,
-        "xWidthAvg": 455,
+        "xWidthAvg": 557,
         "subsets": {
           "latin": {
-            "xWidthAvg": 455
+            "xWidthAvg": 557
           },
           "thai": {
             "xWidthAvg": 1024
@@ -79998,18 +81387,18 @@
     "variants": {
       "regular": {
         "familyName": "Nanum Pen Script",
-        "fullName": "Nanum Pen",
-        "postscriptName": "NanumPen",
+        "fullName": "Nanum Pen Regular",
+        "postscriptName": "NanumPen-Regular",
         "capHeight": 674,
-        "ascent": 920,
-        "descent": -230,
-        "lineGap": 0,
+        "ascent": 800,
+        "descent": -200,
+        "lineGap": 250,
         "unitsPerEm": 1000,
         "xHeight": 476,
-        "xWidthAvg": 354,
+        "xWidthAvg": 474,
         "subsets": {
           "latin": {
-            "xWidthAvg": 354
+            "xWidthAvg": 474
           },
           "thai": {
             "xWidthAvg": 940
@@ -80474,8 +81863,8 @@
     "variants": {
       "200": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt ExtraLight",
-        "postscriptName": "Newsreader16pt-ExtraLight",
+        "fullName": "Newsreader ExtraLight",
+        "postscriptName": "Newsreader-ExtraLight",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80495,8 +81884,8 @@
       },
       "300": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Light",
-        "postscriptName": "Newsreader16pt-Light",
+        "fullName": "Newsreader Light",
+        "postscriptName": "Newsreader-Light",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80516,8 +81905,8 @@
       },
       "500": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Medium",
-        "postscriptName": "Newsreader16pt-Medium",
+        "fullName": "Newsreader Medium",
+        "postscriptName": "Newsreader-Medium",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80537,8 +81926,8 @@
       },
       "600": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt SemiBold",
-        "postscriptName": "Newsreader16pt-SemiBold",
+        "fullName": "Newsreader SemiBold",
+        "postscriptName": "Newsreader-SemiBold",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80558,8 +81947,8 @@
       },
       "700": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Bold",
-        "postscriptName": "Newsreader16pt-Bold",
+        "fullName": "Newsreader Bold",
+        "postscriptName": "Newsreader-Bold",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80579,8 +81968,8 @@
       },
       "800": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt ExtraBold",
-        "postscriptName": "Newsreader16pt-ExtraBold",
+        "fullName": "Newsreader ExtraBold",
+        "postscriptName": "Newsreader-ExtraBold",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80600,8 +81989,8 @@
       },
       "200italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt ExtraLight Italic",
-        "postscriptName": "Newsreader16pt-ExtraLightItalic",
+        "fullName": "Newsreader ExtraLight Italic",
+        "postscriptName": "Newsreader-ExtraLightItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80621,8 +82010,8 @@
       },
       "300italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Light Italic",
-        "postscriptName": "Newsreader16pt-LightItalic",
+        "fullName": "Newsreader Light Italic",
+        "postscriptName": "Newsreader-LightItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80642,8 +82031,8 @@
       },
       "500italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Medium Italic",
-        "postscriptName": "Newsreader16pt-MediumItalic",
+        "fullName": "Newsreader Medium Italic",
+        "postscriptName": "Newsreader-MediumItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80663,8 +82052,8 @@
       },
       "600italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt SemiBold Italic",
-        "postscriptName": "Newsreader16pt-SemiBoldItalic",
+        "fullName": "Newsreader SemiBold Italic",
+        "postscriptName": "Newsreader-SemiBoldItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80684,8 +82073,8 @@
       },
       "700italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Bold Italic",
-        "postscriptName": "Newsreader16pt-BoldItalic",
+        "fullName": "Newsreader Bold Italic",
+        "postscriptName": "Newsreader-BoldItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80705,8 +82094,8 @@
       },
       "800italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt ExtraBold Italic",
-        "postscriptName": "Newsreader16pt-ExtraBoldItalic",
+        "fullName": "Newsreader ExtraBold Italic",
+        "postscriptName": "Newsreader-ExtraBoldItalic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80726,8 +82115,8 @@
       },
       "italic": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Italic",
-        "postscriptName": "Newsreader16pt-Italic",
+        "fullName": "Newsreader Italic",
+        "postscriptName": "Newsreader-Italic",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -80747,8 +82136,8 @@
       },
       "regular": {
         "familyName": "Newsreader",
-        "fullName": "Newsreader 16pt Regular",
-        "postscriptName": "Newsreader16pt-Regular",
+        "fullName": "Newsreader Regular",
+        "postscriptName": "Newsreader-Regular",
         "capHeight": 1340,
         "ascent": 1470,
         "descent": -530,
@@ -82855,16 +84244,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Thin",
         "postscriptName": "NotoSansArabic-Thin",
-        "capHeight": 356,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 325,
-        "xWidthAvg": 540,
+        "xHeight": 528,
+        "xWidthAvg": 439,
         "subsets": {
           "latin": {
-            "xWidthAvg": 540
+            "xWidthAvg": 439
           },
           "thai": {
             "xWidthAvg": 600
@@ -82876,16 +84265,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic ExtraLight",
         "postscriptName": "NotoSansArabic-ExtraLight",
-        "capHeight": 368,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 335,
-        "xWidthAvg": 540,
+        "xHeight": 530,
+        "xWidthAvg": 446,
         "subsets": {
           "latin": {
-            "xWidthAvg": 540
+            "xWidthAvg": 446
           },
           "thai": {
             "xWidthAvg": 600
@@ -82897,16 +84286,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Light",
         "postscriptName": "NotoSansArabic-Light",
-        "capHeight": 386,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 350,
-        "xWidthAvg": 541,
+        "xHeight": 532,
+        "xWidthAvg": 457,
         "subsets": {
           "latin": {
-            "xWidthAvg": 541
+            "xWidthAvg": 457
           },
           "thai": {
             "xWidthAvg": 600
@@ -82918,16 +84307,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Medium",
         "postscriptName": "NotoSansArabic-Medium",
-        "capHeight": 441,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 393,
-        "xWidthAvg": 541,
+        "xHeight": 539,
+        "xWidthAvg": 483,
         "subsets": {
           "latin": {
-            "xWidthAvg": 541
+            "xWidthAvg": 483
           },
           "thai": {
             "xWidthAvg": 600
@@ -82939,16 +84328,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic SemiBold",
         "postscriptName": "NotoSansArabic-SemiBold",
-        "capHeight": 468,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 415,
-        "xWidthAvg": 541,
+        "xHeight": 542,
+        "xWidthAvg": 493,
         "subsets": {
           "latin": {
-            "xWidthAvg": 541
+            "xWidthAvg": 493
           },
           "thai": {
             "xWidthAvg": 600
@@ -82960,16 +84349,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Bold",
         "postscriptName": "NotoSansArabic-Bold",
-        "capHeight": 500,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 440,
-        "xWidthAvg": 542,
+        "xHeight": 546,
+        "xWidthAvg": 504,
         "subsets": {
           "latin": {
-            "xWidthAvg": 542
+            "xWidthAvg": 504
           },
           "thai": {
             "xWidthAvg": 600
@@ -82981,16 +84370,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic ExtraBold",
         "postscriptName": "NotoSansArabic-ExtraBold",
-        "capHeight": 523,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 462,
-        "xWidthAvg": 542,
+        "xHeight": 549,
+        "xWidthAvg": 512,
         "subsets": {
           "latin": {
-            "xWidthAvg": 542
+            "xWidthAvg": 512
           },
           "thai": {
             "xWidthAvg": 600
@@ -83002,16 +84391,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Black",
         "postscriptName": "NotoSansArabic-Black",
-        "capHeight": 550,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 487,
-        "xWidthAvg": 542,
+        "xHeight": 553,
+        "xWidthAvg": 521,
         "subsets": {
           "latin": {
-            "xWidthAvg": 542
+            "xWidthAvg": 521
           },
           "thai": {
             "xWidthAvg": 600
@@ -83023,16 +84412,16 @@
         "familyName": "Noto Sans Arabic",
         "fullName": "Noto Sans Arabic Regular",
         "postscriptName": "NotoSansArabic-Regular",
-        "capHeight": 416,
+        "capHeight": 714,
         "ascent": 1374,
         "descent": -738,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 374,
-        "xWidthAvg": 541,
+        "xHeight": 536,
+        "xWidthAvg": 474,
         "subsets": {
           "latin": {
-            "xWidthAvg": 541
+            "xWidthAvg": 474
           },
           "thai": {
             "xWidthAvg": 600
@@ -91110,11 +92499,11 @@
     }
   },
   {
-    "familyName": "Noto Sans Phags Pa",
+    "familyName": "Noto Sans PhagsPa",
     "defaultVariant": "regular",
     "variants": {
       "regular": {
-        "familyName": "Noto Sans Phags Pa",
+        "familyName": "Noto Sans PhagsPa",
         "fullName": "Noto Sans PhagsPa Regular",
         "postscriptName": "NotoSansPhagsPa-Regular",
         "capHeight": 670,
@@ -91123,10 +92512,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 536,
-        "xWidthAvg": 548,
+        "xWidthAvg": 474,
         "subsets": {
           "latin": {
-            "xWidthAvg": 548
+            "xWidthAvg": 474
           },
           "thai": {
             "xWidthAvg": 600
@@ -94627,10 +96016,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 536,
-        "xWidthAvg": 524,
+        "xWidthAvg": 523,
         "subsets": {
           "latin": {
-            "xWidthAvg": 524
+            "xWidthAvg": 523
           },
           "thai": {
             "xWidthAvg": 592
@@ -96917,6 +98306,180 @@
           },
           "thai": {
             "xWidthAvg": 600
+          }
+        },
+        "category": "serif"
+      }
+    }
+  },
+  {
+    "familyName": "Noto Serif Hentaigana",
+    "defaultVariant": "regular",
+    "variants": {
+      "200": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana ExtraLight",
+        "postscriptName": "NotoSerifHentaigana-ExtraLight",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 442,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 442
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "300": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana Light",
+        "postscriptName": "NotoSerifHentaigana-Light",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 475,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 475
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "500": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana Medium",
+        "postscriptName": "NotoSerifHentaigana-Medium",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 542,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 542
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "600": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana SemiBold",
+        "postscriptName": "NotoSerifHentaigana-SemiBold",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 551,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 551
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "700": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana Bold",
+        "postscriptName": "NotoSerifHentaigana-Bold",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 568,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 568
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "800": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana ExtraBold",
+        "postscriptName": "NotoSerifHentaigana-ExtraBold",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 577,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 577
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "900": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana Black",
+        "postscriptName": "NotoSerifHentaigana-Black",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 586,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 586
+          },
+          "thai": {
+            "xWidthAvg": 500
+          }
+        },
+        "category": "serif"
+      },
+      "regular": {
+        "familyName": "Noto Serif Hentaigana",
+        "fullName": "Noto Serif Hentaigana Regular",
+        "postscriptName": "NotoSerifHentaigana-Regular",
+        "capHeight": 880,
+        "ascent": 1151,
+        "descent": -286,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 880,
+        "xWidthAvg": 509,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 509
+          },
+          "thai": {
+            "xWidthAvg": 500
           }
         },
         "category": "serif"
@@ -100331,6 +101894,33 @@
           },
           "thai": {
             "xWidthAvg": 600
+          }
+        },
+        "category": "serif"
+      }
+    }
+  },
+  {
+    "familyName": "Noto Serif Todhri",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Noto Serif Todhri",
+        "fullName": "Noto Serif Todhri Regular",
+        "postscriptName": "NotoSerifTodhri-Regular",
+        "capHeight": 714,
+        "ascent": 1069,
+        "descent": -293,
+        "lineGap": 0,
+        "unitsPerEm": 1024,
+        "xHeight": 536,
+        "xWidthAvg": 481,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 481
+          },
+          "thai": {
+            "xWidthAvg": 512
           }
         },
         "category": "serif"
@@ -104733,6 +106323,138 @@
     }
   },
   {
+    "familyName": "Parkinsans",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans Light",
+        "postscriptName": "Parkinsans-Light",
+        "capHeight": 690,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 546,
+        "xWidthAvg": 499,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 499
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans Medium",
+        "postscriptName": "Parkinsans-Medium",
+        "capHeight": 695,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 551,
+        "xWidthAvg": 511,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 511
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans SemiBold",
+        "postscriptName": "Parkinsans-SemiBold",
+        "capHeight": 698,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 554,
+        "xWidthAvg": 515,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 515
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans Bold",
+        "postscriptName": "Parkinsans-Bold",
+        "capHeight": 702,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 558,
+        "xWidthAvg": 518,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 518
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans ExtraBold",
+        "postscriptName": "Parkinsans-ExtraBold",
+        "capHeight": 705,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 561,
+        "xWidthAvg": 522,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 522
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Parkinsans",
+        "fullName": "Parkinsans Regular",
+        "postscriptName": "Parkinsans-Regular",
+        "capHeight": 693,
+        "ascent": 1050,
+        "descent": -350,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 549,
+        "xWidthAvg": 505,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 505
+          },
+          "thai": {
+            "xWidthAvg": 600
+          }
+        },
+        "category": "sans-serif"
+      }
+    }
+  },
+  {
     "familyName": "Passero One",
     "defaultVariant": "regular",
     "variants": {
@@ -105946,6 +107668,50 @@
     }
   },
   {
+    "familyName": "Phetsarath",
+    "defaultVariant": "regular",
+    "variants": {
+      "700": {
+        "familyName": "Phetsarath",
+        "fullName": "Phetsarath Bold",
+        "postscriptName": "Phetsarath-Bold",
+        "ascent": 2123,
+        "descent": -857,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xWidthAvg": 132,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 132
+          },
+          "thai": {
+            "xWidthAvg": 0
+          }
+        },
+        "category": "serif"
+      },
+      "regular": {
+        "familyName": "Phetsarath",
+        "fullName": "Phetsarath Regular",
+        "postscriptName": "Phetsarath-Regular",
+        "ascent": 2123,
+        "descent": -857,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xWidthAvg": 133,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 133
+          },
+          "thai": {
+            "xWidthAvg": 0
+          }
+        },
+        "category": "serif"
+      }
+    }
+  },
+  {
     "familyName": "Philosopher",
     "defaultVariant": "regular",
     "variants": {
@@ -107116,11 +108882,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 514,
-        "xWidthAvg": 536,
+        "xHeight": 512,
+        "xWidthAvg": 541,
         "subsets": {
           "latin": {
-            "xWidthAvg": 536
+            "xWidthAvg": 541
           },
           "thai": {
             "xWidthAvg": 598
@@ -107137,11 +108903,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 515,
-        "xWidthAvg": 533,
+        "xHeight": 514,
+        "xWidthAvg": 538,
         "subsets": {
           "latin": {
-            "xWidthAvg": 533
+            "xWidthAvg": 538
           },
           "thai": {
             "xWidthAvg": 597
@@ -107158,11 +108924,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 516,
-        "xWidthAvg": 531,
+        "xHeight": 515,
+        "xWidthAvg": 537,
         "subsets": {
           "latin": {
-            "xWidthAvg": 531
+            "xWidthAvg": 537
           },
           "thai": {
             "xWidthAvg": 597
@@ -107179,11 +108945,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 517,
-        "xWidthAvg": 528,
+        "xHeight": 516,
+        "xWidthAvg": 535,
         "subsets": {
           "latin": {
-            "xWidthAvg": 528
+            "xWidthAvg": 535
           },
           "thai": {
             "xWidthAvg": 597
@@ -107201,10 +108967,10 @@
         "lineGap": 0,
         "unitsPerEm": 1240,
         "xHeight": 518,
-        "xWidthAvg": 525,
+        "xWidthAvg": 533,
         "subsets": {
           "latin": {
-            "xWidthAvg": 525
+            "xWidthAvg": 533
           },
           "thai": {
             "xWidthAvg": 596
@@ -107221,11 +108987,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 519,
-        "xWidthAvg": 521,
+        "xHeight": 520,
+        "xWidthAvg": 530,
         "subsets": {
           "latin": {
-            "xWidthAvg": 521
+            "xWidthAvg": 530
           },
           "thai": {
             "xWidthAvg": 596
@@ -107242,14 +109008,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 514,
-        "xWidthAvg": 510,
+        "xHeight": 512,
+        "xWidthAvg": 512,
         "subsets": {
           "latin": {
-            "xWidthAvg": 510
+            "xWidthAvg": 512
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 598
           }
         },
         "category": "serif"
@@ -107263,14 +109029,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 515,
-        "xWidthAvg": 523,
+        "xHeight": 514,
+        "xWidthAvg": 526,
         "subsets": {
           "latin": {
-            "xWidthAvg": 523
+            "xWidthAvg": 526
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 597
           }
         },
         "category": "serif"
@@ -107284,14 +109050,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 516,
-        "xWidthAvg": 532,
+        "xHeight": 515,
+        "xWidthAvg": 535,
         "subsets": {
           "latin": {
-            "xWidthAvg": 532
+            "xWidthAvg": 535
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 597
           }
         },
         "category": "serif"
@@ -107305,14 +109071,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 517,
-        "xWidthAvg": 543,
+        "xHeight": 516,
+        "xWidthAvg": 547,
         "subsets": {
           "latin": {
-            "xWidthAvg": 543
+            "xWidthAvg": 547
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 597
           }
         },
         "category": "serif"
@@ -107327,13 +109093,13 @@
         "lineGap": 0,
         "unitsPerEm": 1240,
         "xHeight": 518,
-        "xWidthAvg": 555,
+        "xWidthAvg": 559,
         "subsets": {
           "latin": {
-            "xWidthAvg": 555
+            "xWidthAvg": 559
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 596
           }
         },
         "category": "serif"
@@ -107347,14 +109113,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 519,
-        "xWidthAvg": 571,
+        "xHeight": 520,
+        "xWidthAvg": 577,
         "subsets": {
           "latin": {
-            "xWidthAvg": 571
+            "xWidthAvg": 577
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 596
           }
         },
         "category": "serif"
@@ -107368,14 +109134,14 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 514,
-        "xWidthAvg": 515,
+        "xHeight": 513,
+        "xWidthAvg": 517,
         "subsets": {
           "latin": {
-            "xWidthAvg": 515
+            "xWidthAvg": 517
           },
           "thai": {
-            "xWidthAvg": 562
+            "xWidthAvg": 598
           }
         },
         "category": "serif"
@@ -107389,11 +109155,11 @@
         "descent": -390,
         "lineGap": 0,
         "unitsPerEm": 1240,
-        "xHeight": 514,
-        "xWidthAvg": 535,
+        "xHeight": 513,
+        "xWidthAvg": 540,
         "subsets": {
           "latin": {
-            "xWidthAvg": 535
+            "xWidthAvg": 540
           },
           "thai": {
             "xWidthAvg": 598
@@ -108058,6 +109824,33 @@
     }
   },
   {
+    "familyName": "Playwrite AR Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AR Guides",
+        "fullName": "Playwrite AR Guides Regular",
+        "postscriptName": "PlaywriteARGuides-Regular",
+        "capHeight": 1065,
+        "ascent": 1508,
+        "descent": -571,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 529,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 529
+          },
+          "thai": {
+            "xWidthAvg": 983
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite AT",
     "defaultVariant": "regular",
     "variants": {
@@ -108232,6 +110025,54 @@
     }
   },
   {
+    "familyName": "Playwrite AT Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "italic": {
+        "familyName": "Playwrite AT Guides",
+        "fullName": "Playwrite AT Guides Italic",
+        "postscriptName": "PlaywriteATGuides-Italic",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 531,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 531
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Playwrite AT Guides",
+        "fullName": "Playwrite AT Guides Regular",
+        "postscriptName": "PlaywriteATGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 531,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 531
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite AU NSW",
     "defaultVariant": "regular",
     "variants": {
@@ -108315,6 +110156,33 @@
           },
           "thai": {
             "xWidthAvg": 935
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite AU NSW Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AU NSW Guides",
+        "fullName": "Playwrite AU NSW Guides Regular",
+        "postscriptName": "PlaywriteAUNSWGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 508,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 508
+          },
+          "thai": {
+            "xWidthAvg": 936
           }
         },
         "category": "handwriting"
@@ -108412,6 +110280,33 @@
     }
   },
   {
+    "familyName": "Playwrite AU QLD Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AU QLD Guides",
+        "fullName": "Playwrite AU QLD Guides Regular",
+        "postscriptName": "PlaywriteAUQLDGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 518,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 518
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite AU SA",
     "defaultVariant": "regular",
     "variants": {
@@ -108492,6 +110387,33 @@
         "subsets": {
           "latin": {
             "xWidthAvg": 509
+          },
+          "thai": {
+            "xWidthAvg": 927
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite AU SA Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AU SA Guides",
+        "fullName": "Playwrite AU SA Guides Regular",
+        "postscriptName": "PlaywriteAUSAGuides-Regular",
+        "capHeight": 988,
+        "ascent": 1413,
+        "descent": -492,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 508,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 508
           },
           "thai": {
             "xWidthAvg": 927
@@ -108592,6 +110514,33 @@
     }
   },
   {
+    "familyName": "Playwrite AU TAS Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AU TAS Guides",
+        "fullName": "Playwrite AU TAS Guides Regular",
+        "postscriptName": "PlaywriteAUTASGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 506,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 506
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite AU VIC",
     "defaultVariant": "regular",
     "variants": {
@@ -108675,6 +110624,33 @@
           },
           "thai": {
             "xWidthAvg": 935
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite AU VIC Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite AU VIC Guides",
+        "fullName": "Playwrite AU VIC Guides Regular",
+        "postscriptName": "PlaywriteAUVICGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 517,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 517
+          },
+          "thai": {
+            "xWidthAvg": 936
           }
         },
         "category": "handwriting"
@@ -108772,6 +110748,33 @@
     }
   },
   {
+    "familyName": "Playwrite BE VLG Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite BE VLG Guides",
+        "fullName": "Playwrite BE VLG Guides Regular",
+        "postscriptName": "PlaywriteBEVLGGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 525,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 525
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite BE WAL",
     "defaultVariant": "regular",
     "variants": {
@@ -108842,6 +110845,33 @@
         "familyName": "Playwrite BE WAL",
         "fullName": "Playwrite BE WAL Regular",
         "postscriptName": "PlaywriteBEWAL-Regular",
+        "capHeight": 1405,
+        "ascent": 1924,
+        "descent": -922,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 546,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 546
+          },
+          "thai": {
+            "xWidthAvg": 1231
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite BE WAL Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite BE WAL Guides",
+        "fullName": "Playwrite BE WAL Guides Regular",
+        "postscriptName": "PlaywriteBEWALGuides-Regular",
         "capHeight": 1405,
         "ascent": 1924,
         "descent": -922,
@@ -108952,6 +110982,33 @@
     }
   },
   {
+    "familyName": "Playwrite BR Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite BR Guides",
+        "fullName": "Playwrite BR Guides Regular",
+        "postscriptName": "PlaywriteBRGuides-Regular",
+        "capHeight": 1131,
+        "ascent": 1588,
+        "descent": -639,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 531,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 531
+          },
+          "thai": {
+            "xWidthAvg": 1031
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite CA",
     "defaultVariant": "regular",
     "variants": {
@@ -109042,6 +111099,33 @@
     }
   },
   {
+    "familyName": "Playwrite CA Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite CA Guides",
+        "fullName": "Playwrite CA Guides Regular",
+        "postscriptName": "PlaywriteCAGuides-Regular",
+        "capHeight": 996,
+        "ascent": 1423,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 527,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 527
+          },
+          "thai": {
+            "xWidthAvg": 933
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite CL",
     "defaultVariant": "regular",
     "variants": {
@@ -109112,6 +111196,33 @@
         "familyName": "Playwrite CL",
         "fullName": "Playwrite CL Regular",
         "postscriptName": "PlaywriteCL-Regular",
+        "capHeight": 1133,
+        "ascent": 1591,
+        "descent": -641,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 532,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 532
+          },
+          "thai": {
+            "xWidthAvg": 1033
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite CL Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite CL Guides",
+        "fullName": "Playwrite CL Guides Regular",
+        "postscriptName": "PlaywriteCLGuides-Regular",
         "capHeight": 1133,
         "ascent": 1591,
         "descent": -641,
@@ -109222,6 +111333,33 @@
     }
   },
   {
+    "familyName": "Playwrite CO Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite CO Guides",
+        "fullName": "Playwrite CO Guides Regular",
+        "postscriptName": "PlaywriteCOGuides-Regular",
+        "capHeight": 1020,
+        "ascent": 1452,
+        "descent": -525,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 526,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 526
+          },
+          "thai": {
+            "xWidthAvg": 951
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite CU",
     "defaultVariant": "regular",
     "variants": {
@@ -109305,6 +111443,33 @@
           },
           "thai": {
             "xWidthAvg": 1019
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite CU Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite CU Guides",
+        "fullName": "Playwrite CU Guides Regular",
+        "postscriptName": "PlaywriteCUGuides-Regular",
+        "capHeight": 1115,
+        "ascent": 1569,
+        "descent": -623,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 532,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 532
+          },
+          "thai": {
+            "xWidthAvg": 1020
           }
         },
         "category": "handwriting"
@@ -109402,6 +111567,33 @@
     }
   },
   {
+    "familyName": "Playwrite CZ Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite CZ Guides",
+        "fullName": "Playwrite CZ Guides Regular",
+        "postscriptName": "PlaywriteCZGuides-Regular",
+        "capHeight": 985,
+        "ascent": 1410,
+        "descent": -489,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 540,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 540
+          },
+          "thai": {
+            "xWidthAvg": 925
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite DE Grund",
     "defaultVariant": "regular",
     "variants": {
@@ -109472,6 +111664,33 @@
         "familyName": "Playwrite DE Grund",
         "fullName": "Playwrite DE Grund Regular",
         "postscriptName": "PlaywriteDEGrund-Regular",
+        "capHeight": 920,
+        "ascent": 1330,
+        "descent": -421,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 502,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 502
+          },
+          "thai": {
+            "xWidthAvg": 878
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite DE Grund Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DE Grund Guides",
+        "fullName": "Playwrite DE Grund Guides Regular",
+        "postscriptName": "PlaywriteDEGrundGuides-Regular",
         "capHeight": 920,
         "ascent": 1330,
         "descent": -421,
@@ -109582,6 +111801,33 @@
     }
   },
   {
+    "familyName": "Playwrite DE LA Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DE LA Guides",
+        "fullName": "Playwrite DE LA Guides Regular",
+        "postscriptName": "PlaywriteDELAGuides-Regular",
+        "capHeight": 920,
+        "ascent": 1330,
+        "descent": -421,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 520,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 520
+          },
+          "thai": {
+            "xWidthAvg": 878
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite DE SAS",
     "defaultVariant": "regular",
     "variants": {
@@ -109652,6 +111898,33 @@
         "familyName": "Playwrite DE SAS",
         "fullName": "Playwrite DE SAS Regular",
         "postscriptName": "PlaywriteDESAS-Regular",
+        "capHeight": 888,
+        "ascent": 1291,
+        "descent": -388,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 532,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 532
+          },
+          "thai": {
+            "xWidthAvg": 854
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite DE SAS Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DE SAS Guides",
+        "fullName": "Playwrite DE SAS Guides Regular",
+        "postscriptName": "PlaywriteDESASGuides-Regular",
         "capHeight": 888,
         "ascent": 1291,
         "descent": -388,
@@ -109762,6 +112035,33 @@
     }
   },
   {
+    "familyName": "Playwrite DE VA Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DE VA Guides",
+        "fullName": "Playwrite DE VA Guides Regular",
+        "postscriptName": "PlaywriteDEVAGuides-Regular",
+        "capHeight": 979,
+        "ascent": 1402,
+        "descent": -482,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 534,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 534
+          },
+          "thai": {
+            "xWidthAvg": 921
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite DK Loopet",
     "defaultVariant": "regular",
     "variants": {
@@ -109852,6 +112152,33 @@
     }
   },
   {
+    "familyName": "Playwrite DK Loopet Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DK Loopet Guides",
+        "fullName": "Playwrite DK Loopet Guides Regular",
+        "postscriptName": "PlaywriteDKLoopetGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 503,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 503
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite DK Uloopet",
     "defaultVariant": "regular",
     "variants": {
@@ -109935,6 +112262,33 @@
           },
           "thai": {
             "xWidthAvg": 844
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite DK Uloopet Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite DK Uloopet Guides",
+        "fullName": "Playwrite DK Uloopet Guides Regular",
+        "postscriptName": "PlaywriteDKUloopetGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 498,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 498
+          },
+          "thai": {
+            "xWidthAvg": 845
           }
         },
         "category": "handwriting"
@@ -110122,6 +112476,60 @@
     }
   },
   {
+    "familyName": "Playwrite ES Deco Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite ES Deco Guides",
+        "fullName": "Playwrite ES Deco Guides Regular",
+        "postscriptName": "PlaywriteESDecoGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 526,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 526
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite ES Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite ES Guides",
+        "fullName": "Playwrite ES Guides Regular",
+        "postscriptName": "PlaywriteESGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 518,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 518
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite FR Moderne",
     "defaultVariant": "regular",
     "variants": {
@@ -110212,6 +112620,33 @@
     }
   },
   {
+    "familyName": "Playwrite FR Moderne Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite FR Moderne Guides",
+        "fullName": "Playwrite FR Moderne Guides Regular",
+        "postscriptName": "PlaywriteFRModerneGuides-Regular",
+        "capHeight": 1100,
+        "ascent": 1550,
+        "descent": -607,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 513,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 513
+          },
+          "thai": {
+            "xWidthAvg": 1009
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite FR Trad",
     "defaultVariant": "regular",
     "variants": {
@@ -110282,6 +112717,33 @@
         "familyName": "Playwrite FR Trad",
         "fullName": "Playwrite FR Trad Regular",
         "postscriptName": "PlaywriteFRTrad-Regular",
+        "capHeight": 1408,
+        "ascent": 1927,
+        "descent": -925,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 545,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 545
+          },
+          "thai": {
+            "xWidthAvg": 1233
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite FR Trad Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite FR Trad Guides",
+        "fullName": "Playwrite FR Trad Guides Regular",
+        "postscriptName": "PlaywriteFRTradGuides-Regular",
         "capHeight": 1408,
         "ascent": 1927,
         "descent": -925,
@@ -110476,6 +112938,54 @@
     }
   },
   {
+    "familyName": "Playwrite GB J Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "italic": {
+        "familyName": "Playwrite GB J Guides",
+        "fullName": "Playwrite GB J Guides Italic",
+        "postscriptName": "PlaywriteGBJGuides-Italic",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 505,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 505
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Playwrite GB J Guides",
+        "fullName": "Playwrite GB J Guides Regular",
+        "postscriptName": "PlaywriteGBJGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 505,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 505
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite GB S",
     "defaultVariant": "regular",
     "variants": {
@@ -110650,6 +113160,54 @@
     }
   },
   {
+    "familyName": "Playwrite GB S Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "italic": {
+        "familyName": "Playwrite GB S Guides",
+        "fullName": "Playwrite GB S Guides Italic",
+        "postscriptName": "PlaywriteGBSGuides-Italic",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 501,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 501
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      },
+      "regular": {
+        "familyName": "Playwrite GB S Guides",
+        "fullName": "Playwrite GB S Guides Regular",
+        "postscriptName": "PlaywriteGBSGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 501,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 501
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite HR",
     "defaultVariant": "regular",
     "variants": {
@@ -110740,6 +113298,33 @@
     }
   },
   {
+    "familyName": "Playwrite HR Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite HR Guides",
+        "fullName": "Playwrite HR Guides Regular",
+        "postscriptName": "PlaywriteHRGuides-Regular",
+        "capHeight": 879,
+        "ascent": 1280,
+        "descent": -379,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 523,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 523
+          },
+          "thai": {
+            "xWidthAvg": 848
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite HR Lijeva",
     "defaultVariant": "regular",
     "variants": {
@@ -110820,6 +113405,33 @@
         "subsets": {
           "latin": {
             "xWidthAvg": 524
+          },
+          "thai": {
+            "xWidthAvg": 848
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite HR Lijeva Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite HR Lijeva Guides",
+        "fullName": "Playwrite HR Lijeva Guides Regular",
+        "postscriptName": "PlaywriteHRLijevaGuides-Regular",
+        "capHeight": 879,
+        "ascent": 1280,
+        "descent": -379,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 523,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 523
           },
           "thai": {
             "xWidthAvg": 848
@@ -110920,6 +113532,33 @@
     }
   },
   {
+    "familyName": "Playwrite HU Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite HU Guides",
+        "fullName": "Playwrite HU Guides Regular",
+        "postscriptName": "PlaywriteHUGuides-Regular",
+        "capHeight": 946,
+        "ascent": 1362,
+        "descent": -448,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 526,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 526
+          },
+          "thai": {
+            "xWidthAvg": 897
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite ID",
     "defaultVariant": "regular",
     "variants": {
@@ -110990,6 +113629,33 @@
         "familyName": "Playwrite ID",
         "fullName": "Playwrite ID Regular",
         "postscriptName": "PlaywriteID-Regular",
+        "capHeight": 1438,
+        "ascent": 1964,
+        "descent": -956,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 541,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 541
+          },
+          "thai": {
+            "xWidthAvg": 1255
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite ID Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite ID Guides",
+        "fullName": "Playwrite ID Guides Regular",
+        "postscriptName": "PlaywriteIDGuides-Regular",
         "capHeight": 1438,
         "ascent": 1964,
         "descent": -956,
@@ -111100,6 +113766,33 @@
     }
   },
   {
+    "familyName": "Playwrite IE Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite IE Guides",
+        "fullName": "Playwrite IE Guides Regular",
+        "postscriptName": "PlaywriteIEGuides-Regular",
+        "capHeight": 981,
+        "ascent": 1405,
+        "descent": -484,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 527,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 527
+          },
+          "thai": {
+            "xWidthAvg": 922
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite IN",
     "defaultVariant": "regular",
     "variants": {
@@ -111183,6 +113876,33 @@
           },
           "thai": {
             "xWidthAvg": 952
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite IN Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite IN Guides",
+        "fullName": "Playwrite IN Guides Regular",
+        "postscriptName": "PlaywriteINGuides-Regular",
+        "capHeight": 1023,
+        "ascent": 1456,
+        "descent": -528,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 534,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 534
+          },
+          "thai": {
+            "xWidthAvg": 953
           }
         },
         "category": "handwriting"
@@ -111280,6 +114000,33 @@
     }
   },
   {
+    "familyName": "Playwrite IS Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite IS Guides",
+        "fullName": "Playwrite IS Guides Regular",
+        "postscriptName": "PlaywriteISGuides-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 505,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 505
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite IT Moderna",
     "defaultVariant": "regular",
     "variants": {
@@ -111350,6 +114097,33 @@
         "familyName": "Playwrite IT Moderna",
         "fullName": "Playwrite IT Moderna Regular",
         "postscriptName": "PlaywriteITModerna-Regular",
+        "capHeight": 875,
+        "ascent": 1275,
+        "descent": -375,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 505,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 505
+          },
+          "thai": {
+            "xWidthAvg": 845
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite IT Moderna Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite IT Moderna Guides",
+        "fullName": "Playwrite IT Moderna Guides Regular",
+        "postscriptName": "PlaywriteITModernaGuides-Regular",
         "capHeight": 875,
         "ascent": 1275,
         "descent": -375,
@@ -111460,6 +114234,33 @@
     }
   },
   {
+    "familyName": "Playwrite IT Trad Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite IT Trad Guides",
+        "fullName": "Playwrite IT Trad Guides Regular",
+        "postscriptName": "PlaywriteITTradGuides-Regular",
+        "capHeight": 959,
+        "ascent": 1378,
+        "descent": -462,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 523,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 523
+          },
+          "thai": {
+            "xWidthAvg": 906
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite MX",
     "defaultVariant": "regular",
     "variants": {
@@ -111550,6 +114351,33 @@
     }
   },
   {
+    "familyName": "Playwrite MX Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite MX Guides",
+        "fullName": "Playwrite MX Guides Regular",
+        "postscriptName": "PlaywriteMXGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 525,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 525
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite NG Modern",
     "defaultVariant": "regular",
     "variants": {
@@ -111620,6 +114448,33 @@
         "familyName": "Playwrite NG Modern",
         "fullName": "Playwrite NG Modern Regular",
         "postscriptName": "PlaywriteNGModern-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 506,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 506
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite NG Modern Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite NG Modern Guides",
+        "fullName": "Playwrite NG Modern Guides Regular",
+        "postscriptName": "PlaywriteNGModernGuides-Regular",
         "capHeight": 1000,
         "ascent": 1428,
         "descent": -504,
@@ -111730,6 +114585,33 @@
     }
   },
   {
+    "familyName": "Playwrite NL Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite NL Guides",
+        "fullName": "Playwrite NL Guides Regular",
+        "postscriptName": "PlaywriteNLGuides-Regular",
+        "capHeight": 1273,
+        "ascent": 1762,
+        "descent": -786,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 537,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 537
+          },
+          "thai": {
+            "xWidthAvg": 1135
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite NO",
     "defaultVariant": "regular",
     "variants": {
@@ -111813,6 +114695,33 @@
           },
           "thai": {
             "xWidthAvg": 913
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite NO Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite NO Guides",
+        "fullName": "Playwrite NO Guides Regular",
+        "postscriptName": "PlaywriteNOGuides-Regular",
+        "capHeight": 970,
+        "ascent": 1391,
+        "descent": -473,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 516,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 516
+          },
+          "thai": {
+            "xWidthAvg": 914
           }
         },
         "category": "handwriting"
@@ -111910,6 +114819,33 @@
     }
   },
   {
+    "familyName": "Playwrite NZ Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite NZ Guides",
+        "fullName": "Playwrite NZ Guides Regular",
+        "postscriptName": "PlaywriteNZGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 507,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 507
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite PE",
     "defaultVariant": "regular",
     "variants": {
@@ -111980,6 +114916,33 @@
         "familyName": "Playwrite PE",
         "fullName": "Playwrite PE Regular",
         "postscriptName": "PlaywritePE-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 526,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 526
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite PE Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite PE Guides",
+        "fullName": "Playwrite PE Guides Regular",
+        "postscriptName": "PlaywritePEGuides-Regular",
         "capHeight": 1000,
         "ascent": 1428,
         "descent": -504,
@@ -112090,6 +115053,33 @@
     }
   },
   {
+    "familyName": "Playwrite PL Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite PL Guides",
+        "fullName": "Playwrite PL Guides Regular",
+        "postscriptName": "PlaywritePLGuides-Regular",
+        "capHeight": 986,
+        "ascent": 1411,
+        "descent": -490,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 518,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 518
+          },
+          "thai": {
+            "xWidthAvg": 926
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite PT",
     "defaultVariant": "regular",
     "variants": {
@@ -112160,6 +115150,33 @@
         "familyName": "Playwrite PT",
         "fullName": "Playwrite PT Regular",
         "postscriptName": "PlaywritePT-Regular",
+        "capHeight": 1081,
+        "ascent": 1527,
+        "descent": -588,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 529,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 529
+          },
+          "thai": {
+            "xWidthAvg": 995
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite PT Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite PT Guides",
+        "fullName": "Playwrite PT Guides Regular",
+        "postscriptName": "PlaywritePTGuides-Regular",
         "capHeight": 1081,
         "ascent": 1527,
         "descent": -588,
@@ -112270,6 +115287,33 @@
     }
   },
   {
+    "familyName": "Playwrite RO Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite RO Guides",
+        "fullName": "Playwrite RO Guides Regular",
+        "postscriptName": "PlaywriteROGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 525,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 525
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite SK",
     "defaultVariant": "regular",
     "variants": {
@@ -112353,6 +115397,33 @@
           },
           "thai": {
             "xWidthAvg": 924
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite SK Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite SK Guides",
+        "fullName": "Playwrite SK Guides Regular",
+        "postscriptName": "PlaywriteSKGuides-Regular",
+        "capHeight": 985,
+        "ascent": 1410,
+        "descent": -489,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 540,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 540
+          },
+          "thai": {
+            "xWidthAvg": 925
           }
         },
         "category": "handwriting"
@@ -112450,6 +115521,33 @@
     }
   },
   {
+    "familyName": "Playwrite TZ Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite TZ Guides",
+        "fullName": "Playwrite TZ Guides Regular",
+        "postscriptName": "PlaywriteTZGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 522,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 522
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite US Modern",
     "defaultVariant": "regular",
     "variants": {
@@ -112520,6 +115618,33 @@
         "familyName": "Playwrite US Modern",
         "fullName": "Playwrite US Modern Regular",
         "postscriptName": "PlaywriteUSModern-Regular",
+        "capHeight": 938,
+        "ascent": 1352,
+        "descent": -440,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 511,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 511
+          },
+          "thai": {
+            "xWidthAvg": 891
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite US Modern Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite US Modern Guides",
+        "fullName": "Playwrite US Modern Guides Regular",
+        "postscriptName": "PlaywriteUSModernGuides-Regular",
         "capHeight": 938,
         "ascent": 1352,
         "descent": -440,
@@ -112630,6 +115755,33 @@
     }
   },
   {
+    "familyName": "Playwrite US Trad Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite US Trad Guides",
+        "fullName": "Playwrite US Trad Guides Regular",
+        "postscriptName": "PlaywriteUSTradGuides-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 527,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 527
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite VN",
     "defaultVariant": "regular",
     "variants": {
@@ -112720,6 +115872,33 @@
     }
   },
   {
+    "familyName": "Playwrite VN Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite VN Guides",
+        "fullName": "Playwrite VN Guides Regular",
+        "postscriptName": "PlaywriteVNGuides-Regular",
+        "capHeight": 1257,
+        "ascent": 1743,
+        "descent": -769,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 536,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 536
+          },
+          "thai": {
+            "xWidthAvg": 1123
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
     "familyName": "Playwrite ZA",
     "defaultVariant": "regular",
     "variants": {
@@ -112790,6 +115969,33 @@
         "familyName": "Playwrite ZA",
         "fullName": "Playwrite ZA Regular",
         "postscriptName": "PlaywriteZA-Regular",
+        "capHeight": 1000,
+        "ascent": 1428,
+        "descent": -504,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 516,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 516
+          },
+          "thai": {
+            "xWidthAvg": 936
+          }
+        },
+        "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Playwrite ZA Guides",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Playwrite ZA Guides",
+        "fullName": "Playwrite ZA Guides Regular",
+        "postscriptName": "PlaywriteZAGuides-Regular",
         "capHeight": 1000,
         "ascent": 1428,
         "descent": -504,
@@ -113106,6 +116312,33 @@
           }
         },
         "category": "sans-serif"
+      }
+    }
+  },
+  {
+    "familyName": "Pochaevsk",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Pochaevsk",
+        "fullName": "Pochaevsk Regular",
+        "postscriptName": "Pochaevsk-Regular",
+        "capHeight": 700,
+        "ascent": 1051,
+        "descent": -400,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 423,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 423
+          },
+          "thai": {
+            "xWidthAvg": 751
+          }
+        },
+        "category": "display"
       }
     }
   },
@@ -113544,6 +116777,60 @@
           },
           "thai": {
             "xWidthAvg": 1146
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
+    "familyName": "Ponnala",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Ponnala",
+        "fullName": "Ponnala",
+        "postscriptName": "Ponnala",
+        "capHeight": 0,
+        "ascent": 938,
+        "descent": -861,
+        "lineGap": 0,
+        "unitsPerEm": 1024,
+        "xHeight": 0,
+        "xWidthAvg": 354,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 354
+          },
+          "thai": {
+            "xWidthAvg": 374
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
+    "familyName": "Ponomar",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Ponomar",
+        "fullName": "Ponomar Regular",
+        "postscriptName": "Ponomar-Regular",
+        "capHeight": 700,
+        "ascent": 1150,
+        "descent": -460,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 422,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 422
+          },
+          "thai": {
+            "xWidthAvg": 427
           }
         },
         "category": "display"
@@ -118270,7 +121557,7 @@
         "descent": -250,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 525,
+        "xHeight": 527,
         "xWidthAvg": 493,
         "subsets": {
           "latin": {
@@ -118291,7 +121578,7 @@
         "descent": -250,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 525,
+        "xHeight": 529,
         "xWidthAvg": 503,
         "subsets": {
           "latin": {
@@ -118312,7 +121599,7 @@
         "descent": -250,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 525,
+        "xHeight": 531,
         "xWidthAvg": 513,
         "subsets": {
           "latin": {
@@ -118514,10 +121801,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 492,
-        "xWidthAvg": 426,
+        "xWidthAvg": 427,
         "subsets": {
           "latin": {
-            "xWidthAvg": 426
+            "xWidthAvg": 427
           },
           "thai": {
             "xWidthAvg": 514
@@ -118534,11 +121821,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 455,
+        "xHeight": 505,
+        "xWidthAvg": 448,
         "subsets": {
           "latin": {
-            "xWidthAvg": 455
+            "xWidthAvg": 448
           },
           "thai": {
             "xWidthAvg": 514
@@ -118555,11 +121842,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 455,
+        "xHeight": 509,
+        "xWidthAvg": 456,
         "subsets": {
           "latin": {
-            "xWidthAvg": 455
+            "xWidthAvg": 456
           },
           "thai": {
             "xWidthAvg": 514
@@ -118576,11 +121863,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 475,
+        "xHeight": 515,
+        "xWidthAvg": 464,
         "subsets": {
           "latin": {
-            "xWidthAvg": 475
+            "xWidthAvg": 464
           },
           "thai": {
             "xWidthAvg": 514
@@ -118597,7 +121884,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 521,
         "xWidthAvg": 475,
         "subsets": {
           "latin": {
@@ -118618,7 +121905,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 529,
         "xWidthAvg": 488,
         "subsets": {
           "latin": {
@@ -118640,10 +121927,10 @@
         "lineGap": 0,
         "unitsPerEm": 1000,
         "xHeight": 492,
-        "xWidthAvg": 419,
+        "xWidthAvg": 420,
         "subsets": {
           "latin": {
-            "xWidthAvg": 419
+            "xWidthAvg": 420
           },
           "thai": {
             "xWidthAvg": 514
@@ -118660,11 +121947,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 448,
+        "xHeight": 505,
+        "xWidthAvg": 441,
         "subsets": {
           "latin": {
-            "xWidthAvg": 448
+            "xWidthAvg": 441
           },
           "thai": {
             "xWidthAvg": 514
@@ -118681,7 +121968,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 509,
         "xWidthAvg": 448,
         "subsets": {
           "latin": {
@@ -118702,11 +121989,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 467,
+        "xHeight": 515,
+        "xWidthAvg": 457,
         "subsets": {
           "latin": {
-            "xWidthAvg": 467
+            "xWidthAvg": 457
           },
           "thai": {
             "xWidthAvg": 514
@@ -118723,7 +122010,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 521,
         "xWidthAvg": 467,
         "subsets": {
           "latin": {
@@ -118744,7 +122031,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 529,
         "xWidthAvg": 479,
         "subsets": {
           "latin": {
@@ -118765,11 +122052,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
-        "xWidthAvg": 434,
+        "xHeight": 501,
+        "xWidthAvg": 435,
         "subsets": {
           "latin": {
-            "xWidthAvg": 434
+            "xWidthAvg": 435
           },
           "thai": {
             "xWidthAvg": 514
@@ -118786,7 +122073,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 492,
+        "xHeight": 501,
         "xWidthAvg": 442,
         "subsets": {
           "latin": {
@@ -118834,7 +122121,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 495,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118855,7 +122142,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 505,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118876,7 +122163,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 516,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118918,7 +122205,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 495,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118939,7 +122226,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 505,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118960,7 +122247,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 516,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -118981,7 +122268,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 488,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -119002,7 +122289,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 488,
         "xWidthAvg": 600,
         "subsets": {
           "latin": {
@@ -119050,11 +122337,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
-        "xWidthAvg": 469,
+        "xHeight": 495,
+        "xWidthAvg": 459,
         "subsets": {
           "latin": {
-            "xWidthAvg": 469
+            "xWidthAvg": 459
           },
           "thai": {
             "xWidthAvg": 514
@@ -119071,11 +122358,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
-        "xWidthAvg": 469,
+        "xHeight": 505,
+        "xWidthAvg": 475,
         "subsets": {
           "latin": {
-            "xWidthAvg": 469
+            "xWidthAvg": 475
           },
           "thai": {
             "xWidthAvg": 514
@@ -119092,7 +122379,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 516,
         "xWidthAvg": 495,
         "subsets": {
           "latin": {
@@ -119134,11 +122421,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
-        "xWidthAvg": 461,
+        "xHeight": 495,
+        "xWidthAvg": 451,
         "subsets": {
           "latin": {
-            "xWidthAvg": 461
+            "xWidthAvg": 451
           },
           "thai": {
             "xWidthAvg": 514
@@ -119155,11 +122442,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
-        "xWidthAvg": 461,
+        "xHeight": 505,
+        "xWidthAvg": 467,
         "subsets": {
           "latin": {
-            "xWidthAvg": 461
+            "xWidthAvg": 467
           },
           "thai": {
             "xWidthAvg": 514
@@ -119176,7 +122463,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 516,
         "xWidthAvg": 487,
         "subsets": {
           "latin": {
@@ -119197,11 +122484,11 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
-        "xWidthAvg": 439,
+        "xHeight": 488,
+        "xWidthAvg": 440,
         "subsets": {
           "latin": {
-            "xWidthAvg": 439
+            "xWidthAvg": 440
           },
           "thai": {
             "xWidthAvg": 514
@@ -119218,7 +122505,7 @@
         "descent": -305,
         "lineGap": 0,
         "unitsPerEm": 1000,
-        "xHeight": 481,
+        "xHeight": 488,
         "xWidthAvg": 447,
         "subsets": {
           "latin": {
@@ -121231,6 +124518,27 @@
         },
         "category": "sans-serif"
       },
+      "200": {
+        "familyName": "Roboto",
+        "fullName": "Roboto ExtraLight",
+        "postscriptName": "Roboto-ExtraLight",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 887,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 887
+          },
+          "thai": {
+            "xWidthAvg": 908
+          }
+        },
+        "category": "sans-serif"
+      },
       "300": {
         "familyName": "Roboto",
         "fullName": "Roboto Light",
@@ -121241,10 +124549,10 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 895,
+        "xWidthAvg": 896,
         "subsets": {
           "latin": {
-            "xWidthAvg": 895
+            "xWidthAvg": 896
           },
           "thai": {
             "xWidthAvg": 908
@@ -121262,10 +124570,31 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 920,
+        "xWidthAvg": 919,
         "subsets": {
           "latin": {
-            "xWidthAvg": 920
+            "xWidthAvg": 919
+          },
+          "thai": {
+            "xWidthAvg": 908
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Roboto",
+        "fullName": "Roboto SemiBold",
+        "postscriptName": "Roboto-SemiBold",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 923,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 923
           },
           "thai": {
             "xWidthAvg": 908
@@ -121287,6 +124616,27 @@
         "subsets": {
           "latin": {
             "xWidthAvg": 926
+          },
+          "thai": {
+            "xWidthAvg": 908
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Roboto",
+        "fullName": "Roboto ExtraBold",
+        "postscriptName": "Roboto-ExtraBold",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 930,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 930
           },
           "thai": {
             "xWidthAvg": 908
@@ -121325,10 +124675,31 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 864,
+        "xWidthAvg": 855,
         "subsets": {
           "latin": {
-            "xWidthAvg": 864
+            "xWidthAvg": 855
+          },
+          "thai": {
+            "xWidthAvg": 918
+          }
+        },
+        "category": "sans-serif"
+      },
+      "200italic": {
+        "familyName": "Roboto",
+        "fullName": "Roboto ExtraLight Italic",
+        "postscriptName": "Roboto-ExtraLightItalic",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 861,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 861
           },
           "thai": {
             "xWidthAvg": 918
@@ -121346,10 +124717,10 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 878,
+        "xWidthAvg": 871,
         "subsets": {
           "latin": {
-            "xWidthAvg": 878
+            "xWidthAvg": 871
           },
           "thai": {
             "xWidthAvg": 918
@@ -121367,10 +124738,31 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 902,
+        "xWidthAvg": 893,
         "subsets": {
           "latin": {
-            "xWidthAvg": 902
+            "xWidthAvg": 893
+          },
+          "thai": {
+            "xWidthAvg": 918
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Roboto",
+        "fullName": "Roboto SemiBold Italic",
+        "postscriptName": "Roboto-SemiBoldItalic",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 897,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 897
           },
           "thai": {
             "xWidthAvg": 918
@@ -121388,10 +124780,31 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 909,
+        "xWidthAvg": 900,
         "subsets": {
           "latin": {
-            "xWidthAvg": 909
+            "xWidthAvg": 900
+          },
+          "thai": {
+            "xWidthAvg": 918
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Roboto",
+        "fullName": "Roboto ExtraBold Italic",
+        "postscriptName": "Roboto-ExtraBoldItalic",
+        "capHeight": 1456,
+        "ascent": 1900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 2048,
+        "xHeight": 1082,
+        "xWidthAvg": 903,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 903
           },
           "thai": {
             "xWidthAvg": 918
@@ -121409,10 +124822,10 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 915,
+        "xWidthAvg": 907,
         "subsets": {
           "latin": {
-            "xWidthAvg": 915
+            "xWidthAvg": 907
           },
           "thai": {
             "xWidthAvg": 918
@@ -121430,10 +124843,10 @@
         "lineGap": 0,
         "unitsPerEm": 2048,
         "xHeight": 1082,
-        "xWidthAvg": 893,
+        "xWidthAvg": 886,
         "subsets": {
           "latin": {
-            "xWidthAvg": 893
+            "xWidthAvg": 886
           },
           "thai": {
             "xWidthAvg": 918
@@ -121443,7 +124856,7 @@
       },
       "regular": {
         "familyName": "Roboto",
-        "fullName": "Roboto",
+        "fullName": "Roboto Regular",
         "postscriptName": "Roboto-Regular",
         "capHeight": 1456,
         "ascent": 1900,
@@ -128325,6 +131738,33 @@
           }
         },
         "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Shafarik",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Shafarik",
+        "fullName": "Shafarik Regular",
+        "postscriptName": "Shafarik-Regular",
+        "capHeight": 700,
+        "ascent": 1080,
+        "descent": -462,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 423,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 423
+          },
+          "thai": {
+            "xWidthAvg": 427
+          }
+        },
+        "category": "display"
       }
     }
   },
@@ -140804,6 +144244,33 @@
     }
   },
   {
+    "familyName": "Triodion",
+    "defaultVariant": "regular",
+    "variants": {
+      "regular": {
+        "familyName": "Triodion",
+        "fullName": "Triodion Regular",
+        "postscriptName": "Triodion-Regular",
+        "capHeight": 700,
+        "ascent": 1126,
+        "descent": -511,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 422,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 422
+          },
+          "thai": {
+            "xWidthAvg": 651
+          }
+        },
+        "category": "display"
+      }
+    }
+  },
+  {
     "familyName": "Trirong",
     "defaultVariant": "regular",
     "variants": {
@@ -145400,8 +148867,8 @@
     "variants": {
       "100": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Thin",
-        "postscriptName": "Wavefont-Thin",
+        "fullName": "Wavefont Rounded Thin",
+        "postscriptName": "WavefontRounded-Thin",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145421,8 +148888,8 @@
       },
       "200": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont ExtraLight",
-        "postscriptName": "Wavefont-ExtraLight",
+        "fullName": "Wavefont Rounded ExtraLight",
+        "postscriptName": "WavefontRounded-ExtraLight",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145442,8 +148909,8 @@
       },
       "300": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Light",
-        "postscriptName": "Wavefont-Light",
+        "fullName": "Wavefont Rounded Light",
+        "postscriptName": "WavefontRounded-Light",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145463,8 +148930,8 @@
       },
       "500": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Medium",
-        "postscriptName": "Wavefont-Medium",
+        "fullName": "Wavefont Rounded Medium",
+        "postscriptName": "WavefontRounded-Medium",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145484,8 +148951,8 @@
       },
       "600": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont SemiBold",
-        "postscriptName": "Wavefont-SemiBold",
+        "fullName": "Wavefont Rounded SemiBold",
+        "postscriptName": "WavefontRounded-SemiBold",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145505,8 +148972,8 @@
       },
       "700": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Bold",
-        "postscriptName": "Wavefont-Bold",
+        "fullName": "Wavefont Rounded Bold",
+        "postscriptName": "WavefontRounded-Bold",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145526,8 +148993,8 @@
       },
       "800": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont ExtraBold",
-        "postscriptName": "Wavefont-ExtraBold",
+        "fullName": "Wavefont Rounded ExtraBold",
+        "postscriptName": "WavefontRounded-ExtraBold",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145547,8 +149014,8 @@
       },
       "900": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Black",
-        "postscriptName": "Wavefont-Black",
+        "fullName": "Wavefont Rounded Black",
+        "postscriptName": "WavefontRounded-Black",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145568,8 +149035,8 @@
       },
       "regular": {
         "familyName": "Wavefont",
-        "fullName": "Wavefont Regular",
-        "postscriptName": "Wavefont-Regular",
+        "fullName": "Wavefont Rounded Regular",
+        "postscriptName": "WavefontRounded-Regular",
         "capHeight": 0,
         "ascent": 1200,
         "descent": -200,
@@ -145715,6 +149182,306 @@
           }
         },
         "category": "handwriting"
+      }
+    }
+  },
+  {
+    "familyName": "Winky Sans",
+    "defaultVariant": "regular",
+    "variants": {
+      "300": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Light",
+        "postscriptName": "WinkySans-Light",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 418,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 418
+          },
+          "thai": {
+            "xWidthAvg": 472
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Medium",
+        "postscriptName": "WinkySans-Medium",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 423,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 423
+          },
+          "thai": {
+            "xWidthAvg": 483
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans SemiBold",
+        "postscriptName": "WinkySans-SemiBold",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 428,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 428
+          },
+          "thai": {
+            "xWidthAvg": 494
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Bold",
+        "postscriptName": "WinkySans-Bold",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 432,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 432
+          },
+          "thai": {
+            "xWidthAvg": 504
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans ExtraBold",
+        "postscriptName": "WinkySans-ExtraBold",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 437,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 437
+          },
+          "thai": {
+            "xWidthAvg": 515
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Black",
+        "postscriptName": "WinkySans-Black",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 441,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 441
+          },
+          "thai": {
+            "xWidthAvg": 525
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Light Italic",
+        "postscriptName": "WinkySans-LightItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 418,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 418
+          },
+          "thai": {
+            "xWidthAvg": 534
+          }
+        },
+        "category": "sans-serif"
+      },
+      "500italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Medium Italic",
+        "postscriptName": "WinkySans-MediumItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 423,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 423
+          },
+          "thai": {
+            "xWidthAvg": 513
+          }
+        },
+        "category": "sans-serif"
+      },
+      "600italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans SemiBold Italic",
+        "postscriptName": "WinkySans-SemiBoldItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 428,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 428
+          },
+          "thai": {
+            "xWidthAvg": 522
+          }
+        },
+        "category": "sans-serif"
+      },
+      "700italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Bold Italic",
+        "postscriptName": "WinkySans-BoldItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 432,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 432
+          },
+          "thai": {
+            "xWidthAvg": 530
+          }
+        },
+        "category": "sans-serif"
+      },
+      "800italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans ExtraBold Italic",
+        "postscriptName": "WinkySans-ExtraBoldItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 437,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 437
+          },
+          "thai": {
+            "xWidthAvg": 539
+          }
+        },
+        "category": "sans-serif"
+      },
+      "900italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Black Italic",
+        "postscriptName": "WinkySans-BlackItalic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 441,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 441
+          },
+          "thai": {
+            "xWidthAvg": 548
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Italic",
+        "postscriptName": "WinkySans-Italic",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 419,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 419
+          },
+          "thai": {
+            "xWidthAvg": 504
+          }
+        },
+        "category": "sans-serif"
+      },
+      "regular": {
+        "familyName": "Winky Sans",
+        "fullName": "Winky Sans Regular",
+        "postscriptName": "WinkySans-Regular",
+        "capHeight": 667,
+        "ascent": 1015,
+        "descent": -315,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 500,
+        "xWidthAvg": 419,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 419
+          },
+          "thai": {
+            "xWidthAvg": 473
+          }
+        },
+        "category": "sans-serif"
       }
     }
   },
@@ -147199,13 +150966,13 @@
         "lineGap": 0,
         "unitsPerEm": 1040,
         "xHeight": 500,
-        "xWidthAvg": 740,
+        "xWidthAvg": 759,
         "subsets": {
           "latin": {
-            "xWidthAvg": 740
+            "xWidthAvg": 759
           },
           "thai": {
-            "xWidthAvg": 520
+            "xWidthAvg": 325
           }
         },
         "category": "display"
@@ -147226,13 +150993,13 @@
         "lineGap": 0,
         "unitsPerEm": 1040,
         "xHeight": 500,
-        "xWidthAvg": 747,
+        "xWidthAvg": 756,
         "subsets": {
           "latin": {
-            "xWidthAvg": 747
+            "xWidthAvg": 756
           },
           "thai": {
-            "xWidthAvg": 520
+            "xWidthAvg": 325
           }
         },
         "category": "display"
@@ -147253,13 +151020,13 @@
         "lineGap": 0,
         "unitsPerEm": 960,
         "xHeight": 500,
-        "xWidthAvg": 676,
+        "xWidthAvg": 681,
         "subsets": {
           "latin": {
-            "xWidthAvg": 676
+            "xWidthAvg": 681
           },
           "thai": {
-            "xWidthAvg": 480
+            "xWidthAvg": 200
           }
         },
         "category": "display"
@@ -147280,13 +151047,13 @@
         "lineGap": 0,
         "unitsPerEm": 960,
         "xHeight": 500,
-        "xWidthAvg": 676,
+        "xWidthAvg": 675,
         "subsets": {
           "latin": {
-            "xWidthAvg": 676
+            "xWidthAvg": 675
           },
           "thai": {
-            "xWidthAvg": 480
+            "xWidthAvg": 200
           }
         },
         "category": "display"
@@ -149307,6 +153074,48 @@
         "subsets": {
           "latin": {
             "xWidthAvg": 355
+          },
+          "thai": {
+            "xWidthAvg": 531
+          }
+        },
+        "category": "sans-serif"
+      },
+      "300italic": {
+        "familyName": "Zain",
+        "fullName": "Zain Light Italic",
+        "postscriptName": "Zain-LightItalic",
+        "capHeight": 556,
+        "ascent": 900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 360,
+        "xWidthAvg": 340,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 340
+          },
+          "thai": {
+            "xWidthAvg": 524
+          }
+        },
+        "category": "sans-serif"
+      },
+      "italic": {
+        "familyName": "Zain",
+        "fullName": "Zain Italic",
+        "postscriptName": "Zain-Italic",
+        "capHeight": 556,
+        "ascent": 900,
+        "descent": -500,
+        "lineGap": 0,
+        "unitsPerEm": 1000,
+        "xHeight": 368,
+        "xWidthAvg": 341,
+        "subsets": {
+          "latin": {
+            "xWidthAvg": 341
           },
           "thai": {
             "xWidthAvg": 531

--- a/packages/metrics/scripts/source-data/googleFontsData.json
+++ b/packages/metrics/scripts/source-data/googleFontsData.json
@@ -2,6 +2,34 @@
   "kind": "webfonts#webfontList",
   "items": [
     {
+      "family": "42dot Sans",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800"
+      ],
+      "subsets": [
+        "korean",
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2025-03-21",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRiHYkNScXgiTCI-.ttf",
+        "500": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRjrYkNScXgiTCI-.ttf",
+        "600": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRgHZUNScXgiTCI-.ttf",
+        "700": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRg-ZUNScXgiTCI-.ttf",
+        "800": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRhZZUNScXgiTCI-.ttf",
+        "regular": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRjZYkNScXgiTCI-.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/42dotsans/v2/BXR7vFK-2v7FnQ1xTYUJy2T9rRBKbpqjqRjZYnNTe3w.ttf"
+    },
+    {
       "family": "ABeeZee",
       "variants": [
         "regular",
@@ -155,14 +183,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v8",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/abyssinicasil/v5/oY1H8ezOqK7iI3rK_45WKoc8J6UZBFOVAXuI.ttf"
+        "regular": "https://fonts.gstatic.com/s/abyssinicasil/v8/oY1H8ezOqK7iI3rK_45WKoc8J6UZBFOVAXuI.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/abyssinicasil/v5/oY1H8ezOqK7iI3rK_45WKoc8J5UYDlc.ttf"
+      "menu": "https://fonts.gstatic.com/s/abyssinicasil/v8/oY1H8ezOqK7iI3rK_45WKoc8J5UYDlc.ttf"
     },
     {
       "family": "Aclonica",
@@ -170,16 +198,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/aclonica/v22/K2FyfZJVlfNNSEBXGb7TCI6oBjLz.ttf"
+        "regular": "https://fonts.gstatic.com/s/aclonica/v23/K2FyfZJVlfNNSEBXGb7TCI6oBjLz.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/aclonica/v22/K2FyfZJVlfNNSEBXGY7SAoo.ttf"
+      "menu": "https://fonts.gstatic.com/s/aclonica/v23/K2FyfZJVlfNNSEBXGY7SAoo.ttf"
     },
     {
       "family": "Acme",
@@ -307,21 +336,21 @@
         "symbols",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-18",
       "files": {
-        "500": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfiftWmA08mCgdfM.ttf",
-        "600": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfsvqWmA08mCgdfM.ttf",
-        "700": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfvLqWmA08mCgdfM.ttf",
-        "regular": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfhXtWmA08mCgdfM.ttf",
-        "italic": "https://fonts.gstatic.com/s/afacad/v1/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92usiM-9kKlZfNfuw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/afacad/v1/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92ugCM-9kKlZfNfuw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/afacad/v1/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92ubCQ-9kKlZfNfuw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/afacad/v1/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92uVSQ-9kKlZfNfuw.ttf"
+        "500": "https://fonts.gstatic.com/s/afacad/v2/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfiftWmA08mCgdfM.ttf",
+        "600": "https://fonts.gstatic.com/s/afacad/v2/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfsvqWmA08mCgdfM.ttf",
+        "700": "https://fonts.gstatic.com/s/afacad/v2/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfvLqWmA08mCgdfM.ttf",
+        "regular": "https://fonts.gstatic.com/s/afacad/v2/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfhXtWmA08mCgdfM.ttf",
+        "italic": "https://fonts.gstatic.com/s/afacad/v2/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92usiM-9kKlZfNfuw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/afacad/v2/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92ugCM-9kKlZfNfuw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/afacad/v2/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92ubCQ-9kKlZfNfuw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/afacad/v2/6NUI8FKMIQOGaw6ahLYEvBjUVG5Ga92uVSQ-9kKlZfNfuw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/afacad/v1/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfhXtamE-9g.ttf"
+      "menu": "https://fonts.gstatic.com/s/afacad/v2/6NUK8FKMIQOGaw6wjYT7ZHG_zsBBfhXtamE-9g.ttf"
     },
     {
       "family": "Afacad Flux",
@@ -399,6 +428,25 @@
       "menu": "https://fonts.gstatic.com/s/agdasima/v4/PN_zRfyxp2f1fUCgAPg7pTw.ttf"
     },
     {
+      "family": "Agu Display",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "vietnamese"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/agudisplay/v1/iJWXBXKbbi6BeMC1_RX7qF_V5E7aciGRRWUwX4ftka9LM6y8Zg.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/agudisplay/v1/iJWXBXKbbi6BeMC1_RX7qF_V5E7aciGRRWUwX4fdkKVP.ttf"
+    },
+    {
       "family": "Aguafina Script",
       "variants": [
         "regular"
@@ -474,14 +522,14 @@
         "latin-ext",
         "telugu"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/akayatelivigala/v22/lJwc-oo_iG9wXqU3rCTD395tp0uifdLdsIH0YH8.ttf"
+        "regular": "https://fonts.gstatic.com/s/akayatelivigala/v27/lJwc-oo_iG9wXqU3rCTD395tp0uifdLdsIH0YH8.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/akayatelivigala/v22/lJwc-oo_iG9wXqU3rCTD395tp0uiTdPXtA.ttf"
+      "menu": "https://fonts.gstatic.com/s/akayatelivigala/v27/lJwc-oo_iG9wXqU3rCTD395tp0uiTdPXtA.ttf"
     },
     {
       "family": "Akronim",
@@ -515,18 +563,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSSgFy9CY94XsnPc.ttf",
-        "500": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSUQFy9CY94XsnPc.ttf",
-        "600": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSagCy9CY94XsnPc.ttf",
-        "700": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSZECy9CY94XsnPc.ttf",
-        "regular": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSXYFy9CY94XsnPc.ttf"
+        "300": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSSgFy9CY94XsnPc.ttf",
+        "500": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSUQFy9CY94XsnPc.ttf",
+        "600": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSagCy9CY94XsnPc.ttf",
+        "700": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSZECy9CY94XsnPc.ttf",
+        "regular": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSXYFy9CY94XsnPc.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/akshar/v9/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSXYF-9GS8w.ttf"
+      "menu": "https://fonts.gstatic.com/s/akshar/v14/Yq6I-LyHWTfz9rGoqDaUbHvhkAUsSXYF-9GS8w.ttf"
     },
     {
       "family": "Aladin",
@@ -662,17 +710,18 @@
       ],
       "subsets": [
         "hebrew",
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/alef/v21/FeVQS0NQpLYglo50L5la2bxii28.ttf",
-        "regular": "https://fonts.gstatic.com/s/alef/v21/FeVfS0NQpLYgrjJbC5FxxbU.ttf"
+        "700": "https://fonts.gstatic.com/s/alef/v22/FeVQS0NQpLYglo50L5la2bxii28.ttf",
+        "regular": "https://fonts.gstatic.com/s/alef/v22/FeVfS0NQpLYgrjJbC5FxxbU.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/alef/v21/FeVfS0NQpLYgnjNRDw.ttf"
+      "menu": "https://fonts.gstatic.com/s/alef/v22/FeVfS0NQpLYgnjNRDw.ttf"
     },
     {
       "family": "Alegreya",
@@ -1195,17 +1244,17 @@
         "arabic",
         "latin"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/almarai/v13/tssoApxBaigK_hnnS_anhnicoq72sXg.ttf",
-        "700": "https://fonts.gstatic.com/s/almarai/v13/tssoApxBaigK_hnnS-aghnicoq72sXg.ttf",
-        "800": "https://fonts.gstatic.com/s/almarai/v13/tssoApxBaigK_hnnS_qjhnicoq72sXg.ttf",
-        "regular": "https://fonts.gstatic.com/s/almarai/v13/tsstApxBaigK_hnnc1qPonC3vqc.ttf"
+        "300": "https://fonts.gstatic.com/s/almarai/v18/tssoApxBaigK_hnnS_anhnicoq72sXg.ttf",
+        "700": "https://fonts.gstatic.com/s/almarai/v18/tssoApxBaigK_hnnS-aghnicoq72sXg.ttf",
+        "800": "https://fonts.gstatic.com/s/almarai/v18/tssoApxBaigK_hnnS_qjhnicoq72sXg.ttf",
+        "regular": "https://fonts.gstatic.com/s/almarai/v18/tsstApxBaigK_hnnc1qPonC3vqc.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/almarai/v13/tsstApxBaigK_hnnQ1uFpg.ttf"
+      "menu": "https://fonts.gstatic.com/s/almarai/v18/tsstApxBaigK_hnnQ1uFpg.ttf"
     },
     {
       "family": "Almendra",
@@ -1525,14 +1574,14 @@
         "arabic",
         "latin"
       ],
-      "version": "v14",
-      "lastModified": "2024-08-12",
+      "version": "v17",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/amiriquran/v14/_Xmo-Hk0rD6DbUL4_vH8Zq5t7Cycsu-2.ttf"
+        "regular": "https://fonts.gstatic.com/s/amiriquran/v17/_Xmo-Hk0rD6DbUL4_vH8Zq5t7Cycsu-2.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/amiriquran/v14/_Xmo-Hk0rD6DbUL4_vH8Zp5s5ig.ttf",
+      "menu": "https://fonts.gstatic.com/s/amiriquran/v17/_Xmo-Hk0rD6DbUL4_vH8Zp5s5ig.ttf",
       "colorCapabilities": [
         "COLRv0",
         "SVG"
@@ -1638,17 +1687,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2025-03-18",
       "files": {
-        "700": "https://fonts.gstatic.com/s/andika/v25/mem8Ya6iyW-Lwqg40ZM1UpcaXcl0Aw.ttf",
-        "regular": "https://fonts.gstatic.com/s/andika/v25/mem_Ya6iyW-LwqgAbbwRWrwGVA.ttf",
-        "italic": "https://fonts.gstatic.com/s/andika/v25/mem9Ya6iyW-Lwqgwb7YVeLkWVNBt.ttf",
-        "700italic": "https://fonts.gstatic.com/s/andika/v25/mem6Ya6iyW-Lwqgwb46pV50ef8xkA76a.ttf"
+        "700": "https://fonts.gstatic.com/s/andika/v26/mem8Ya6iyW-Lwqg40ZM1UpcaXcl0Aw.ttf",
+        "regular": "https://fonts.gstatic.com/s/andika/v26/mem_Ya6iyW-LwqgAbbwRWrwGVA.ttf",
+        "italic": "https://fonts.gstatic.com/s/andika/v26/mem9Ya6iyW-Lwqgwb7YVeLkWVNBt.ttf",
+        "700italic": "https://fonts.gstatic.com/s/andika/v26/mem6Ya6iyW-Lwqgwb46pV50ef8xkA76a.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/andika/v25/mem_Ya6iyW-LwqgwbLYV.ttf"
+      "menu": "https://fonts.gstatic.com/s/andika/v26/mem_Ya6iyW-LwqgwbLYV.ttf"
     },
     {
       "family": "Anek Bangla",
@@ -1667,21 +1716,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9YIocg56yyvt0.ttf",
-        "200": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofu9ZIocg56yyvt0.ttf",
-        "300": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfjFZIocg56yyvt0.ttf",
-        "500": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofl1ZIocg56yyvt0.ttf",
-        "600": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfrFeIocg56yyvt0.ttf",
-        "700": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfoheIocg56yyvt0.ttf",
-        "800": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofu9eIocg56yyvt0.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9ZIocg56yyvt0.ttf"
+        "100": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9YIocg56yyvt0.ttf",
+        "200": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofu9ZIocg56yyvt0.ttf",
+        "300": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfjFZIocg56yyvt0.ttf",
+        "500": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofl1ZIocg56yyvt0.ttf",
+        "600": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfrFeIocg56yyvt0.ttf",
+        "700": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3OfoheIocg56yyvt0.ttf",
+        "800": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofu9eIocg56yyvt0.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9ZIocg56yyvt0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekbangla/v5/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9ZEoYq4w.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekbangla/v15/_gPW1R38qTExHg-17BhM6n66QhabMYB0fBKONtHhRSIUIre5mq3Ofm9ZEoYq4w.ttf"
     },
     {
       "family": "Anek Devanagari",
@@ -1700,21 +1749,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtk-9nFk0LjZ7E.ttf",
-        "200": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLBtku9nFk0LjZ7E.ttf",
-        "300": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLCzku9nFk0LjZ7E.ttf",
-        "500": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDfku9nFk0LjZ7E.ttf",
-        "600": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLAzle9nFk0LjZ7E.ttf",
-        "700": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLAKle9nFk0LjZ7E.ttf",
-        "800": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLBtle9nFk0LjZ7E.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtku9nFk0LjZ7E.ttf"
+        "100": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtk-9nFk0LjZ7E.ttf",
+        "200": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLBtku9nFk0LjZ7E.ttf",
+        "300": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLCzku9nFk0LjZ7E.ttf",
+        "500": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDfku9nFk0LjZ7E.ttf",
+        "600": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLAzle9nFk0LjZ7E.ttf",
+        "700": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLAKle9nFk0LjZ7E.ttf",
+        "800": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLBtle9nFk0LjZ7E.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtku9nFk0LjZ7E.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekdevanagari/v8/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtkt9mHEk.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekdevanagari/v14/jVyo7nP0CGrUsxB-QiRgw0NlLaVt_QUAkYxLRoCL23mlh20ZVHOMAWbgHLDtkt9mHEk.ttf"
     },
     {
       "family": "Anek Gujarati",
@@ -1733,21 +1782,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5G7w0KgB7Lm7g.ttf",
-        "200": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0l5C7w0KgB7Lm7g.ttf",
-        "300": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0SZC7w0KgB7Lm7g.ttf",
-        "500": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0JZC7w0KgB7Lm7g.ttf",
-        "600": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0yZe7w0KgB7Lm7g.ttf",
-        "700": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-08Je7w0KgB7Lm7g.ttf",
-        "800": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0l5e7w0KgB7Lm7g.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5C7w0KgB7Lm7g.ttf"
+        "100": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5G7w0KgB7Lm7g.ttf",
+        "200": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0l5C7w0KgB7Lm7g.ttf",
+        "300": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0SZC7w0KgB7Lm7g.ttf",
+        "500": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0JZC7w0KgB7Lm7g.ttf",
+        "600": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0yZe7w0KgB7Lm7g.ttf",
+        "700": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-08Je7w0KgB7Lm7g.ttf",
+        "800": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0l5e7w0KgB7Lm7g.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5C7w0KgB7Lm7g.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekgujarati/v9/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5CLwkik.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekgujarati/v16/l7g_bj5oysqknvkCo2T_8FuiIRBA7lncQUmbIBEtPKiYYQhRwyBxCD-0F5CLwkik.ttf"
     },
     {
       "family": "Anek Gurmukhi",
@@ -1799,21 +1848,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDEAukVReA1oef.ttf",
-        "200": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dHDEQukVReA1oef.ttf",
-        "300": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dEdEQukVReA1oef.ttf",
-        "500": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFxEQukVReA1oef.ttf",
-        "600": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dGdFgukVReA1oef.ttf",
-        "700": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dGkFgukVReA1oef.ttf",
-        "800": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dHDFgukVReA1oef.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDEQukVReA1oef.ttf"
+        "100": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDEAukVReA1oef.ttf",
+        "200": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dHDEQukVReA1oef.ttf",
+        "300": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dEdEQukVReA1oef.ttf",
+        "500": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFxEQukVReA1oef.ttf",
+        "600": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dGdFgukVReA1oef.ttf",
+        "700": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dGkFgukVReA1oef.ttf",
+        "800": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dHDFgukVReA1oef.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDEQukVReA1oef.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekkannada/v5/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDETulXxM.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekkannada/v14/raxcHiCNvNMKe1CKFsINYFlgkEIwGa8nL6ruWJg1j--h8pvBKSiw4dFDETulXxM.ttf"
     },
     {
       "family": "Anek Latin",
@@ -1865,21 +1914,21 @@
         "latin-ext",
         "malayalam"
       ],
-      "version": "v6",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu_HMr5PDO71Qs.ttf",
-        "200": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTURu-HMr5PDO71Qs.ttf",
-        "300": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUcW-HMr5PDO71Qs.ttf",
-        "500": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUam-HMr5PDO71Qs.ttf",
-        "600": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUUW5HMr5PDO71Qs.ttf",
-        "700": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUXy5HMr5PDO71Qs.ttf",
-        "800": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTURu5HMr5PDO71Qs.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu-HMr5PDO71Qs.ttf"
+        "100": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu_HMr5PDO71Qs.ttf",
+        "200": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTURu-HMr5PDO71Qs.ttf",
+        "300": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUcW-HMr5PDO71Qs.ttf",
+        "500": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUam-HMr5PDO71Qs.ttf",
+        "600": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUUW5HMr5PDO71Qs.ttf",
+        "700": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUXy5HMr5PDO71Qs.ttf",
+        "800": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTURu5HMr5PDO71Qs.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu-HMr5PDO71Qs.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekmalayalam/v6/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu-LMvzOA.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekmalayalam/v17/6qLjKZActRTs_mZAJUZWWkhke0nYa_vC8_Azq3-gP1SReZeOtqQuDVUTUZu-LMvzOA.ttf"
     },
     {
       "family": "Anek Odia",
@@ -1898,21 +1947,21 @@
         "latin-ext",
         "oriya"
       ],
-      "version": "v6",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZf63mXZAtm_es.ttf",
-        "200": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnkZfq3mXZAtm_es.ttf",
-        "300": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnnHfq3mXZAtm_es.ttf",
-        "500": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmrfq3mXZAtm_es.ttf",
-        "600": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnlHea3mXZAtm_es.ttf",
-        "700": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnl-ea3mXZAtm_es.ttf",
-        "800": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnkZea3mXZAtm_es.ttf",
-        "regular": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZfq3mXZAtm_es.ttf"
+        "100": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZf63mXZAtm_es.ttf",
+        "200": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnkZfq3mXZAtm_es.ttf",
+        "300": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnnHfq3mXZAtm_es.ttf",
+        "500": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmrfq3mXZAtm_es.ttf",
+        "600": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnlHea3mXZAtm_es.ttf",
+        "700": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnl-ea3mXZAtm_es.ttf",
+        "800": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnkZea3mXZAtm_es.ttf",
+        "regular": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZfq3mXZAtm_es.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anekodia/v6/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZfp3nV5Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/anekodia/v16/TK3PWkoJARApz5UCd345tuevwwQX0CwsoYkAWgWYevAauivBUnmZfp3nV5Q.ttf"
     },
     {
       "family": "Anek Tamil",
@@ -1931,21 +1980,21 @@
         "latin-ext",
         "tamil"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQiZ6q4v4oegjOQ.ttf",
-        "200": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNwid6q4v4oegjOQ.ttf",
-        "300": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNHCd6q4v4oegjOQ.ttf",
-        "500": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNcCd6q4v4oegjOQ.ttf",
-        "600": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNnCB6q4v4oegjOQ.ttf",
-        "700": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNpSB6q4v4oegjOQ.ttf",
-        "800": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNwiB6q4v4oegjOQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQid6q4v4oegjOQ.ttf"
+        "100": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQiZ6q4v4oegjOQ.ttf",
+        "200": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNwid6q4v4oegjOQ.ttf",
+        "300": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNHCd6q4v4oegjOQ.ttf",
+        "500": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNcCd6q4v4oegjOQ.ttf",
+        "600": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNnCB6q4v4oegjOQ.ttf",
+        "700": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNpSB6q4v4oegjOQ.ttf",
+        "800": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNwiB6q4v4oegjOQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQid6q4v4oegjOQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anektamil/v9/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQidKqoH8.ttf"
+      "menu": "https://fonts.gstatic.com/s/anektamil/v17/XLYJIZH2bYJHGYtPGSbUB8JKTp-_9n55SsLHW0WZez6TjtkDu3uNQidKqoH8.ttf"
     },
     {
       "family": "Anek Telugu",
@@ -1964,21 +2013,21 @@
         "latin-ext",
         "telugu"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y-_oE2G2ep10_8.ttf",
-        "200": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i136--oE2G2ep10_8.ttf",
-        "300": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i133G-oE2G2ep10_8.ttf",
-        "500": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13x2-oE2G2ep10_8.ttf",
-        "600": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13_G5oE2G2ep10_8.ttf",
-        "700": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i138i5oE2G2ep10_8.ttf",
-        "800": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i136-5oE2G2ep10_8.ttf",
-        "regular": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y--oE2G2ep10_8.ttf"
+        "100": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y-_oE2G2ep10_8.ttf",
+        "200": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i136--oE2G2ep10_8.ttf",
+        "300": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i133G-oE2G2ep10_8.ttf",
+        "500": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13x2-oE2G2ep10_8.ttf",
+        "600": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13_G5oE2G2ep10_8.ttf",
+        "700": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i138i5oE2G2ep10_8.ttf",
+        "800": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i136-5oE2G2ep10_8.ttf",
+        "regular": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y--oE2G2ep10_8.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/anektelugu/v8/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y--kEyM3Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/anektelugu/v10/LhWLMVrUNvsddMtYGCx4FcVWOjlwE1WgXdoJ-5XHMl2DkooGK7i13y--kEyM3Q.ttf"
     },
     {
       "family": "Angkor",
@@ -1989,14 +2038,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v32",
-      "lastModified": "2024-08-12",
+      "version": "v33",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/angkor/v32/H4cmBXyAlsPdnlb-8iw-4Lqggw.ttf"
+        "regular": "https://fonts.gstatic.com/s/angkor/v33/H4cmBXyAlsPdnlb-8iw-4Lqggw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/angkor/v32/H4cmBXyAlsPdnlbO8yY6.ttf"
+      "menu": "https://fonts.gstatic.com/s/angkor/v33/H4cmBXyAlsPdnlbO8yY6.ttf"
     },
     {
       "family": "Annapurna SIL",
@@ -2027,16 +2076,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/annieuseyourtelescope/v18/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGjlDfB3UUVZA.ttf"
+        "regular": "https://fonts.gstatic.com/s/annieuseyourtelescope/v19/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGjlDfB3UUVZA.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/annieuseyourtelescope/v18/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGTlT3F.ttf"
+      "menu": "https://fonts.gstatic.com/s/annieuseyourtelescope/v19/daaLSS4tI2qYYl3Jq9s_Hu74xwktnlKxH6osGVGTlT3F.ttf"
     },
     {
       "family": "Anonymous Pro",
@@ -2368,16 +2418,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/architectsdaughter/v18/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvfY5q4szgE-Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/architectsdaughter/v19/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvfY5q4szgE-Q.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/architectsdaughter/v18/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvTY9g5g.ttf"
+      "menu": "https://fonts.gstatic.com/s/architectsdaughter/v19/KtkxAKiDZI_td1Lkx62xHZHDtgO_Y-bvTY9g5g.ttf"
     },
     {
       "family": "Archivo",
@@ -2534,15 +2585,15 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2025-03-03",
       "files": {
-        "700": "https://fonts.gstatic.com/s/arefruqaaink/v10/1q2cY5WOGUFlt84GTOkP6Kdx71xde6WhqWBCyxWn.ttf",
-        "regular": "https://fonts.gstatic.com/s/arefruqaaink/v10/1q2fY5WOGUFlt84GTOkP6Kdx72ThVIGpgnxL.ttf"
+        "700": "https://fonts.gstatic.com/s/arefruqaaink/v11/1q2cY5WOGUFlt84GTOkP6Kdx71xde6WhqWBCyxWn.ttf",
+        "regular": "https://fonts.gstatic.com/s/arefruqaaink/v11/1q2fY5WOGUFlt84GTOkP6Kdx72ThVIGpgnxL.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/arefruqaaink/v10/1q2fY5WOGUFlt84GTOkP6Kdx71TgXoU.ttf",
+      "menu": "https://fonts.gstatic.com/s/arefruqaaink/v11/1q2fY5WOGUFlt84GTOkP6Kdx71TgXoU.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -2885,14 +2936,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/asar/v22/sZlLdRyI6TBIXkYQDLlTW6E.ttf"
+        "regular": "https://fonts.gstatic.com/s/asar/v23/sZlLdRyI6TBIXkYQDLlTW6E.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/asar/v22/sZlLdRyI6TBIbkcaCA.ttf"
+      "menu": "https://fonts.gstatic.com/s/asar/v23/sZlLdRyI6TBIbkcaCA.ttf"
     },
     {
       "family": "Asset",
@@ -2931,20 +2982,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtmZnEGGf3qGuvM4.ttf",
-        "300": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtrhnEGGf3qGuvM4.ttf",
-        "500": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQttRnEGGf3qGuvM4.ttf",
-        "600": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtjhgEGGf3qGuvM4.ttf",
-        "700": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtgFgEGGf3qGuvM4.ttf",
-        "800": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtmZgEGGf3qGuvM4.ttf",
-        "regular": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtuZnEGGf3qGuvM4.ttf"
+        "200": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtmZnEGGf3qGuvM4.ttf",
+        "300": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtrhnEGGf3qGuvM4.ttf",
+        "500": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQttRnEGGf3qGuvM4.ttf",
+        "600": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtjhgEGGf3qGuvM4.ttf",
+        "700": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtgFgEGGf3qGuvM4.ttf",
+        "800": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtmZgEGGf3qGuvM4.ttf",
+        "regular": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtuZnEGGf3qGuvM4.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/assistant/v19/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtuZnIGCV2g.ttf"
+      "menu": "https://fonts.gstatic.com/s/assistant/v22/2sDPZGJYnIjSi6H75xkZZE1I0yCmYzzQtuZnIGCV2g.ttf"
     },
     {
       "family": "Astloch",
@@ -3039,6 +3090,94 @@
       "menu": "https://fonts.gstatic.com/s/atkinsonhyperlegible/v11/9Bt23C1KxNDXMspQ1lPyU89-1h6ONRlW45G05JIt.ttf"
     },
     {
+      "family": "Atkinson Hyperlegible Mono",
+      "variants": [
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v5",
+      "lastModified": "2025-03-11",
+      "files": {
+        "200": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZnNeiDSkb2qzelw.ttf",
+        "300": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZQteiDSkb2qzelw.ttf",
+        "500": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZLteiDSkb2qzelw.ttf",
+        "600": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZwtCiDSkb2qzelw.ttf",
+        "700": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZ-9CiDSkb2qzelw.ttf",
+        "800": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZnNCiDSkb2qzelw.ttf",
+        "regular": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZHNeiDSkb2qzelw.ttf",
+        "200italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JTKTiMf-KnOlxYs.ttf",
+        "300italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JQUTiMf-KnOlxYs.ttf",
+        "italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JRKTiMf-KnOlxYs.ttf",
+        "500italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JR4TiMf-KnOlxYs.ttf",
+        "600italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JSUSSMf-KnOlxYs.ttf",
+        "700italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JStSSMf-KnOlxYs.ttf",
+        "800italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssPAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiwKonlKh6PW-UyGM1JTKSSMf-KnOlxYs.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/atkinsonhyperlegiblemono/v5/tssNAoFBci4C4gvhPXrt3wjT1MqSzhA4t7IIcncBiyihrK15gZ4k_SaZHNeSDCMf.ttf"
+    },
+    {
+      "family": "Atkinson Hyperlegible Next",
+      "variants": [
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v4",
+      "lastModified": "2025-03-11",
+      "files": {
+        "200": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW3bLQhtNl93TwPEQ.ttf",
+        "300": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW3srQhtNl93TwPEQ.ttf",
+        "500": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW33rQhtNl93TwPEQ.ttf",
+        "600": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW3MrMhtNl93TwPEQ.ttf",
+        "700": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW3C7MhtNl93TwPEQ.ttf",
+        "800": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW3bLMhtNl93TwPEQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW37LQhtNl93TwPEQ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPdJ99N5_zkfEYNP.ttf",
+        "300italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPeX99N5_zkfEYNP.ttf",
+        "italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPfJ99N5_zkfEYNP.ttf",
+        "500italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPf799N5_zkfEYNP.ttf",
+        "600italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPcX8NN5_zkfEYNP.ttf",
+        "700italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPcu8NN5_zkfEYNP.ttf",
+        "800italic": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP6cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGseiMhXSWUJ7iyGKiJPdJ8NN5_zkfEYNP.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/atkinsonhyperlegiblenext/v4/NaP4cYPdHfdVxJw0IfIP0lvYFqijb-UxCtm5_wdGscKFt4tOOfV4ZmW37LQRtdN5.ttf"
+    },
+    {
       "family": "Atma",
       "variants": [
         "300",
@@ -3071,16 +3210,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-04",
+      "version": "v28",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/atomicage/v27/f0Xz0eug6sdmRFkYZZGL58Ht9a8GYeA.ttf"
+        "regular": "https://fonts.gstatic.com/s/atomicage/v28/f0Xz0eug6sdmRFkYZZGL58Ht9a8GYeA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/atomicage/v27/f0Xz0eug6sdmRFkYZZGL18Dn8Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/atomicage/v28/f0Xz0eug6sdmRFkYZZGL18Dn8Q.ttf"
     },
     {
       "family": "Aubrey",
@@ -3296,31 +3436,31 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPRh0raa-5s3AA.ttf",
-        "200": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfHPVh0raa-5s3AA.ttf",
-        "300": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfwvVh0raa-5s3AA.ttf",
-        "500": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfrvVh0raa-5s3AA.ttf",
-        "600": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfQvJh0raa-5s3AA.ttf",
-        "700": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfe_Jh0raa-5s3AA.ttf",
-        "800": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfHPJh0raa-5s3AA.ttf",
-        "900": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfNfJh0raa-5s3AA.ttf",
-        "regular": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPVh0raa-5s3AA.ttf",
-        "100italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLaJkLye2Z4nAN7J.ttf",
-        "200italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYJkbye2Z4nAN7J.ttf",
-        "300italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLbXkbye2Z4nAN7J.ttf",
-        "italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLaJkbye2Z4nAN7J.ttf",
-        "500italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLa7kbye2Z4nAN7J.ttf",
-        "600italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLZXlrye2Z4nAN7J.ttf",
-        "700italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLZulrye2Z4nAN7J.ttf",
-        "800italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYJlrye2Z4nAN7J.ttf",
-        "900italic": "https://fonts.gstatic.com/s/azeretmono/v17/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYglrye2Z4nAN7J.ttf"
+        "100": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPRh0raa-5s3AA.ttf",
+        "200": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfHPVh0raa-5s3AA.ttf",
+        "300": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfwvVh0raa-5s3AA.ttf",
+        "500": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfrvVh0raa-5s3AA.ttf",
+        "600": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfQvJh0raa-5s3AA.ttf",
+        "700": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfe_Jh0raa-5s3AA.ttf",
+        "800": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfHPJh0raa-5s3AA.ttf",
+        "900": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfNfJh0raa-5s3AA.ttf",
+        "regular": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPVh0raa-5s3AA.ttf",
+        "100italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLaJkLye2Z4nAN7J.ttf",
+        "200italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYJkbye2Z4nAN7J.ttf",
+        "300italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLbXkbye2Z4nAN7J.ttf",
+        "italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLaJkbye2Z4nAN7J.ttf",
+        "500italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLa7kbye2Z4nAN7J.ttf",
+        "600italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLZXlrye2Z4nAN7J.ttf",
+        "700italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLZulrye2Z4nAN7J.ttf",
+        "800italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYJlrye2Z4nAN7J.ttf",
+        "900italic": "https://fonts.gstatic.com/s/azeretmono/v18/3XF_ErsiyJsY9O_Gepph-HHkf_fUKCzX1EOKVLYglrye2Z4nAN7J.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/azeretmono/v17/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPVR07ye.ttf"
+      "menu": "https://fonts.gstatic.com/s/azeretmono/v18/3XF5ErsiyJsY9O_Gepph-FvtTQgMQUdNekSfnPVR07ye.ttf"
     },
     {
       "family": "B612",
@@ -3504,16 +3644,38 @@
       ],
       "subsets": [
         "cyrillic",
-        "latin"
+        "cyrillic-ext",
+        "latin",
+        "latin-ext",
+        "vietnamese"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/badscript/v16/6NUT8F6PJgbFWQn47_x7lOwuzd1AZtw.ttf"
+        "regular": "https://fonts.gstatic.com/s/badscript/v17/6NUT8F6PJgbFWQn47_x7lOwuzd1AZtw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/badscript/v16/6NUT8F6PJgbFWQn47_x7pO0kyQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/badscript/v17/6NUT8F6PJgbFWQn47_x7pO0kyQ.ttf"
+    },
+    {
+      "family": "Badeen Display",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "arabic",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/badeendisplay/v1/pxidypY2sdZSjFU4cPmNBzckadeLYk1Mq3ap.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/badeendisplay/v1/pxidypY2sdZSjFU4cPmNBzckaeeKaEk.ttf"
     },
     {
       "family": "Bagel Fat One",
@@ -3525,14 +3687,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v2",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bagelfatone/v1/hYkPPucsQOr5dy02WmQr5Zkd0B5mvv0dSbM.ttf"
+        "regular": "https://fonts.gstatic.com/s/bagelfatone/v2/hYkPPucsQOr5dy02WmQr5Zkd0B5mvv0dSbM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bagelfatone/v1/hYkPPucsQOr5dy02WmQr5Zkd4B9sug.ttf"
+      "menu": "https://fonts.gstatic.com/s/bagelfatone/v2/hYkPPucsQOr5dy02WmQr5Zkd4B9sug.ttf"
     },
     {
       "family": "Bahiana",
@@ -3623,14 +3785,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v9",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bakbakone/v8/zOL54pXAl6RI-p_ardnuycRuv-hHkOs.ttf"
+        "regular": "https://fonts.gstatic.com/s/bakbakone/v9/zOL54pXAl6RI-p_ardnuycRuv-hHkOs.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bakbakone/v8/zOL54pXAl6RI-p_ardnu-cVkuw.ttf"
+      "menu": "https://fonts.gstatic.com/s/bakbakone/v9/zOL54pXAl6RI-p_ardnu-cVkuw.ttf"
     },
     {
       "family": "Ballet",
@@ -4258,18 +4420,18 @@
         "khmer",
         "latin"
       ],
-      "version": "v24",
-      "lastModified": "2024-08-12",
+      "version": "v25",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/battambang/v24/uk-kEGe7raEw-HjkzZabNhGp5w50_o9T7Q.ttf",
-        "300": "https://fonts.gstatic.com/s/battambang/v24/uk-lEGe7raEw-HjkzZabNtmLxyRa8oZK9I0.ttf",
-        "700": "https://fonts.gstatic.com/s/battambang/v24/uk-lEGe7raEw-HjkzZabNsmMxyRa8oZK9I0.ttf",
-        "900": "https://fonts.gstatic.com/s/battambang/v24/uk-lEGe7raEw-HjkzZabNvGOxyRa8oZK9I0.ttf",
-        "regular": "https://fonts.gstatic.com/s/battambang/v24/uk-mEGe7raEw-HjkzZabDnWj4yxx7o8.ttf"
+        "100": "https://fonts.gstatic.com/s/battambang/v25/uk-kEGe7raEw-HjkzZabNhGp5w50_o9T7Q.ttf",
+        "300": "https://fonts.gstatic.com/s/battambang/v25/uk-lEGe7raEw-HjkzZabNtmLxyRa8oZK9I0.ttf",
+        "700": "https://fonts.gstatic.com/s/battambang/v25/uk-lEGe7raEw-HjkzZabNsmMxyRa8oZK9I0.ttf",
+        "900": "https://fonts.gstatic.com/s/battambang/v25/uk-lEGe7raEw-HjkzZabNvGOxyRa8oZK9I0.ttf",
+        "regular": "https://fonts.gstatic.com/s/battambang/v25/uk-mEGe7raEw-HjkzZabDnWj4yxx7o8.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/battambang/v24/uk-mEGe7raEw-HjkzZabPnSp5w.ttf"
+      "menu": "https://fonts.gstatic.com/s/battambang/v25/uk-mEGe7raEw-HjkzZabPnSp5w.ttf"
     },
     {
       "family": "Baumans",
@@ -4414,21 +4576,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2024-12-04",
       "files": {
-        "200": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Y95wujgWg2SGdV.ttf",
-        "300": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9bj5wujgWg2SGdV.ttf",
-        "500": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9aP5wujgWg2SGdV.ttf",
-        "600": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Zj4AujgWg2SGdV.ttf",
-        "700": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Za4AujgWg2SGdV.ttf",
-        "800": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Y94AujgWg2SGdV.ttf",
-        "900": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9YU4AujgWg2SGdV.ttf",
-        "regular": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9a95wujgWg2SGdV.ttf"
+        "200": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Y95wujgWg2SGdV.ttf",
+        "300": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9bj5wujgWg2SGdV.ttf",
+        "500": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9aP5wujgWg2SGdV.ttf",
+        "600": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Zj4AujgWg2SGdV.ttf",
+        "700": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Za4AujgWg2SGdV.ttf",
+        "800": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9Y94AujgWg2SGdV.ttf",
+        "900": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9YU4AujgWg2SGdV.ttf",
+        "regular": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9a95wujgWg2SGdV.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/beiruti/v2/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9a95zuii2w.ttf"
+      "menu": "https://fonts.gstatic.com/s/beiruti/v4/JTUIjIU69Cmr9FGcYgRFEb7cdQn2-9a95zuii2w.ttf"
     },
     {
       "family": "Belanosima",
@@ -4613,16 +4775,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-08-12",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bentham/v18/VdGeAZQPEpYfmHglKWw7CJaK_y4.ttf"
+        "regular": "https://fonts.gstatic.com/s/bentham/v19/VdGeAZQPEpYfmHglKWw7CJaK_y4.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bentham/v18/VdGeAZQPEpYfmHglGW0xDA.ttf"
+      "menu": "https://fonts.gstatic.com/s/bentham/v19/VdGeAZQPEpYfmHglGW0xDA.ttf"
     },
     {
       "family": "Berkshire Swash",
@@ -4740,7 +4903,7 @@
       "menu": "https://fonts.gstatic.com/s/bhutukaexpandedone/v7/SLXXc0jZ4WUJcClHTtv0t7IaDRsBsWRiJByW-Jw.ttf"
     },
     {
-      "family": "Big Shoulders Display",
+      "family": "Big Shoulders",
       "variants": [
         "100",
         "200",
@@ -4757,25 +4920,25 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdY86JF46SRP4yZQ.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdQ87JF46SRP4yZQ.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YddE7JF46SRP4yZQ.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0Ydb07JF46SRP4yZQ.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdVE8JF46SRP4yZQ.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdWg8JF46SRP4yZQ.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdQ88JF46SRP4yZQ.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdSY8JF46SRP4yZQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdY87JF46SRP4yZQ.ttf"
+        "100": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9SOL9ANM1LlZAtA.ttf",
+        "200": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9yOP9ANM1LlZAtA.ttf",
+        "300": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9FuP9ANM1LlZAtA.ttf",
+        "500": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9euP9ANM1LlZAtA.ttf",
+        "600": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9luT9ANM1LlZAtA.ttf",
+        "700": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9r-T9ANM1LlZAtA.ttf",
+        "800": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9yOT9ANM1LlZAtA.ttf",
+        "900": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko94eT9ANM1LlZAtA.ttf",
+        "regular": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9SOP9ANM1LlZAtA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshouldersdisplay/v21/fC1MPZJEZG-e9gHhdI4-NBbfd2ys3SjJCx12wPgf9g-_3F0YdY87FF8wTQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/bigshoulders/v2/qFdk35CPh40oITJ69S3GFqy5-BQAcbz7z7beObrv_PytqyTi33thrko9SOPNAdkx.ttf"
     },
     {
-      "family": "Big Shoulders Inline Display",
+      "family": "Big Shoulders Inline",
       "variants": [
         "100",
         "200",
@@ -4792,25 +4955,25 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0nBEnR5yPc2Huux.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0lBE3R5yPc2Huux.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0mfE3R5yPc2Huux.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0nzE3R5yPc2Huux.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0kfFHR5yPc2Huux.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0kmFHR5yPc2Huux.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0lBFHR5yPc2Huux.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0loFHR5yPc2Huux.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0nBE3R5yPc2Huux.ttf"
+        "100": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1nHb-oUTA-kSKkM.ttf",
+        "200": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1vHa-oUTA-kSKkM.ttf",
+        "300": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1i_a-oUTA-kSKkM.ttf",
+        "500": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1kPa-oUTA-kSKkM.ttf",
+        "600": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1q_d-oUTA-kSKkM.ttf",
+        "700": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1pbd-oUTA-kSKkM.ttf",
+        "800": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1vHd-oUTA-kSKkM.ttf",
+        "900": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1tjd-oUTA-kSKkM.ttf",
+        "regular": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1nHa-oUTA-kSKkM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshouldersinlinedisplay/v27/_LOumyfF4eSU_SCrJc9OI24U7siGvBGcZqmqV9-ZZ85CGNOFeNLxoYMPJ0nBE0R4wvM.ttf"
+      "menu": "https://fonts.gstatic.com/s/bigshouldersinline/v2/bx68NwSCkev-8u0YNXAF6gArLyznvspgMZDcnsTZieUyOqQzOiBfauOMaRhGeKwO1nHayoQZBw.ttf"
     },
     {
-      "family": "Big Shoulders Inline Text",
+      "family": "Big Shoulders Stencil",
       "variants": [
         "100",
         "200",
@@ -4827,127 +4990,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwga0yqGN7Y6Jsc8c.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgY0y6GN7Y6Jsc8c.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgbqy6GN7Y6Jsc8c.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgaGy6GN7Y6Jsc8c.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgZqzKGN7Y6Jsc8c.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgZTzKGN7Y6Jsc8c.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgY0zKGN7Y6Jsc8c.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwgYdzKGN7Y6Jsc8c.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwga0y6GN7Y6Jsc8c.ttf"
+        "100": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp2x5OZJnqtwIp4I.ttf",
+        "200": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp0x5eZJnqtwIp4I.ttf",
+        "300": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp3v5eZJnqtwIp4I.ttf",
+        "500": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp2D5eZJnqtwIp4I.ttf",
+        "600": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp1v4uZJnqtwIp4I.ttf",
+        "700": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp1W4uZJnqtwIp4I.ttf",
+        "800": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp0x4uZJnqtwIp4I.ttf",
+        "900": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp0Y4uZJnqtwIp4I.ttf",
+        "regular": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp2x5eZJnqtwIp4I.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshouldersinlinetext/v26/vm8XdQDmVECV5-vm5dJ-Tp-6WDeRjL4RV7dP8u-NMyHY74qpoNNcwga0y5GM54o.ttf"
-    },
-    {
-      "family": "Big Shoulders Stencil Display",
-      "variants": [
-        "100",
-        "200",
-        "300",
-        "regular",
-        "500",
-        "600",
-        "700",
-        "800",
-        "900"
-      ],
-      "subsets": [
-        "latin",
-        "latin-ext",
-        "vietnamese"
-      ],
-      "version": "v28",
-      "lastModified": "2024-09-04",
-      "files": {
-        "100": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_O0nPKHznJucP9w.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_u0jPKHznJucP9w.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_ZUjPKHznJucP9w.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_CUjPKHznJucP9w.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_5U_PKHznJucP9w.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_3E_PKHznJucP9w.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_u0_PKHznJucP9w.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_kk_PKHznJucP9w.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_O0jPKHznJucP9w.ttf"
-      },
-      "category": "display",
-      "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshouldersstencildisplay/v28/6aeZ4LS6U6pR_bp5b_t2ugOhHWFcxSGP9ttD96KCb8xPytKb-oPRU-vkuLm_O0j_KXbj.ttf"
-    },
-    {
-      "family": "Big Shoulders Stencil Text",
-      "variants": [
-        "100",
-        "200",
-        "300",
-        "regular",
-        "500",
-        "600",
-        "700",
-        "800",
-        "900"
-      ],
-      "subsets": [
-        "latin",
-        "latin-ext",
-        "vietnamese"
-      ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
-      "files": {
-        "100": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGR04XIGS_Py_AWbQ.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGRU4TIGS_Py_AWbQ.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGRjYTIGS_Py_AWbQ.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGR4YTIGS_Py_AWbQ.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGRDYPIGS_Py_AWbQ.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGRNIPIGS_Py_AWbQ.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGRU4PIGS_Py_AWbQ.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGReoPIGS_Py_AWbQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGR04TIGS_Py_AWbQ.ttf"
-      },
-      "category": "display",
-      "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshouldersstenciltext/v26/5aUV9-i2oxDMNwY3dHfW7UAt3Q453SM15wNj53bCcab2SJYLLUtk1OGR04T4GCXL.ttf"
-    },
-    {
-      "family": "Big Shoulders Text",
-      "variants": [
-        "100",
-        "200",
-        "300",
-        "regular",
-        "500",
-        "600",
-        "700",
-        "800",
-        "900"
-      ],
-      "subsets": [
-        "latin",
-        "latin-ext",
-        "vietnamese"
-      ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
-      "files": {
-        "100": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Y-r3TIPNl6P2pc.ttf",
-        "200": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Q-q3TIPNl6P2pc.ttf",
-        "300": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3dGq3TIPNl6P2pc.ttf",
-        "500": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3b2q3TIPNl6P2pc.ttf",
-        "600": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3VGt3TIPNl6P2pc.ttf",
-        "700": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Wit3TIPNl6P2pc.ttf",
-        "800": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Q-t3TIPNl6P2pc.ttf",
-        "900": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Sat3TIPNl6P2pc.ttf",
-        "regular": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Y-q3TIPNl6P2pc.ttf"
-      },
-      "category": "display",
-      "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bigshoulderstext/v24/55xEezRtP9G3CGPIf49hxc8P0eytUxB2l66LmF6xc3kA3Y-q7TMFMg.ttf"
+      "menu": "https://fonts.gstatic.com/s/bigshouldersstencil/v2/TwM2-JIEQ1Je5sI6Bx1TKHD83rT3u3NSCfbFxqa9oQbR_CiZMgOzPB7iSLKdsgE9Sp2x5dZIlK8.ttf"
     },
     {
       "family": "Bigelow Rules",
@@ -5036,20 +5094,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OrIimiaki-gkRDE.ttf",
-        "300": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4Omwimiaki-gkRDE.ttf",
-        "500": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OgAimiaki-gkRDE.ttf",
-        "600": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4Ouwlmiaki-gkRDE.ttf",
-        "700": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OtUlmiaki-gkRDE.ttf",
-        "800": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OrIlmiaki-gkRDE.ttf",
-        "regular": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OjIimiaki-gkRDE.ttf"
+        "200": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OrIimiaki-gkRDE.ttf",
+        "300": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4Omwimiaki-gkRDE.ttf",
+        "500": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OgAimiaki-gkRDE.ttf",
+        "600": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4Ouwlmiaki-gkRDE.ttf",
+        "700": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OtUlmiaki-gkRDE.ttf",
+        "800": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OrIlmiaki-gkRDE.ttf",
+        "regular": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OjIimiaki-gkRDE.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/biorhyme/v17/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OjIiqieujw.ttf"
+      "menu": "https://fonts.gstatic.com/s/biorhyme/v20/1cXeaULHBpDMsHYW_GZNh7loEHurwOIGadI205trrbeBgQs4OjIiqieujw.ttf"
     },
     {
       "family": "BioRhyme Expanded",
@@ -5177,31 +5235,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v36",
-      "lastModified": "2024-09-04",
+      "version": "v39",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbeCL_EXFh2reU.ttf",
-        "200": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8XbfCL_EXFh2reU.ttf",
-        "300": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8ajfCL_EXFh2reU.ttf",
-        "500": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8cTfCL_EXFh2reU.ttf",
-        "600": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8SjYCL_EXFh2reU.ttf",
-        "700": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8RHYCL_EXFh2reU.ttf",
-        "800": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8XbYCL_EXFh2reU.ttf",
-        "900": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8V_YCL_EXFh2reU.ttf",
-        "regular": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbfCL_EXFh2reU.ttf",
-        "100italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c4P3OWHpzveWxBw.ttf",
-        "200italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cYPzOWHpzveWxBw.ttf",
-        "300italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cvvzOWHpzveWxBw.ttf",
-        "italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c4PzOWHpzveWxBw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c0vzOWHpzveWxBw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cPvvOWHpzveWxBw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cB_vOWHpzveWxBw.ttf",
-        "800italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cYPvOWHpzveWxBw.ttf",
-        "900italic": "https://fonts.gstatic.com/s/bitter/v36/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cSfvOWHpzveWxBw.ttf"
+        "100": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbeCL_EXFh2reU.ttf",
+        "200": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8XbfCL_EXFh2reU.ttf",
+        "300": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8ajfCL_EXFh2reU.ttf",
+        "500": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8cTfCL_EXFh2reU.ttf",
+        "600": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8SjYCL_EXFh2reU.ttf",
+        "700": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8RHYCL_EXFh2reU.ttf",
+        "800": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8XbYCL_EXFh2reU.ttf",
+        "900": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8V_YCL_EXFh2reU.ttf",
+        "regular": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbfCL_EXFh2reU.ttf",
+        "100italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c4P3OWHpzveWxBw.ttf",
+        "200italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cYPzOWHpzveWxBw.ttf",
+        "300italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cvvzOWHpzveWxBw.ttf",
+        "italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c4PzOWHpzveWxBw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6c0vzOWHpzveWxBw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cPvvOWHpzveWxBw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cB_vOWHpzveWxBw.ttf",
+        "800italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cYPvOWHpzveWxBw.ttf",
+        "900italic": "https://fonts.gstatic.com/s/bitter/v39/raxjHiqOu8IVPmn7epZnDMyKBvHf5D6cSfvOWHpzveWxBw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bitter/v36/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbfOL7OWA.ttf"
+      "menu": "https://fonts.gstatic.com/s/bitter/v39/raxhHiqOu8IVPmnRc6SY1KXhnF_Y8fbfOL7OWA.ttf"
     },
     {
       "family": "Black And White Picture",
@@ -5212,14 +5270,14 @@
         "korean",
         "latin"
       ],
-      "version": "v24",
-      "lastModified": "2024-08-12",
+      "version": "v29",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/blackandwhitepicture/v24/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqI5HbcMi-yWY.ttf"
+        "regular": "https://fonts.gstatic.com/s/blackandwhitepicture/v29/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqI5HbcMi-yWY.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/blackandwhitepicture/v24/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqL5GZ8c.ttf"
+      "menu": "https://fonts.gstatic.com/s/blackandwhitepicture/v29/TwMe-JAERlQd3ooUHBUXGmrmioKjjnRSFO-NqL5GZ8c.ttf"
     },
     {
       "family": "Black Han Sans",
@@ -5230,14 +5288,14 @@
         "korean",
         "latin"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/blackhansans/v17/ea8Aad44WunzF9a-dL6toA8r8nqVIXSkH-Hc.ttf"
+        "regular": "https://fonts.gstatic.com/s/blackhansans/v23/ea8Aad44WunzF9a-dL6toA8r8nqVIXSkH-Hc.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/blackhansans/v17/ea8Aad44WunzF9a-dL6toA8r8kqUK3A.ttf"
+      "menu": "https://fonts.gstatic.com/s/blackhansans/v23/ea8Aad44WunzF9a-dL6toA8r8kqUK3A.ttf"
     },
     {
       "family": "Black Ops One",
@@ -5307,14 +5365,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/blakaink/v8/AlZy_zVVtpj22Znag2chdXf4XB0Tow.ttf"
+        "regular": "https://fonts.gstatic.com/s/blakaink/v10/AlZy_zVVtpj22Znag2chdXf4XB0Tow.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/blakaink/v8/AlZy_zVVtpj22Znag2cRdH38.ttf",
+      "menu": "https://fonts.gstatic.com/s/blakaink/v10/AlZy_zVVtpj22Znag2cRdH38.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -5416,25 +5474,25 @@
         "math",
         "symbols"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbDzuXJyb9N7yr8E.ttf",
-        "600": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbNDpXJyb9N7yr8E.ttf",
-        "700": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbOnpXJyb9N7yr8E.ttf",
-        "800": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbI7pXJyb9N7yr8E.ttf",
-        "900": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbKfpXJyb9N7yr8E.ttf",
-        "regular": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbA7uXJyb9N7yr8E.ttf",
-        "italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecattN-R8Pz3v8Etew.ttf",
-        "500italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatht-R8Pz3v8Etew.ttf",
-        "600italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatatiR8Pz3v8Etew.ttf",
-        "700italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatU9iR8Pz3v8Etew.ttf",
-        "800italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatNNiR8Pz3v8Etew.ttf",
-        "900italic": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatHdiR8Pz3v8Etew.ttf"
+        "500": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbDzuXJyb9N7yr8E.ttf",
+        "600": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbNDpXJyb9N7yr8E.ttf",
+        "700": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbOnpXJyb9N7yr8E.ttf",
+        "800": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbI7pXJyb9N7yr8E.ttf",
+        "900": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbKfpXJyb9N7yr8E.ttf",
+        "regular": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbA7uXJyb9N7yr8E.ttf",
+        "italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecattN-R8Pz3v8Etew.ttf",
+        "500italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatht-R8Pz3v8Etew.ttf",
+        "600italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatatiR8Pz3v8Etew.ttf",
+        "700italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatU9iR8Pz3v8Etew.ttf",
+        "800italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatNNiR8Pz3v8Etew.ttf",
+        "900italic": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjndGTykkIgA8197UwkzHp8F8_dYp-6DdBNRF6RX6k1R5fi-Gf55IgAecatHdiR8Pz3v8Etew.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bodonimodasc/v1/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbA7ubJ2R8A.ttf"
+      "menu": "https://fonts.gstatic.com/s/bodonimodasc/v2/LYjhdGTykkIgA8197UwkzHp8F-XUUG5UNs2KqliEb-g_DaUdIA6SfiYHbA7ubJ2R8A.ttf"
     },
     {
       "family": "Bokor",
@@ -5445,14 +5503,32 @@
         "khmer",
         "latin"
       ],
-      "version": "v30",
-      "lastModified": "2024-08-12",
+      "version": "v31",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bokor/v30/m8JcjfpeeaqTiR2WdInbcaxE.ttf"
+        "regular": "https://fonts.gstatic.com/s/bokor/v31/m8JcjfpeeaqTiR2WdInbcaxE.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bokor/v30/m8JcjfpeeaqTiS2Xfo0.ttf"
+      "menu": "https://fonts.gstatic.com/s/bokor/v31/m8JcjfpeeaqTiS2Xfo0.ttf"
+    },
+    {
+      "family": "Boldonse",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2025-03-18",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/boldonse/v1/ZgNQjPxGPbbJUZemjC38hmHmNpCO.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/boldonse/v1/ZgNQjPxGPbbJUZemjB39jGU.ttf"
     },
     {
       "family": "Bona Nova",
@@ -5690,20 +5766,20 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v7",
-      "lastModified": "2024-09-04",
+      "version": "v8",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvZviyM0vs-wJDtw.ttf",
-        "300": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvUXiyM0vs-wJDtw.ttf",
-        "500": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvSniyM0vs-wJDtw.ttf",
-        "600": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvcXlyM0vs-wJDtw.ttf",
-        "700": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvfzlyM0vs-wJDtw.ttf",
-        "800": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvZvlyM0vs-wJDtw.ttf",
-        "regular": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvRviyM0vs-wJDtw.ttf"
+        "200": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvZviyM0vs-wJDtw.ttf",
+        "300": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvUXiyM0vs-wJDtw.ttf",
+        "500": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvSniyM0vs-wJDtw.ttf",
+        "600": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvcXlyM0vs-wJDtw.ttf",
+        "700": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvfzlyM0vs-wJDtw.ttf",
+        "800": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvZvlyM0vs-wJDtw.ttf",
+        "regular": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvRviyM0vs-wJDtw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bricolagegrotesque/v7/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvRvi-Mwltw.ttf"
+      "menu": "https://fonts.gstatic.com/s/bricolagegrotesque/v8/3y9U6as8bTXq_nANBjzKo3IeZx8z6up5BeSl5jBNz_19PpbpMXuECpwUxJBOm_OJWiaaD30YfKfjZZoLvRvi-Mwltw.ttf"
     },
     {
       "family": "Bruno Ace",
@@ -5834,21 +5910,25 @@
       "family": "Buenard",
       "variants": [
         "regular",
+        "500",
+        "600",
         "700"
       ],
       "subsets": [
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2025-03-05",
       "files": {
-        "700": "https://fonts.gstatic.com/s/buenard/v17/OD5GuM6Cyma8FnnsB4vSjGCWALepwss.ttf",
-        "regular": "https://fonts.gstatic.com/s/buenard/v17/OD5DuM6Cyma8FnnsPzf9qGi9HL4.ttf"
+        "500": "https://fonts.gstatic.com/s/buenard/v20/OD5cuM6Cyma8FnnsJTzfWLAhv7i92sqbK0_3iBYVfsc4.ttf",
+        "600": "https://fonts.gstatic.com/s/buenard/v20/OD5cuM6Cyma8FnnsJTzfWLAhv7i92sp3LE_3iBYVfsc4.ttf",
+        "700": "https://fonts.gstatic.com/s/buenard/v20/OD5cuM6Cyma8FnnsJTzfWLAhv7i92spOLE_3iBYVfsc4.ttf",
+        "regular": "https://fonts.gstatic.com/s/buenard/v20/OD5cuM6Cyma8FnnsJTzfWLAhv7i92sqpK0_3iBYVfsc4.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/buenard/v17/OD5DuM6Cyma8FnnsDzb3rA.ttf"
+      "menu": "https://fonts.gstatic.com/s/buenard/v20/OD5cuM6Cyma8FnnsJTzfWLAhv7i92sqpK3_2ghI.ttf"
     },
     {
       "family": "Bungee",
@@ -5860,14 +5940,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungee/v14/N0bU2SZBIuF2PU_ECn50Kd_PmA.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungee/v15/N0bU2SZBIuF2PU_ECn50Kd_PmA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungee/v14/N0bU2SZBIuF2PU_0C3Rw.ttf"
+      "menu": "https://fonts.gstatic.com/s/bungee/v15/N0bU2SZBIuF2PU_0C3Rw.ttf"
     },
     {
       "family": "Bungee Hairline",
@@ -5879,14 +5959,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeehairline/v23/snfys0G548t04270a_ljTLUVrv-7YB2dQ5ZPqQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeehairline/v24/snfys0G548t04270a_ljTLUVrv-7YB2dQ5ZPqQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeehairline/v23/snfys0G548t04270a_ljTLUVrv-LYReZ.ttf"
+      "menu": "https://fonts.gstatic.com/s/bungeehairline/v24/snfys0G548t04270a_ljTLUVrv-LYReZ.ttf"
     },
     {
       "family": "Bungee Inline",
@@ -5898,14 +5978,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeeinline/v16/Gg8zN58UcgnlCweMrih332VuDGJ1-FEglsc.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeeinline/v17/Gg8zN58UcgnlCweMrih332VuDGJ1-FEglsc.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeeinline/v16/Gg8zN58UcgnlCweMrih332VuPGN__A.ttf"
+      "menu": "https://fonts.gstatic.com/s/bungeeinline/v17/Gg8zN58UcgnlCweMrih332VuPGN__A.ttf"
     },
     {
       "family": "Bungee Outline",
@@ -5917,14 +5997,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeeoutline/v21/_6_mEDvmVP24UvU2MyiGDslL3Qg3YhJqPXxo.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeeoutline/v22/_6_mEDvmVP24UvU2MyiGDslL3Qg3YhJqPXxo.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeeoutline/v21/_6_mEDvmVP24UvU2MyiGDslL3Tg2aBY.ttf"
+      "menu": "https://fonts.gstatic.com/s/bungeeoutline/v22/_6_mEDvmVP24UvU2MyiGDslL3Tg2aBY.ttf"
     },
     {
       "family": "Bungee Shade",
@@ -5936,14 +6016,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeeshade/v14/DtVkJxarWL0t2KdzK3oI_jks7iLSrwFUlw.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeeshade/v15/DtVkJxarWL0t2KdzK3oI_jks7iLSrwFUlw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeeshade/v14/DtVkJxarWL0t2KdzK3oI_jkc7yjW.ttf"
+      "menu": "https://fonts.gstatic.com/s/bungeeshade/v15/DtVkJxarWL0t2KdzK3oI_jkc7yjW.ttf"
     },
     {
       "family": "Bungee Spice",
@@ -5955,14 +6035,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeespice/v12/nwpTtK2nIhxE0q-IwgSpZBqCzyI-aMPF7Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeespice/v14/nwpTtK2nIhxE0q-IwgSpZBqCzyI-aMPF7Q.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeespice/v12/nwpTtK2nIhxE0q-IwgSpZBqyzig6.ttf",
+      "menu": "https://fonts.gstatic.com/s/bungeespice/v14/nwpTtK2nIhxE0q-IwgSpZBqyzig6.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -5978,14 +6058,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/bungeetint/v1/J7abnpl_EGtUEuAJwN9WmrtKMDwTpTkB.ttf"
+        "regular": "https://fonts.gstatic.com/s/bungeetint/v3/J7abnpl_EGtUEuAJwN9WmrtKMDwTpTkB.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/bungeetint/v1/J7abnpl_EGtUEuAJwN9WmotLOjg.ttf",
+      "menu": "https://fonts.gstatic.com/s/bungeetint/v3/J7abnpl_EGtUEuAJwN9WmotLOjg.ttf",
       "colorCapabilities": [
         "COLRv0"
       ]
@@ -6025,6 +6105,24 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/butterflykids/v25/ll8lK2CWTjuqAsXDqlnIbMNs5R4bpRU.ttf"
+    },
+    {
+      "family": "Bytesized",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2025-03-18",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/bytesized/v1/goksH6L8FkdnROln8XBTS0CjkP1Yog.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/bytesized/v1/goksH6L8FkdnROln8XBjSkqn.ttf"
     },
     {
       "family": "Cabin",
@@ -6115,14 +6213,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v6",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/cactusclassicalserif/v5/sZlVdQ6K-zJOCzUaS90zMNN-Ep-OoC8dZr0JFuBIFX-pv-E.ttf"
+        "regular": "https://fonts.gstatic.com/s/cactusclassicalserif/v6/sZlVdQ6K-zJOCzUaS90zMNN-Ep-OoC8dZr0JFuBIFX-pv-E.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cactusclassicalserif/v5/sZlVdQ6K-zJOCzUaS90zMNN-Ep-OoC8dZr0JJuFCEQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/cactusclassicalserif/v6/sZlVdQ6K-zJOCzUaS90zMNN-Ep-OoC8dZr0JJuFCEQ.ttf"
     },
     {
       "family": "Caesar Dressing",
@@ -6208,21 +6306,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v7",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-03-03",
       "files": {
-        "200": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1EnYq9yXa8GvzaA.ttf",
-        "300": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1zHYq9yXa8GvzaA.ttf",
-        "500": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1oHYq9yXa8GvzaA.ttf",
-        "600": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1THEq9yXa8GvzaA.ttf",
-        "700": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1dXEq9yXa8GvzaA.ttf",
-        "800": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1EnEq9yXa8GvzaA.ttf",
-        "900": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1O3Eq9yXa8GvzaA.ttf",
-        "regular": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1knYq9yXa8GvzaA.ttf"
+        "200": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1EnYq9yXa8GvzaA.ttf",
+        "300": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1zHYq9yXa8GvzaA.ttf",
+        "500": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1oHYq9yXa8GvzaA.ttf",
+        "600": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1THEq9yXa8GvzaA.ttf",
+        "700": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1dXEq9yXa8GvzaA.ttf",
+        "800": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1EnEq9yXa8GvzaA.ttf",
+        "900": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1O3Eq9yXa8GvzaA.ttf",
+        "regular": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1knYq9yXa8GvzaA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cairoplay/v7/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1knYa9i_e.ttf",
+      "menu": "https://fonts.gstatic.com/s/cairoplay/v12/wXKEE3QSpo4vpRz_mz6FP-8iaauCLt_Hjopv3miu5IvcJo49mOo1knYa9i_e.ttf",
       "colorCapabilities": [
         "COLRv0"
       ]
@@ -6300,17 +6398,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2024-12-04",
       "files": {
-        "700": "https://fonts.gstatic.com/s/cambay/v12/SLXKc1rY6H0_ZDs-0pusx_lwYX99kA.ttf",
-        "regular": "https://fonts.gstatic.com/s/cambay/v12/SLXJc1rY6H0_ZDsGbrSIz9JsaA.ttf",
-        "italic": "https://fonts.gstatic.com/s/cambay/v12/SLXLc1rY6H0_ZDs2bL6M7dd8aGZk.ttf",
-        "700italic": "https://fonts.gstatic.com/s/cambay/v12/SLXMc1rY6H0_ZDs2bIYwwvN0Q3ptkDMN.ttf"
+        "700": "https://fonts.gstatic.com/s/cambay/v13/SLXKc1rY6H0_ZDs-0pusx_lwYX99kA.ttf",
+        "regular": "https://fonts.gstatic.com/s/cambay/v13/SLXJc1rY6H0_ZDsGbrSIz9JsaA.ttf",
+        "italic": "https://fonts.gstatic.com/s/cambay/v13/SLXLc1rY6H0_ZDs2bL6M7dd8aGZk.ttf",
+        "700italic": "https://fonts.gstatic.com/s/cambay/v13/SLXMc1rY6H0_ZDs2bIYwwvN0Q3ptkDMN.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cambay/v12/SLXJc1rY6H0_ZDs2b76M.ttf"
+      "menu": "https://fonts.gstatic.com/s/cambay/v13/SLXJc1rY6H0_ZDs2b76M.ttf"
     },
     {
       "family": "Cambo",
@@ -6970,18 +7068,18 @@
         "latin",
         "telugu"
       ],
-      "version": "v20",
-      "lastModified": "2024-08-12",
+      "version": "v21",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/chathura/v20/_gP91R7-rzUuVjim42dEq0SbTvZyuDo.ttf",
-        "300": "https://fonts.gstatic.com/s/chathura/v20/_gP81R7-rzUuVjim42eMiWSxYPp7oSNy.ttf",
-        "700": "https://fonts.gstatic.com/s/chathura/v20/_gP81R7-rzUuVjim42ecjmSxYPp7oSNy.ttf",
-        "800": "https://fonts.gstatic.com/s/chathura/v20/_gP81R7-rzUuVjim42eAjWSxYPp7oSNy.ttf",
-        "regular": "https://fonts.gstatic.com/s/chathura/v20/_gP71R7-rzUuVjim418goUC5S-Zy.ttf"
+        "100": "https://fonts.gstatic.com/s/chathura/v21/_gP91R7-rzUuVjim42dEq0SbTvZyuDo.ttf",
+        "300": "https://fonts.gstatic.com/s/chathura/v21/_gP81R7-rzUuVjim42eMiWSxYPp7oSNy.ttf",
+        "700": "https://fonts.gstatic.com/s/chathura/v21/_gP81R7-rzUuVjim42ecjmSxYPp7oSNy.ttf",
+        "800": "https://fonts.gstatic.com/s/chathura/v21/_gP81R7-rzUuVjim42eAjWSxYPp7oSNy.ttf",
+        "regular": "https://fonts.gstatic.com/s/chathura/v21/_gP71R7-rzUuVjim418goUC5S-Zy.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/chathura/v20/_gP71R7-rzUuVjim428hq0Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/chathura/v21/_gP71R7-rzUuVjim428hq0Q.ttf"
     },
     {
       "family": "Chau Philomene One",
@@ -7177,14 +7275,14 @@
         "latin-ext",
         "malayalam"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/chilanka/v20/WWXRlj2DZQiMJYaYRrJQI9EAZhTO.ttf"
+        "regular": "https://fonts.gstatic.com/s/chilanka/v22/WWXRlj2DZQiMJYaYRrJQI9EAZhTO.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/chilanka/v20/WWXRlj2DZQiMJYaYRoJRKdU.ttf"
+      "menu": "https://fonts.gstatic.com/s/chilanka/v22/WWXRlj2DZQiMJYaYRoJRKdU.ttf"
     },
     {
       "family": "Chivo",
@@ -7304,14 +7402,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v6",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/chocolateclassicalsans/v5/nuFqD-PLTZX4XIgT-P2ToCDudWHHflqUpTpfjWdDPI2J9mHITw.ttf"
+        "regular": "https://fonts.gstatic.com/s/chocolateclassicalsans/v6/nuFqD-PLTZX4XIgT-P2ToCDudWHHflqUpTpfjWdDPI2J9mHITw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/chocolateclassicalsans/v5/nuFqD-PLTZX4XIgT-P2ToCDudWHHflqUpTpfjWdzPYeN.ttf"
+      "menu": "https://fonts.gstatic.com/s/chocolateclassicalsans/v6/nuFqD-PLTZX4XIgT-P2ToCDudWHHflqUpTpfjWdzPYeN.ttf"
     },
     {
       "family": "Chokokutai",
@@ -7389,18 +7487,19 @@
         "900"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/cinzeldecorative/v16/daaHSScvJGqLYhG8nNt8KPPswUAPniZoaelDQzCLlQXE.ttf",
-        "900": "https://fonts.gstatic.com/s/cinzeldecorative/v16/daaHSScvJGqLYhG8nNt8KPPswUAPniZQa-lDQzCLlQXE.ttf",
-        "regular": "https://fonts.gstatic.com/s/cinzeldecorative/v16/daaCSScvJGqLYhG8nNt8KPPswUAPnh7URs1LaCyC.ttf"
+        "700": "https://fonts.gstatic.com/s/cinzeldecorative/v17/daaHSScvJGqLYhG8nNt8KPPswUAPniZoaelDQzCLlQXE.ttf",
+        "900": "https://fonts.gstatic.com/s/cinzeldecorative/v17/daaHSScvJGqLYhG8nNt8KPPswUAPniZQa-lDQzCLlQXE.ttf",
+        "regular": "https://fonts.gstatic.com/s/cinzeldecorative/v17/daaCSScvJGqLYhG8nNt8KPPswUAPnh7URs1LaCyC.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cinzeldecorative/v16/daaCSScvJGqLYhG8nNt8KPPswUAPni7VTMk.ttf"
+      "menu": "https://fonts.gstatic.com/s/cinzeldecorative/v17/daaCSScvJGqLYhG8nNt8KPPswUAPni7VTMk.ttf"
     },
     {
       "family": "Clicker Script",
@@ -7429,14 +7528,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v9",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/climatecrisis/v8/wEOpEB3AntNeKCPBVW9XOKlmp3AUgWFN1DvIvcM0gFp6jaUrGb7PsQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/climatecrisis/v9/wEOpEB3AntNeKCPBVW9XOKlmp3AUgWFN1DvIvcM0gFp6jaUrGb7PsQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/climatecrisis/v8/wEOpEB3AntNeKCPBVW9XOKlmp3AUgWFN1DvIvcM0gFpKjK8v.ttf"
+      "menu": "https://fonts.gstatic.com/s/climatecrisis/v9/wEOpEB3AntNeKCPBVW9XOKlmp3AUgWFN1DvIvcM0gFpKjK8v.ttf"
     },
     {
       "family": "Coda",
@@ -7685,22 +7784,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNcGPe7Fu0jUdk.ttf",
-        "200": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTENdGPe7Fu0jUdk.ttf",
-        "300": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTJ1dGPe7Fu0jUdk.ttf",
-        "500": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTPFdGPe7Fu0jUdk.ttf",
-        "600": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTB1aGPe7Fu0jUdk.ttf",
-        "700": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTCRaGPe7Fu0jUdk.ttf",
-        "800": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTENaGPe7Fu0jUdk.ttf",
-        "900": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTGpaGPe7Fu0jUdk.ttf",
-        "regular": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNdGPe7Fu0jUdk.ttf"
+        "100": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNcGPe7Fu0jUdk.ttf",
+        "200": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTENdGPe7Fu0jUdk.ttf",
+        "300": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTJ1dGPe7Fu0jUdk.ttf",
+        "500": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTPFdGPe7Fu0jUdk.ttf",
+        "600": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTB1aGPe7Fu0jUdk.ttf",
+        "700": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTCRaGPe7Fu0jUdk.ttf",
+        "800": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTENaGPe7Fu0jUdk.ttf",
+        "900": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTGpaGPe7Fu0jUdk.ttf",
+        "regular": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNdGPe7Fu0jUdk.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/commissioner/v20/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNdKPaxEg.ttf"
+      "menu": "https://fonts.gstatic.com/s/commissioner/v23/tDaH2o2WnlgI0FNDgduEk4jAhwgumbU1SVfU5BD8OuRL8OstC6KOhgvBYWSFJ-Mgdrgiju6fF8meZm0rk4eF-ZugTMNdKPaxEg.ttf"
     },
     {
       "family": "Concert One",
@@ -7747,15 +7846,15 @@
       "subsets": [
         "khmer"
       ],
-      "version": "v24",
-      "lastModified": "2022-09-22",
+      "version": "v27",
+      "lastModified": "2024-12-04",
       "files": {
-        "700": "https://fonts.gstatic.com/s/content/v24/zrfg0HLayePhU_AwaRzdBirfWCHvkAI.ttf",
-        "regular": "https://fonts.gstatic.com/s/content/v24/zrfl0HLayePhU_AwUaDyIiL0RCg.ttf"
+        "700": "https://fonts.gstatic.com/s/content/v27/zrfg0HLayePhU_AwaRzdBirfWCHvkAI.ttf",
+        "regular": "https://fonts.gstatic.com/s/content/v27/zrfl0HLayePhU_AwUaDyIiL0RCg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/content/v24/zrfl0HLayePhU_AwYaH4Jg.ttf"
+      "menu": "https://fonts.gstatic.com/s/content/v27/zrfl0HLayePhU_AwYaH4Jg.ttf"
     },
     {
       "family": "Contrail One",
@@ -7910,14 +8009,14 @@
       "family": "Cormorant Garamond",
       "variants": [
         "300",
-        "300italic",
         "regular",
-        "italic",
         "500",
-        "500italic",
         "600",
-        "600italic",
         "700",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
         "700italic"
       ],
       "subsets": [
@@ -7927,36 +8026,36 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2025-03-05",
       "files": {
-        "300": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQAllvuQWJ5heb_w.ttf",
-        "500": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQWlhvuQWJ5heb_w.ttf",
-        "600": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQdl9vuQWJ5heb_w.ttf",
-        "700": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3YmX5slCNuHLi8bLeY9MK7whWMhyjQEl5vuQWJ5heb_w.ttf",
-        "300italic": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPjuw-NxBKL_y94.ttf",
-        "regular": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3bmX5slCNuHLi8bLeY9MK7whWMhyjornFLsS6V7w.ttf",
-        "italic": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3ZmX5slCNuHLi8bLeY9MK7whWMhyjYrHtPkyuF7w6C.ttf",
-        "500italic": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEO7ug-NxBKL_y94.ttf",
-        "600italic": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEOXvQ-NxBKL_y94.ttf",
-        "700italic": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3WmX5slCNuHLi8bLeY9MK7whWMhyjYrEPzvA-NxBKL_y94.ttf"
+        "300": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_qE6GnPEi_s4Mfs.ttf",
+        "500": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_s06GnPEi_s4Mfs.ttf",
+        "600": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_iE9GnPEi_s4Mfs.ttf",
+        "700": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_hg9GnPEi_s4Mfs.ttf",
+        "regular": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_v86GnPEi_s4Mfs.ttf",
+        "300italic": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3smX5slCNuHLi8bLeY9MK7whWMhyjYrGFEsdtdc62E6zd5rDDOj9k9Ifu5UQ.ttf",
+        "italic": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3smX5slCNuHLi8bLeY9MK7whWMhyjYrGFEsdtdc62E6zd58jDOj9k9Ifu5UQ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3smX5slCNuHLi8bLeY9MK7whWMhyjYrGFEsdtdc62E6zd5wDDOj9k9Ifu5UQ.ttf",
+        "600italic": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3smX5slCNuHLi8bLeY9MK7whWMhyjYrGFEsdtdc62E6zd5LDfOj9k9Ifu5UQ.ttf",
+        "700italic": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3smX5slCNuHLi8bLeY9MK7whWMhyjYrGFEsdtdc62E6zd5FTfOj9k9Ifu5UQ.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cormorantgaramond/v16/co3bmX5slCNuHLi8bLeY9MK7whWMhyjYr3tP.ttf"
+      "menu": "https://fonts.gstatic.com/s/cormorantgaramond/v19/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_v86KnLOjw.ttf"
     },
     {
       "family": "Cormorant Infant",
       "variants": [
         "300",
-        "300italic",
         "regular",
-        "italic",
         "500",
-        "500italic",
         "600",
-        "600italic",
         "700",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
         "700italic"
       ],
       "subsets": [
@@ -7966,23 +8065,23 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2025-03-05",
       "files": {
-        "300": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyIU44g9vKiM1sORYSiWeAsLN9951w3_DMrQqcdJrk.ttf",
-        "500": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyIU44g9vKiM1sORYSiWeAsLN995wQ2_DMrQqcdJrk.ttf",
-        "600": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyIU44g9vKiM1sORYSiWeAsLN995ygx_DMrQqcdJrk.ttf",
-        "700": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyIU44g9vKiM1sORYSiWeAsLN9950ww_DMrQqcdJrk.ttf",
-        "300italic": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyKU44g9vKiM1sORYSiWeAsLN997_ItcDEhRoUYNrn_Ig.ttf",
-        "regular": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyPU44g9vKiM1sORYSiWeAsLN993_Af2DsAXq4.ttf",
-        "italic": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyJU44g9vKiM1sORYSiWeAsLN997_IV3BkFTq4EPw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyKU44g9vKiM1sORYSiWeAsLN997_ItKDAhRoUYNrn_Ig.ttf",
-        "600italic": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyKU44g9vKiM1sORYSiWeAsLN997_ItBDchRoUYNrn_Ig.ttf",
-        "700italic": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyKU44g9vKiM1sORYSiWeAsLN997_ItYDYhRoUYNrn_Ig.ttf"
+        "300": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrhxYOWThDlDkWSy.ttf",
+        "500": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrgdYOWThDlDkWSy.ttf",
+        "600": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrjxZ-WThDlDkWSy.ttf",
+        "700": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrjIZ-WThDlDkWSy.ttf",
+        "regular": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrgvYOWThDlDkWSy.ttf",
+        "300italic": "https://fonts.gstatic.com/s/cormorantinfant/v20/Hhy8U44g9vKiM1sORYSiWeAsLN997_IP1zv1ljKnOa3nI1PQjj1hlHSyazs.ttf",
+        "italic": "https://fonts.gstatic.com/s/cormorantinfant/v20/Hhy8U44g9vKiM1sORYSiWeAsLN997_IP1zv1ljKnOa3nIw3Qjj1hlHSyazs.ttf",
+        "500italic": "https://fonts.gstatic.com/s/cormorantinfant/v20/Hhy8U44g9vKiM1sORYSiWeAsLN997_IP1zv1ljKnOa3nIz_Qjj1hlHSyazs.ttf",
+        "600italic": "https://fonts.gstatic.com/s/cormorantinfant/v20/Hhy8U44g9vKiM1sORYSiWeAsLN997_IP1zv1ljKnOa3nI9PXjj1hlHSyazs.ttf",
+        "700italic": "https://fonts.gstatic.com/s/cormorantinfant/v20/Hhy8U44g9vKiM1sORYSiWeAsLN997_IP1zv1ljKnOa3nI-rXjj1hlHSyazs.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cormorantinfant/v17/HhyPU44g9vKiM1sORYSiWeAsLN997_EV3A.ttf"
+      "menu": "https://fonts.gstatic.com/s/cormorantinfant/v20/HhyCU44g9vKiM1sORYSiWeAsLN99xfs9KOOc_agJPrgvYNWSjj0.ttf"
     },
     {
       "family": "Cormorant SC",
@@ -8166,16 +8265,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/coveredbyyourgrace/v15/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOS0FgItq6bFIg.ttf"
+        "regular": "https://fonts.gstatic.com/s/coveredbyyourgrace/v16/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOS0FgItq6bFIg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/coveredbyyourgrace/v15/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOSEFwgp.ttf"
+      "menu": "https://fonts.gstatic.com/s/coveredbyyourgrace/v16/QGYwz-AZahWOJJI9kykWW9mD6opopoqXSOSEFwgp.ttf"
     },
     {
       "family": "Crafty Girls",
@@ -8333,16 +8433,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v29",
-      "lastModified": "2024-09-04",
+      "version": "v30",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/crushed/v29/U9Mc6dym6WXImTlFT1kfuIqyLzA.ttf"
+        "regular": "https://fonts.gstatic.com/s/crushed/v30/U9Mc6dym6WXImTlFT1kfuIqyLzA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/crushed/v29/U9Mc6dym6WXImTlFf1gVvA.ttf"
+      "menu": "https://fonts.gstatic.com/s/crushed/v30/U9Mc6dym6WXImTlFf1gVvA.ttf"
     },
     {
       "family": "Cuprum",
@@ -8388,14 +8489,14 @@
         "korean",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v27",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/cutefont/v22/Noaw6Uny2oWPbSHMrY6vmJNVNC9hkw.ttf"
+        "regular": "https://fonts.gstatic.com/s/cutefont/v27/Noaw6Uny2oWPbSHMrY6vmJNVNC9hkw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/cutefont/v22/Noaw6Uny2oWPbSHMrY6fmZlR.ttf"
+      "menu": "https://fonts.gstatic.com/s/cutefont/v27/Noaw6Uny2oWPbSHMrY6fmZlR.ttf"
     },
     {
       "family": "Cutive",
@@ -8643,14 +8744,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v3",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/danfo/v3/snf3s0u_98t16THfK1Csj3N41ZqbYDe5S71ToPrNKQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/danfo/v4/snf3s0u_98t16THfK1Csj3N41ZqbYDe5S71ToPrNKQ.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/danfo/v3/snf3s0u_98t16THfK1Csj3N41ZqbYDeJSrdX.ttf"
+      "menu": "https://fonts.gstatic.com/s/danfo/v4/snf3s0u_98t16THfK1Csj3N41ZqbYDeJSrdX.ttf"
     },
     {
       "family": "Dangrek",
@@ -8661,14 +8762,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v30",
-      "lastModified": "2024-08-12",
+      "version": "v31",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/dangrek/v30/LYjCdG30nEgoH8E2gCNqqVIuTN4.ttf"
+        "regular": "https://fonts.gstatic.com/s/dangrek/v31/LYjCdG30nEgoH8E2gCNqqVIuTN4.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/dangrek/v30/LYjCdG30nEgoH8E2sCJgrQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/dangrek/v31/LYjCdG30nEgoH8E2sCJgrQ.ttf"
     },
     {
       "family": "Darker Grotesque",
@@ -8812,14 +8913,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v16",
-      "lastModified": "2024-08-07",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/delagothicone/v16/hESp6XxvMDRA-2eD0lXpDa6QkBAGRUsJQAlbUA.ttf"
+        "regular": "https://fonts.gstatic.com/s/delagothicone/v17/hESp6XxvMDRA-2eD0lXpDa6QkBAGRUsJQAlbUA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/delagothicone/v16/hESp6XxvMDRA-2eD0lXpDa6QkBA2REEN.ttf"
+      "menu": "https://fonts.gstatic.com/s/delagothicone/v17/hESp6XxvMDRA-2eD0lXpDa6QkBA2REEN.ttf"
     },
     {
       "family": "Delicious Handrawn",
@@ -8956,14 +9057,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v24",
-      "lastModified": "2024-08-12",
+      "version": "v25",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/dhurjati/v24/_6_8ED3gSeatXfFiFX3ySKQtuTA2.ttf"
+        "regular": "https://fonts.gstatic.com/s/dhurjati/v25/_6_8ED3gSeatXfFiFX3ySKQtuTA2.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/dhurjati/v24/_6_8ED3gSeatXfFiFU3zQqA.ttf"
+      "menu": "https://fonts.gstatic.com/s/dhurjati/v25/_6_8ED3gSeatXfFiFU3zQqA.ttf"
     },
     {
       "family": "Didact Gothic",
@@ -8997,14 +9098,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/diphylleia/v1/DtVmJxCtRKMixK4_HXsIulwm6gDXvwE.ttf"
+        "regular": "https://fonts.gstatic.com/s/diphylleia/v2/DtVmJxCtRKMixK4_HXsIulwm6gDXvwE.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/diphylleia/v1/DtVmJxCtRKMixK4_HXsIil0s7g.ttf"
+      "menu": "https://fonts.gstatic.com/s/diphylleia/v2/DtVmJxCtRKMixK4_HXsIil0s7g.ttf"
     },
     {
       "family": "Diplomata",
@@ -9069,14 +9170,14 @@
         "korean",
         "latin"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-12",
+      "version": "v22",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/dokdo/v17/esDf315XNuCBLxLo4NaMlKcH.ttf"
+        "regular": "https://fonts.gstatic.com/s/dokdo/v22/esDf315XNuCBLxLo4NaMlKcH.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/dokdo/v17/esDf315XNuCBLyLp6tI.ttf"
+      "menu": "https://fonts.gstatic.com/s/dokdo/v22/esDf315XNuCBLyLp6tI.ttf"
     },
     {
       "family": "Domine",
@@ -9133,16 +9234,16 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v12",
-      "lastModified": "2024-08-12",
+      "version": "v15",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/dongle/v12/sJoG3Ltdjt6VPkqeEcxrYjWNzXvVPA.ttf",
-        "700": "https://fonts.gstatic.com/s/dongle/v12/sJoG3Ltdjt6VPkqeActrYjWNzXvVPA.ttf",
-        "regular": "https://fonts.gstatic.com/s/dongle/v12/sJoF3Ltdjt6VPkqmveRPah6RxA.ttf"
+        "300": "https://fonts.gstatic.com/s/dongle/v15/sJoG3Ltdjt6VPkqeEcxrYjWNzXvVPA.ttf",
+        "700": "https://fonts.gstatic.com/s/dongle/v15/sJoG3Ltdjt6VPkqeActrYjWNzXvVPA.ttf",
+        "regular": "https://fonts.gstatic.com/s/dongle/v15/sJoF3Ltdjt6VPkqmveRPah6RxA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/dongle/v12/sJoF3Ltdjt6VPkqWvO5L.ttf"
+      "menu": "https://fonts.gstatic.com/s/dongle/v15/sJoF3Ltdjt6VPkqWvO5L.ttf"
     },
     {
       "family": "Doppio One",
@@ -9221,14 +9322,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/dotgothic16/v18/v6-QGYjBJFKgyw5nSoDAGE7L435YPFrT.ttf"
+        "regular": "https://fonts.gstatic.com/s/dotgothic16/v19/v6-QGYjBJFKgyw5nSoDAGE7L435YPFrT.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/dotgothic16/v18/v6-QGYjBJFKgyw5nSoDAGH7K6Xo.ttf"
+      "menu": "https://fonts.gstatic.com/s/dotgothic16/v19/v6-QGYjBJFKgyw5nSoDAGH7K6Xo.ttf"
     },
     {
       "family": "Doto",
@@ -9247,22 +9348,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-11-07",
+      "version": "v2",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOOez0WSvrlpgw.ttf",
-        "200": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOKez0WSvrlpgw.ttf",
-        "300": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFZuKez0WSvrlpgw.ttf",
-        "500": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFCuKez0WSvrlpgw.ttf",
-        "600": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF5uWez0WSvrlpgw.ttf",
-        "700": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF3-Wez0WSvrlpgw.ttf",
-        "800": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOWez0WSvrlpgw.ttf",
-        "900": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFkeWez0WSvrlpgw.ttf",
-        "regular": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKez0WSvrlpgw.ttf"
+        "100": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOOez0WSvrlpgw.ttf",
+        "200": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOKez0WSvrlpgw.ttf",
+        "300": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFZuKez0WSvrlpgw.ttf",
+        "500": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFCuKez0WSvrlpgw.ttf",
+        "600": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF5uWez0WSvrlpgw.ttf",
+        "700": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphF3-Wez0WSvrlpgw.ttf",
+        "800": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFuOWez0WSvrlpgw.ttf",
+        "900": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFkeWez0WSvrlpgw.ttf",
+        "regular": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKez0WSvrlpgw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/doto/v1/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKuzk-W.ttf"
+      "menu": "https://fonts.gstatic.com/s/doto/v2/t5tJIRMbNJ6TQG7Il_EKPqP9zTnvqqGNcuvLMt1JIphFOOKuzk-W.ttf"
     },
     {
       "family": "Dr Sugiyama",
@@ -9411,14 +9512,14 @@
         "korean",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/eastseadokdo/v22/xfuo0Wn2V2_KanASqXSZp22m05_aGavYS18y.ttf"
+        "regular": "https://fonts.gstatic.com/s/eastseadokdo/v25/xfuo0Wn2V2_KanASqXSZp22m05_aGavYS18y.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/eastseadokdo/v22/xfuo0Wn2V2_KanASqXSZp22m06_bE68.ttf"
+      "menu": "https://fonts.gstatic.com/s/eastseadokdo/v25/xfuo0Wn2V2_KanASqXSZp22m06_bE68.ttf"
     },
     {
       "family": "Eater",
@@ -9490,6 +9591,30 @@
       "category": "serif",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/eczar/v22/BXR2vF3Pi-DLmxcpJB-qbNTyTMDXHd6mqDgR.ttf"
+    },
+    {
+      "family": "Edu AU VIC WA NT Arrows",
+      "variants": [
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-20",
+      "files": {
+        "500": "https://fonts.gstatic.com/s/eduauvicwantarrows/v1/z7N7dQTteSlUDJZJAmUB9MuVbLPBjsrTFZLUbdjnSmlATbEWXt5tM8vhTTk90n91Vw.ttf",
+        "600": "https://fonts.gstatic.com/s/eduauvicwantarrows/v1/z7N7dQTteSlUDJZJAmUB9MuVbLPBjsrTFZLUbdjnSmlATbEWXt5t38zhTTk90n91Vw.ttf",
+        "700": "https://fonts.gstatic.com/s/eduauvicwantarrows/v1/z7N7dQTteSlUDJZJAmUB9MuVbLPBjsrTFZLUbdjnSmlATbEWXt5t5szhTTk90n91Vw.ttf",
+        "regular": "https://fonts.gstatic.com/s/eduauvicwantarrows/v1/z7N7dQTteSlUDJZJAmUB9MuVbLPBjsrTFZLUbdjnSmlATbEWXt5tAcvhTTk90n91Vw.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/eduauvicwantarrows/v1/z7N7dQTteSlUDJZJAmUB9MuVbLPBjsrTFZLUbdjnSmlATbEWXt5tAcvRTDM5.ttf"
     },
     {
       "family": "Edu AU VIC WA NT Dots",
@@ -10037,16 +10162,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/engagement/v26/x3dlckLDZbqa7RUs9MFVXNossybsHQI.ttf"
+        "regular": "https://fonts.gstatic.com/s/engagement/v27/x3dlckLDZbqa7RUs9MFVXNossybsHQI.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/engagement/v26/x3dlckLDZbqa7RUs9MFVbNsmtw.ttf"
+      "menu": "https://fonts.gstatic.com/s/engagement/v27/x3dlckLDZbqa7RUs9MFVbNsmtw.ttf"
     },
     {
       "family": "Englebert",
@@ -10057,14 +10183,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/englebert/v21/xn7iYH8w2XGrC8AR4HSxT_fYdN-WZw.ttf"
+        "regular": "https://fonts.gstatic.com/s/englebert/v23/xn7iYH8w2XGrC8AR4HSxT_fYdN-WZw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/englebert/v21/xn7iYH8w2XGrC8AR4HSBTv3c.ttf"
+      "menu": "https://fonts.gstatic.com/s/englebert/v23/xn7iYH8w2XGrC8AR4HSBTv3c.ttf"
     },
     {
       "family": "Enriqueta",
@@ -10422,14 +10548,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-11-07",
+      "version": "v4",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/facultyglyphic/v1/RrQIbot2-iBvI2mYSyKIrcgoBuQIG-eFNVmULg.ttf"
+        "regular": "https://fonts.gstatic.com/s/facultyglyphic/v4/RrQIbot2-iBvI2mYSyKIrcgoBuQIG-eFNVmULg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/facultyglyphic/v1/RrQIbot2-iBvI2mYSyKIrcgoBuQ4Gu2B.ttf"
+      "menu": "https://fonts.gstatic.com/s/facultyglyphic/v4/RrQIbot2-iBvI2mYSyKIrcgoBuQ4Gu2B.ttf"
     },
     {
       "family": "Fahkwang",
@@ -10513,17 +10639,18 @@
         "italic"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/fanwoodtext/v15/3XFtErwl05Ad_vSCF6Fq7xXGRdbY1P1Sbg.ttf",
-        "italic": "https://fonts.gstatic.com/s/fanwoodtext/v15/3XFzErwl05Ad_vSCF6Fq7xX2R9zc9vhCblye.ttf"
+        "regular": "https://fonts.gstatic.com/s/fanwoodtext/v16/3XFtErwl05Ad_vSCF6Fq7xXGRdbY1P1Sbg.ttf",
+        "italic": "https://fonts.gstatic.com/s/fanwoodtext/v16/3XFzErwl05Ad_vSCF6Fq7xX2R9zc9vhCblye.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fanwoodtext/v15/3XFtErwl05Ad_vSCF6Fq7xX2RNzc.ttf"
+      "menu": "https://fonts.gstatic.com/s/fanwoodtext/v16/3XFtErwl05Ad_vSCF6Fq7xX2RNzc.ttf"
     },
     {
       "family": "Farro",
@@ -10575,16 +10702,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/fascinate/v21/z7NWdRrufC8XJK0IIEli1LbQRPyNrw.ttf"
+        "regular": "https://fonts.gstatic.com/s/fascinate/v22/z7NWdRrufC8XJK0IIEli1LbQRPyNrw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fascinate/v21/z7NWdRrufC8XJK0IIElS1bzU.ttf"
+      "menu": "https://fonts.gstatic.com/s/fascinate/v22/z7NWdRrufC8XJK0IIElS1bzU.ttf"
     },
     {
       "family": "Fascinate Inline",
@@ -10592,16 +10720,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/fascinateinline/v22/jVyR7mzzB3zc-jp6QCAu60poNqIy1g3CfRXxWZQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/fascinateinline/v23/jVyR7mzzB3zc-jp6QCAu60poNqIy1g3CfRXxWZQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fascinateinline/v22/jVyR7mzzB3zc-jp6QCAu60poNqIy5gzIeQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/fascinateinline/v23/jVyR7mzzB3zc-jp6QCAu60poNqIy5gzIeQ.ttf"
     },
     {
       "family": "Faster One",
@@ -10809,27 +10938,27 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v6",
-      "lastModified": "2024-09-30",
+      "version": "v7",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_chQF5ewkEU4HTy.ttf",
-        "500": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_dNQF5ewkEU4HTy.ttf",
-        "600": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_ehR15ewkEU4HTy.ttf",
-        "700": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_eYR15ewkEU4HTy.ttf",
-        "800": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_f_R15ewkEU4HTy.ttf",
-        "900": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_fWR15ewkEU4HTy.ttf",
-        "regular": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QF5ewkEU4HTy.ttf",
-        "300italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A-gdyEU25WTybO8.ttf",
-        "italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A7YdyEU25WTybO8.ttf",
-        "500italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A4QdyEU25WTybO8.ttf",
-        "600italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A2gayEU25WTybO8.ttf",
-        "700italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A1EayEU25WTybO8.ttf",
-        "800italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3AzYayEU25WTybO8.ttf",
-        "900italic": "https://fonts.gstatic.com/s/figtree/v6/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3Ax8ayEU25WTybO8.ttf"
+        "300": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_chQF5ewkEU4HTy.ttf",
+        "500": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_dNQF5ewkEU4HTy.ttf",
+        "600": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_ehR15ewkEU4HTy.ttf",
+        "700": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_eYR15ewkEU4HTy.ttf",
+        "800": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_f_R15ewkEU4HTy.ttf",
+        "900": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_fWR15ewkEU4HTy.ttf",
+        "regular": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QF5ewkEU4HTy.ttf",
+        "300italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A-gdyEU25WTybO8.ttf",
+        "italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A7YdyEU25WTybO8.ttf",
+        "500italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A4QdyEU25WTybO8.ttf",
+        "600italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A2gayEU25WTybO8.ttf",
+        "700italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3A1EayEU25WTybO8.ttf",
+        "800italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3AzYayEU25WTybO8.ttf",
+        "900italic": "https://fonts.gstatic.com/s/figtree/v7/_Xm9-HUzqDCFdgfMm4GnA4aZFrUvtOK3Ax8ayEU25WTybO8.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/figtree/v6/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QG5fyEU.ttf"
+      "menu": "https://fonts.gstatic.com/s/figtree/v7/_Xmz-HUzqDCFdgfMsYiV_F7wfS-Bs_d_QG5fyEU.ttf"
     },
     {
       "family": "Finger Paint",
@@ -10866,21 +10995,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v9",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/finlandica/v8/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19AJrEjx9i5ss3a3.ttf",
-        "600": "https://fonts.gstatic.com/s/finlandica/v8/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19Dlq0jx9i5ss3a3.ttf",
-        "700": "https://fonts.gstatic.com/s/finlandica/v8/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19Dcq0jx9i5ss3a3.ttf",
-        "regular": "https://fonts.gstatic.com/s/finlandica/v8/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19A7rEjx9i5ss3a3.ttf",
-        "italic": "https://fonts.gstatic.com/s/finlandica/v8/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz76Cy_CpOtma3uNQ.ttf",
-        "500italic": "https://fonts.gstatic.com/s/finlandica/v8/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz75Ky_CpOtma3uNQ.ttf",
-        "600italic": "https://fonts.gstatic.com/s/finlandica/v8/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz7361_CpOtma3uNQ.ttf",
-        "700italic": "https://fonts.gstatic.com/s/finlandica/v8/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz70e1_CpOtma3uNQ.ttf"
+        "500": "https://fonts.gstatic.com/s/finlandica/v9/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19AJrEjx9i5ss3a3.ttf",
+        "600": "https://fonts.gstatic.com/s/finlandica/v9/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19Dlq0jx9i5ss3a3.ttf",
+        "700": "https://fonts.gstatic.com/s/finlandica/v9/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19Dcq0jx9i5ss3a3.ttf",
+        "regular": "https://fonts.gstatic.com/s/finlandica/v9/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19A7rEjx9i5ss3a3.ttf",
+        "italic": "https://fonts.gstatic.com/s/finlandica/v9/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz76Cy_CpOtma3uNQ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/finlandica/v9/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz75Ky_CpOtma3uNQ.ttf",
+        "600italic": "https://fonts.gstatic.com/s/finlandica/v9/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz7361_CpOtma3uNQ.ttf",
+        "700italic": "https://fonts.gstatic.com/s/finlandica/v9/-nFuOGk-8vAc7lEtg0aS45mfNAn722rq0MXz70e1_CpOtma3uNQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/finlandica/v8/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19A7rHjw_Co.ttf"
+      "menu": "https://fonts.gstatic.com/s/finlandica/v9/-nFsOGk-8vAc7lEtg0aSyZCty9GSsPBE19A7rHjw_Co.ttf"
     },
     {
       "family": "Fira Code",
@@ -11214,14 +11343,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/flowblock/v11/wlp0gwfPCEB65UmTk-d6-WZlbCBXE_I.ttf"
+        "regular": "https://fonts.gstatic.com/s/flowblock/v12/wlp0gwfPCEB65UmTk-d6-WZlbCBXE_I.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/flowblock/v11/wlp0gwfPCEB65UmTk-d6yWdvaA.ttf"
+      "menu": "https://fonts.gstatic.com/s/flowblock/v12/wlp0gwfPCEB65UmTk-d6yWdvaA.ttf"
     },
     {
       "family": "Flow Circular",
@@ -11235,14 +11364,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/flowcircular/v11/lJwB-pc4j2F-H8YKuyvfxdZ45ifpWdr2rIg.ttf"
+        "regular": "https://fonts.gstatic.com/s/flowcircular/v12/lJwB-pc4j2F-H8YKuyvfxdZ45ifpWdr2rIg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/flowcircular/v11/lJwB-pc4j2F-H8YKuyvfxdZ41ibjXQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/flowcircular/v12/lJwB-pc4j2F-H8YKuyvfxdZ41ibjXQ.ttf"
     },
     {
       "family": "Flow Rounded",
@@ -11256,14 +11385,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/flowrounded/v11/-zki91mtwsU9qlLiGwD4oQX3oZX-Xup87g.ttf"
+        "regular": "https://fonts.gstatic.com/s/flowrounded/v12/-zki91mtwsU9qlLiGwD4oQX3oZX-Xup87g.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/flowrounded/v11/-zki91mtwsU9qlLiGwD4oQXHoJ_6.ttf"
+      "menu": "https://fonts.gstatic.com/s/flowrounded/v12/-zki91mtwsU9qlLiGwD4oQXHoJ_6.ttf"
     },
     {
       "family": "Foldit",
@@ -11283,22 +11412,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v5",
-      "lastModified": "2024-09-04",
+      "version": "v7",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpANmapUYLHkN80.ttf",
-        "200": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XhAMmapUYLHkN80.ttf",
-        "300": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8Xs4MmapUYLHkN80.ttf",
-        "500": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XqIMmapUYLHkN80.ttf",
-        "600": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8Xk4LmapUYLHkN80.ttf",
-        "700": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XncLmapUYLHkN80.ttf",
-        "800": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XhALmapUYLHkN80.ttf",
-        "900": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XjkLmapUYLHkN80.ttf",
-        "regular": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpAMmapUYLHkN80.ttf"
+        "100": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpANmapUYLHkN80.ttf",
+        "200": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XhAMmapUYLHkN80.ttf",
+        "300": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8Xs4MmapUYLHkN80.ttf",
+        "500": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XqIMmapUYLHkN80.ttf",
+        "600": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8Xk4LmapUYLHkN80.ttf",
+        "700": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XncLmapUYLHkN80.ttf",
+        "800": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XhALmapUYLHkN80.ttf",
+        "900": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XjkLmapUYLHkN80.ttf",
+        "regular": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpAMmapUYLHkN80.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/foldit/v5/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpAMqateZA.ttf",
+      "menu": "https://fonts.gstatic.com/s/foldit/v7/aFTI7PF3Y3c9WdjNrRVE0Rk2b7j8XpAMqateZA.ttf",
       "colorCapabilities": [
         "COLRv1"
       ]
@@ -11458,31 +11587,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v31",
-      "lastModified": "2024-09-04",
+      "version": "v32",
+      "lastModified": "2025-01-06",
       "files": {
-        "100": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxqjDvTShUtWNg.ttf",
-        "200": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcNxujDvTShUtWNg.ttf",
-        "300": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIc6RujDvTShUtWNg.ttf",
-        "500": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIchRujDvTShUtWNg.ttf",
-        "600": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcaRyjDvTShUtWNg.ttf",
-        "700": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcUByjDvTShUtWNg.ttf",
-        "800": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcNxyjDvTShUtWNg.ttf",
-        "900": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcHhyjDvTShUtWNg.ttf",
-        "regular": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxujDvTShUtWNg.ttf",
-        "100italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1hLTP7Wp05GNi3k.ttf",
-        "200italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jLTf7Wp05GNi3k.ttf",
-        "300italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1gVTf7Wp05GNi3k.ttf",
-        "italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1hLTf7Wp05GNi3k.ttf",
-        "500italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1h5Tf7Wp05GNi3k.ttf",
-        "600italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1iVSv7Wp05GNi3k.ttf",
-        "700italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1isSv7Wp05GNi3k.ttf",
-        "800italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jLSv7Wp05GNi3k.ttf",
-        "900italic": "https://fonts.gstatic.com/s/fraunces/v31/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jiSv7Wp05GNi3k.ttf"
+        "100": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxqjDvTShUtWNg.ttf",
+        "200": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcNxujDvTShUtWNg.ttf",
+        "300": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIc6RujDvTShUtWNg.ttf",
+        "500": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIchRujDvTShUtWNg.ttf",
+        "600": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcaRyjDvTShUtWNg.ttf",
+        "700": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcUByjDvTShUtWNg.ttf",
+        "800": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcNxyjDvTShUtWNg.ttf",
+        "900": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIcHhyjDvTShUtWNg.ttf",
+        "regular": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxujDvTShUtWNg.ttf",
+        "100italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1hLTP7Wp05GNi3k.ttf",
+        "200italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jLTf7Wp05GNi3k.ttf",
+        "300italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1gVTf7Wp05GNi3k.ttf",
+        "italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1hLTf7Wp05GNi3k.ttf",
+        "500italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1h5Tf7Wp05GNi3k.ttf",
+        "600italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1iVSv7Wp05GNi3k.ttf",
+        "700italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1isSv7Wp05GNi3k.ttf",
+        "800italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jLSv7Wp05GNi3k.ttf",
+        "900italic": "https://fonts.gstatic.com/s/fraunces/v32/6NVf8FyLNQOQZAnv9ZwNjucMHVn85Ni7emAe9lKqZTnbB-gzTK0K1ChJdt9vIVYX9G37lvd9sPEKsxx664UJf1jiSv7Wp05GNi3k.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fraunces/v31/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxuTD_7W.ttf"
+      "menu": "https://fonts.gstatic.com/s/fraunces/v32/6NUh8FyLNQOQZAnv9bYEvDiIdE9Ea92uemAk_WBq8U_9v0c2Wa0K7iN7hzFUPJH58nib1603gg7S2nfgRYIctxuTD_7W.ttf"
     },
     {
       "family": "Freckle Face",
@@ -11534,18 +11663,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OryLMFuOLlNldbw.ttf",
-        "500": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OwyLMFuOLlNldbw.ttf",
-        "600": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OLyXMFuOLlNldbw.ttf",
-        "700": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OFiXMFuOLlNldbw.ttf",
-        "regular": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3O8SLMFuOLlNldbw.ttf"
+        "300": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OryLMFuOLlNldbw.ttf",
+        "500": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OwyLMFuOLlNldbw.ttf",
+        "600": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OLyXMFuOLlNldbw.ttf",
+        "700": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3OFiXMFuOLlNldbw.ttf",
+        "regular": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3O8SLMFuOLlNldbw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/fredoka/v14/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3O8SL8F-mP.ttf"
+      "menu": "https://fonts.gstatic.com/s/fredoka/v16/X7nP4b87HvSqjb_WIi2yDCRwoQ_k7367_B-i2yQag0-mac3O8SL8F-mP.ttf"
     },
     {
       "family": "Freehand",
@@ -11556,14 +11685,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v31",
-      "lastModified": "2024-08-12",
+      "version": "v32",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/freehand/v31/cIf-Ma5eqk01VjKTgAmBTmUOmZJk.ttf"
+        "regular": "https://fonts.gstatic.com/s/freehand/v32/cIf-Ma5eqk01VjKTgAmBTmUOmZJk.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/freehand/v31/cIf-Ma5eqk01VjKTgDmARGE.ttf"
+      "menu": "https://fonts.gstatic.com/s/freehand/v32/cIf-Ma5eqk01VjKTgDmARGE.ttf"
     },
     {
       "family": "Freeman",
@@ -11847,14 +11976,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gamaamli/v2/uU9NCBsQ4c-DPW1Yo3rR2t6CilKOdQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/gamaamli/v3/uU9NCBsQ4c-DPW1Yo3rR2t6CilKOdQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gamaamli/v2/uU9NCBsQ4c-DPW1Yo3rh29SG.ttf"
+      "menu": "https://fonts.gstatic.com/s/gamaamli/v3/uU9NCBsQ4c-DPW1Yo3rh29SG.ttf"
     },
     {
       "family": "Gabarito",
@@ -11915,16 +12044,16 @@
         "korean",
         "latin"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-12",
+      "version": "v22",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/gaegu/v17/TuGSUVB6Up9NU57nifw74sdtBk0x.ttf",
-        "700": "https://fonts.gstatic.com/s/gaegu/v17/TuGSUVB6Up9NU573jvw74sdtBk0x.ttf",
-        "regular": "https://fonts.gstatic.com/s/gaegu/v17/TuGfUVB6Up9NU6ZLodgzydtk.ttf"
+        "300": "https://fonts.gstatic.com/s/gaegu/v22/TuGSUVB6Up9NU57nifw74sdtBk0x.ttf",
+        "700": "https://fonts.gstatic.com/s/gaegu/v22/TuGSUVB6Up9NU573jvw74sdtBk0x.ttf",
+        "regular": "https://fonts.gstatic.com/s/gaegu/v22/TuGfUVB6Up9NU6ZLodgzydtk.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gaegu/v17/TuGfUVB6Up9NU5ZKq9w.ttf"
+      "menu": "https://fonts.gstatic.com/s/gaegu/v22/TuGfUVB6Up9NU5ZKq9w.ttf"
     },
     {
       "family": "Gafata",
@@ -11972,14 +12101,14 @@
         "bengali",
         "latin"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/galada/v18/H4cmBXyGmcjXlUX-8iw-4Lqggw.ttf"
+        "regular": "https://fonts.gstatic.com/s/galada/v19/H4cmBXyGmcjXlUX-8iw-4Lqggw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/galada/v18/H4cmBXyGmcjXlUXO8yY6.ttf"
+      "menu": "https://fonts.gstatic.com/s/galada/v19/H4cmBXyGmcjXlUXO8yY6.ttf"
     },
     {
       "family": "Galdeano",
@@ -12025,14 +12154,14 @@
         "korean",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gamjaflower/v22/6NUR8FiKJg-Pa0rM6uN40Z4kyf9Fdty2ew.ttf"
+        "regular": "https://fonts.gstatic.com/s/gamjaflower/v25/6NUR8FiKJg-Pa0rM6uN40Z4kyf9Fdty2ew.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gamjaflower/v22/6NUR8FiKJg-Pa0rM6uN40Z4UyPVB.ttf"
+      "menu": "https://fonts.gstatic.com/s/gamjaflower/v25/6NUR8FiKJg-Pa0rM6uN40Z4UyPVB.ttf"
     },
     {
       "family": "Gantari",
@@ -12116,16 +12245,16 @@
         "latin",
         "malayalam"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/gayathri/v17/MCoWzAb429DbBilWLLhc-pvSA_gA2W8.ttf",
-        "700": "https://fonts.gstatic.com/s/gayathri/v17/MCoXzAb429DbBilWLLiE37v4LfQJwHbn.ttf",
-        "regular": "https://fonts.gstatic.com/s/gayathri/v17/MCoQzAb429DbBilWLIA48J_wBugA.ttf"
+        "100": "https://fonts.gstatic.com/s/gayathri/v18/MCoWzAb429DbBilWLLhc-pvSA_gA2W8.ttf",
+        "700": "https://fonts.gstatic.com/s/gayathri/v18/MCoXzAb429DbBilWLLiE37v4LfQJwHbn.ttf",
+        "regular": "https://fonts.gstatic.com/s/gayathri/v18/MCoQzAb429DbBilWLIA48J_wBugA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gayathri/v17/MCoQzAb429DbBilWLLA5-ps.ttf"
+      "menu": "https://fonts.gstatic.com/s/gayathri/v18/MCoQzAb429DbBilWLLA5-ps.ttf"
     },
     {
       "family": "Geist",
@@ -12552,22 +12681,44 @@
       "menu": "https://fonts.gstatic.com/s/gideonroman/v11/e3tmeuGrVOys8sxzZgWlmXoQeknS.ttf"
     },
     {
+      "family": "Gidole",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "greek",
+        "latin",
+        "latin-ext",
+        "vietnamese"
+      ],
+      "version": "v24",
+      "lastModified": "2025-03-18",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/gidole/v24/sZlFdR6O8zVVEiMaCJtWS6EPcA.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/gidole/v24/sZlFdR6O8zVVEiMqCZFS.ttf"
+    },
+    {
       "family": "Gidugu",
       "variants": [
         "regular"
       ],
       "subsets": [
         "latin",
+        "latin-ext",
         "telugu"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gidugu/v25/L0x8DFMkk1Uf6w3RvPCmRSlUig.ttf"
+        "regular": "https://fonts.gstatic.com/s/gidugu/v26/L0x8DFMkk1Uf6w3RvPCmRSlUig.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gidugu/v25/L0x8DFMkk1Uf6w3hvfqi.ttf"
+      "menu": "https://fonts.gstatic.com/s/gidugu/v26/L0x8DFMkk1Uf6w3hvfqi.ttf"
     },
     {
       "family": "Gilda Display",
@@ -12611,16 +12762,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/giveyouglory/v15/8QIQdiHOgt3vv4LR7ahjw9-XYc1zB4ZD6rwa.ttf"
+        "regular": "https://fonts.gstatic.com/s/giveyouglory/v16/8QIQdiHOgt3vv4LR7ahjw9-XYc1zB4ZD6rwa.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/giveyouglory/v15/8QIQdiHOgt3vv4LR7ahjw9-XYf1yDYI.ttf"
+      "menu": "https://fonts.gstatic.com/s/giveyouglory/v16/8QIQdiHOgt3vv4LR7ahjw9-XYf1yDYI.ttf"
     },
     {
       "family": "Glass Antiqua",
@@ -12686,16 +12838,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gloriahallelujah/v21/LYjYdHv3kUk9BMV96EIswT9DIbW-MLSy3TKEvkCF.ttf"
+        "regular": "https://fonts.gstatic.com/s/gloriahallelujah/v22/LYjYdHv3kUk9BMV96EIswT9DIbW-MLSy3TKEvkCF.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gloriahallelujah/v21/LYjYdHv3kUk9BMV96EIswT9DIbW-MISz1zY.ttf"
+      "menu": "https://fonts.gstatic.com/s/gloriahallelujah/v22/LYjYdHv3kUk9BMV96EIswT9DIbW-MISz1zY.ttf"
     },
     {
       "family": "Glory",
@@ -12899,25 +13052,31 @@
         "900"
       ],
       "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "greek",
+        "greek-ext",
         "korean",
-        "latin"
+        "latin",
+        "latin-ext",
+        "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-11-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/gothica1/v13/CSR74z5ZnPydRjlCCwlCCMcqYtd2vfwk.ttf",
-        "200": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlCpOYKSPl6tOU9Eg.ttf",
-        "300": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlCwOUKSPl6tOU9Eg.ttf",
-        "500": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlCmOQKSPl6tOU9Eg.ttf",
-        "600": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlCtOMKSPl6tOU9Eg.ttf",
-        "700": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlC0OIKSPl6tOU9Eg.ttf",
-        "800": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlCzOEKSPl6tOU9Eg.ttf",
-        "900": "https://fonts.gstatic.com/s/gothica1/v13/CSR44z5ZnPydRjlCCwlC6OAKSPl6tOU9Eg.ttf",
-        "regular": "https://fonts.gstatic.com/s/gothica1/v13/CSR94z5ZnPydRjlCCwl6bM0uQNJmvQ.ttf"
+        "100": "https://fonts.gstatic.com/s/gothica1/v17/CSR74z5ZnPydRjlCCwlCCMcqYtd2vfwk.ttf",
+        "200": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlCpOYKSPl6tOU9Eg.ttf",
+        "300": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlCwOUKSPl6tOU9Eg.ttf",
+        "500": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlCmOQKSPl6tOU9Eg.ttf",
+        "600": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlCtOMKSPl6tOU9Eg.ttf",
+        "700": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlC0OIKSPl6tOU9Eg.ttf",
+        "800": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlCzOEKSPl6tOU9Eg.ttf",
+        "900": "https://fonts.gstatic.com/s/gothica1/v17/CSR44z5ZnPydRjlCCwlC6OAKSPl6tOU9Eg.ttf",
+        "regular": "https://fonts.gstatic.com/s/gothica1/v17/CSR94z5ZnPydRjlCCwl6bM0uQNJmvQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gothica1/v13/CSR94z5ZnPydRjlCCwlKbccq.ttf"
+      "menu": "https://fonts.gstatic.com/s/gothica1/v17/CSR94z5ZnPydRjlCCwlKbccq.ttf"
     },
     {
       "family": "Gotu",
@@ -12968,15 +13127,15 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v7",
-      "lastModified": "2024-08-12",
+      "version": "v11",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/gowunbatang/v7/ijwNs5nhRMIjYsdSgcMa3wRZ4J7awssxJii23w.ttf",
-        "regular": "https://fonts.gstatic.com/s/gowunbatang/v7/ijwSs5nhRMIjYsdSgcMa3wRhXLH-yuAtLw.ttf"
+        "700": "https://fonts.gstatic.com/s/gowunbatang/v11/ijwNs5nhRMIjYsdSgcMa3wRZ4J7awssxJii23w.ttf",
+        "regular": "https://fonts.gstatic.com/s/gowunbatang/v11/ijwSs5nhRMIjYsdSgcMa3wRhXLH-yuAtLw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gowunbatang/v7/ijwSs5nhRMIjYsdSgcMa3wRRXbv6.ttf"
+      "menu": "https://fonts.gstatic.com/s/gowunbatang/v11/ijwSs5nhRMIjYsdSgcMa3wRRXbv6.ttf"
     },
     {
       "family": "Gowun Dodum",
@@ -12989,14 +13148,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v7",
-      "lastModified": "2024-08-12",
+      "version": "v11",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gowundodum/v7/3Jn5SD_00GqwlBnWc1TUJF0FfORL0fNy.ttf"
+        "regular": "https://fonts.gstatic.com/s/gowundodum/v11/3Jn5SD_00GqwlBnWc1TUJF0FfORL0fNy.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gowundodum/v7/3Jn5SD_00GqwlBnWc1TUJG0EduA.ttf"
+      "menu": "https://fonts.gstatic.com/s/gowundodum/v11/3Jn5SD_00GqwlBnWc1TUJG0EduA.ttf"
     },
     {
       "family": "Graduate",
@@ -13356,14 +13515,14 @@
         "korean",
         "latin"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v20",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gugi/v15/A2BVn5dXywshVA6A9DEfgqM.ttf"
+        "regular": "https://fonts.gstatic.com/s/gugi/v20/A2BVn5dXywshVA6A9DEfgqM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gugi/v15/A2BVn5dXywshZA-K8A.ttf"
+      "menu": "https://fonts.gstatic.com/s/gugi/v20/A2BVn5dXywshZA-K8A.ttf"
     },
     {
       "family": "Gulzar",
@@ -13394,16 +13553,16 @@
       "subsets": [
         "latin"
       ],
-      "version": "v15",
-      "lastModified": "2024-10-17",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "500": "https://fonts.gstatic.com/s/gupter/v15/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf",
-        "700": "https://fonts.gstatic.com/s/gupter/v15/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf",
-        "regular": "https://fonts.gstatic.com/s/gupter/v15/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf"
+        "500": "https://fonts.gstatic.com/s/gupter/v17/2-cl9JNmxJqPO1Qslb-bUsT5rZhaZg.ttf",
+        "700": "https://fonts.gstatic.com/s/gupter/v17/2-cl9JNmxJqPO1Qs3bmbUsT5rZhaZg.ttf",
+        "regular": "https://fonts.gstatic.com/s/gupter/v17/2-cm9JNmxJqPO1QUYZa_Wu_lpA.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gupter/v15/2-cm9JNmxJqPO1QkYJy7.ttf"
+      "menu": "https://fonts.gstatic.com/s/gupter/v17/2-cm9JNmxJqPO1QkYJy7.ttf"
     },
     {
       "family": "Gurajada",
@@ -13412,16 +13571,17 @@
       ],
       "subsets": [
         "latin",
+        "latin-ext",
         "telugu"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/gurajada/v19/FwZY7-Qx308m-l-0Kd6A4sijpFu_.ttf"
+        "regular": "https://fonts.gstatic.com/s/gurajada/v20/FwZY7-Qx308m-l-0Kd6A4sijpFu_.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/gurajada/v19/FwZY7-Qx308m-l-0Ke6B6Mw.ttf"
+      "menu": "https://fonts.gstatic.com/s/gurajada/v20/FwZY7-Qx308m-l-0Ke6B6Mw.ttf"
     },
     {
       "family": "Gwendolyn",
@@ -13473,14 +13633,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/hachimarupop/v20/HI_TiYoRLqpLrEiMAuO9Ysfz7rW1EM_btd8u.ttf"
+        "regular": "https://fonts.gstatic.com/s/hachimarupop/v21/HI_TiYoRLqpLrEiMAuO9Ysfz7rW1EM_btd8u.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hachimarupop/v20/HI_TiYoRLqpLrEiMAuO9Ysfz7oW0Gss.ttf"
+      "menu": "https://fonts.gstatic.com/s/hachimarupop/v21/HI_TiYoRLqpLrEiMAuO9Ysfz7oW0Gss.ttf"
     },
     {
       "family": "Hahmlet",
@@ -13501,22 +13661,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-08-12",
+      "version": "v18",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKOdjobsO-aVxn.ttf",
-        "200": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjKONjobsO-aVxn.ttf",
-        "300": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RgUONjobsO-aVxn.ttf",
-        "500": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4Rh4ONjobsO-aVxn.ttf",
-        "600": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RiUP9jobsO-aVxn.ttf",
-        "700": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RitP9jobsO-aVxn.ttf",
-        "800": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjKP9jobsO-aVxn.ttf",
-        "900": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjjP9jobsO-aVxn.ttf",
-        "regular": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKONjobsO-aVxn.ttf"
+        "100": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKOdjobsO-aVxn.ttf",
+        "200": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjKONjobsO-aVxn.ttf",
+        "300": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RgUONjobsO-aVxn.ttf",
+        "500": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4Rh4ONjobsO-aVxn.ttf",
+        "600": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RiUP9jobsO-aVxn.ttf",
+        "700": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RitP9jobsO-aVxn.ttf",
+        "800": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjKP9jobsO-aVxn.ttf",
+        "900": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RjjP9jobsO-aVxn.ttf",
+        "regular": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKONjobsO-aVxn.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hahmlet/v13/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKOOjpZMc.ttf"
+      "menu": "https://fonts.gstatic.com/s/hahmlet/v18/BngXUXpCQ3nKpIo0TfPyfCdXfaeU4RhKOOjpZMc.ttf"
     },
     {
       "family": "Halant",
@@ -13532,18 +13692,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/halant/v14/u-490qaujRI2Pbsvc_pCmwZqcwdRXg.ttf",
-        "500": "https://fonts.gstatic.com/s/halant/v14/u-490qaujRI2PbsvK_tCmwZqcwdRXg.ttf",
-        "600": "https://fonts.gstatic.com/s/halant/v14/u-490qaujRI2PbsvB_xCmwZqcwdRXg.ttf",
-        "700": "https://fonts.gstatic.com/s/halant/v14/u-490qaujRI2PbsvY_1CmwZqcwdRXg.ttf",
-        "regular": "https://fonts.gstatic.com/s/halant/v14/u-4-0qaujRI2PbsX39Jmky12eg.ttf"
+        "300": "https://fonts.gstatic.com/s/halant/v16/u-490qaujRI2Pbsvc_pCmwZqcwdRXg.ttf",
+        "500": "https://fonts.gstatic.com/s/halant/v16/u-490qaujRI2PbsvK_tCmwZqcwdRXg.ttf",
+        "600": "https://fonts.gstatic.com/s/halant/v16/u-490qaujRI2PbsvB_xCmwZqcwdRXg.ttf",
+        "700": "https://fonts.gstatic.com/s/halant/v16/u-490qaujRI2PbsvY_1CmwZqcwdRXg.ttf",
+        "regular": "https://fonts.gstatic.com/s/halant/v16/u-4-0qaujRI2PbsX39Jmky12eg.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/halant/v14/u-4-0qaujRI2Pbsn3thi.ttf"
+      "menu": "https://fonts.gstatic.com/s/halant/v16/u-4-0qaujRI2Pbsn3thi.ttf"
     },
     {
       "family": "Hammersmith One",
@@ -13724,18 +13884,18 @@
         "khmer",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/hanuman/v22/VuJzdNvD15HhpJJBQMLdPKNiaRpFvg.ttf",
-        "300": "https://fonts.gstatic.com/s/hanuman/v22/VuJ0dNvD15HhpJJBQAr_HIlMZRNcp0o.ttf",
-        "700": "https://fonts.gstatic.com/s/hanuman/v22/VuJ0dNvD15HhpJJBQBr4HIlMZRNcp0o.ttf",
-        "900": "https://fonts.gstatic.com/s/hanuman/v22/VuJ0dNvD15HhpJJBQCL6HIlMZRNcp0o.ttf",
-        "regular": "https://fonts.gstatic.com/s/hanuman/v22/VuJxdNvD15HhpJJBeKbXOIFneRo.ttf"
+        "100": "https://fonts.gstatic.com/s/hanuman/v23/VuJzdNvD15HhpJJBQMLdPKNiaRpFvg.ttf",
+        "300": "https://fonts.gstatic.com/s/hanuman/v23/VuJ0dNvD15HhpJJBQAr_HIlMZRNcp0o.ttf",
+        "700": "https://fonts.gstatic.com/s/hanuman/v23/VuJ0dNvD15HhpJJBQBr4HIlMZRNcp0o.ttf",
+        "900": "https://fonts.gstatic.com/s/hanuman/v23/VuJ0dNvD15HhpJJBQCL6HIlMZRNcp0o.ttf",
+        "regular": "https://fonts.gstatic.com/s/hanuman/v23/VuJxdNvD15HhpJJBeKbXOIFneRo.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hanuman/v22/VuJxdNvD15HhpJJBSKfdPA.ttf"
+      "menu": "https://fonts.gstatic.com/s/hanuman/v23/VuJxdNvD15HhpJJBSKfdPA.ttf"
     },
     {
       "family": "Happy Monkey",
@@ -13768,17 +13928,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "500": "https://fonts.gstatic.com/s/harmattan/v19/gokpH6L2DkFvVvRp9Xprv2mHmNZEq6TTFw.ttf",
-        "600": "https://fonts.gstatic.com/s/harmattan/v19/gokpH6L2DkFvVvRp9Xprk26HmNZEq6TTFw.ttf",
-        "700": "https://fonts.gstatic.com/s/harmattan/v19/gokpH6L2DkFvVvRp9Xpr92-HmNZEq6TTFw.ttf",
-        "regular": "https://fonts.gstatic.com/s/harmattan/v19/goksH6L2DkFvVvRp9XpTS0CjkP1Yog.ttf"
+        "500": "https://fonts.gstatic.com/s/harmattan/v21/gokpH6L2DkFvVvRp9Xprv2mHmNZEq6TTFw.ttf",
+        "600": "https://fonts.gstatic.com/s/harmattan/v21/gokpH6L2DkFvVvRp9Xprk26HmNZEq6TTFw.ttf",
+        "700": "https://fonts.gstatic.com/s/harmattan/v21/gokpH6L2DkFvVvRp9Xpr92-HmNZEq6TTFw.ttf",
+        "regular": "https://fonts.gstatic.com/s/harmattan/v21/goksH6L2DkFvVvRp9XpTS0CjkP1Yog.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/harmattan/v19/goksH6L2DkFvVvRp9XpjSkqn.ttf"
+      "menu": "https://fonts.gstatic.com/s/harmattan/v21/goksH6L2DkFvVvRp9XpjSkqn.ttf"
     },
     {
       "family": "Headland One",
@@ -13954,14 +14114,14 @@
         "korean",
         "latin"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v18",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/himelody/v15/46ktlbP8Vnz0pJcqCTbEf29E31BBGA.ttf"
+        "regular": "https://fonts.gstatic.com/s/himelody/v18/46ktlbP8Vnz0pJcqCTbEf29E31BBGA.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/himelody/v15/46ktlbP8Vnz0pJcqCTb0fmVA.ttf"
+      "menu": "https://fonts.gstatic.com/s/himelody/v18/46ktlbP8Vnz0pJcqCTb0fmVA.ttf"
     },
     {
       "family": "Hina Mincho",
@@ -13975,14 +14135,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v13",
-      "lastModified": "2024-08-07",
+      "version": "v14",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/hinamincho/v13/2sDaZGBRhpXa2Jjz5w5LAGW8KbkVZTHR.ttf"
+        "regular": "https://fonts.gstatic.com/s/hinamincho/v14/2sDaZGBRhpXa2Jjz5w5LAGW8KbkVZTHR.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hinamincho/v13/2sDaZGBRhpXa2Jjz5w5LAFW9I70.ttf"
+      "menu": "https://fonts.gstatic.com/s/hinamincho/v14/2sDaZGBRhpXa2Jjz5w5LAFW9I70.ttf"
     },
     {
       "family": "Hind",
@@ -13998,18 +14158,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/hind/v16/5aU19_a8oxmIfMJaIRuYjDpf5Vw.ttf",
-        "500": "https://fonts.gstatic.com/s/hind/v16/5aU19_a8oxmIfJpbIRuYjDpf5Vw.ttf",
-        "600": "https://fonts.gstatic.com/s/hind/v16/5aU19_a8oxmIfLZcIRuYjDpf5Vw.ttf",
-        "700": "https://fonts.gstatic.com/s/hind/v16/5aU19_a8oxmIfNJdIRuYjDpf5Vw.ttf",
-        "regular": "https://fonts.gstatic.com/s/hind/v16/5aU69_a8oxmIRG5yBROzkDM.ttf"
+        "300": "https://fonts.gstatic.com/s/hind/v17/5aU19_a8oxmIfMJaIRuYjDpf5Vw.ttf",
+        "500": "https://fonts.gstatic.com/s/hind/v17/5aU19_a8oxmIfJpbIRuYjDpf5Vw.ttf",
+        "600": "https://fonts.gstatic.com/s/hind/v17/5aU19_a8oxmIfLZcIRuYjDpf5Vw.ttf",
+        "700": "https://fonts.gstatic.com/s/hind/v17/5aU19_a8oxmIfNJdIRuYjDpf5Vw.ttf",
+        "regular": "https://fonts.gstatic.com/s/hind/v17/5aU69_a8oxmIRG5yBROzkDM.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hind/v16/5aU69_a8oxmIdG94AQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/hind/v17/5aU69_a8oxmIdG94AQ.ttf"
     },
     {
       "family": "Hind Guntur",
@@ -14025,18 +14185,18 @@
         "latin-ext",
         "telugu"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/hindguntur/v12/wXKyE3UZrok56nvamSuJd_yGn1czn9zaj5Ju.ttf",
-        "500": "https://fonts.gstatic.com/s/hindguntur/v12/wXKyE3UZrok56nvamSuJd_zenlczn9zaj5Ju.ttf",
-        "600": "https://fonts.gstatic.com/s/hindguntur/v12/wXKyE3UZrok56nvamSuJd_zymVczn9zaj5Ju.ttf",
-        "700": "https://fonts.gstatic.com/s/hindguntur/v12/wXKyE3UZrok56nvamSuJd_yWmFczn9zaj5Ju.ttf",
-        "regular": "https://fonts.gstatic.com/s/hindguntur/v12/wXKvE3UZrok56nvamSuJd8Qqt3M7tMDT.ttf"
+        "300": "https://fonts.gstatic.com/s/hindguntur/v13/wXKyE3UZrok56nvamSuJd_yGn1czn9zaj5Ju.ttf",
+        "500": "https://fonts.gstatic.com/s/hindguntur/v13/wXKyE3UZrok56nvamSuJd_zenlczn9zaj5Ju.ttf",
+        "600": "https://fonts.gstatic.com/s/hindguntur/v13/wXKyE3UZrok56nvamSuJd_zymVczn9zaj5Ju.ttf",
+        "700": "https://fonts.gstatic.com/s/hindguntur/v13/wXKyE3UZrok56nvamSuJd_yWmFczn9zaj5Ju.ttf",
+        "regular": "https://fonts.gstatic.com/s/hindguntur/v13/wXKvE3UZrok56nvamSuJd8Qqt3M7tMDT.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hindguntur/v12/wXKvE3UZrok56nvamSuJd_QrvXc.ttf"
+      "menu": "https://fonts.gstatic.com/s/hindguntur/v13/wXKvE3UZrok56nvamSuJd_QrvXc.ttf"
     },
     {
       "family": "Hind Madurai",
@@ -14066,6 +14226,33 @@
       "menu": "https://fonts.gstatic.com/s/hindmadurai/v11/f0Xx0e2p98ZvDXdZQIOcpqjX8IcH.ttf"
     },
     {
+      "family": "Hind Mysuru",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "kannada",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-04",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/hindmysuru/v1/sykq-yB3k7wiAJ-U5l_li8pppHWQBVTqU4sY.ttf",
+        "500": "https://fonts.gstatic.com/s/hindmysuru/v1/sykq-yB3k7wiAJ-U5l_li8oxpXWQBVTqU4sY.ttf",
+        "600": "https://fonts.gstatic.com/s/hindmysuru/v1/sykq-yB3k7wiAJ-U5l_li8odonWQBVTqU4sY.ttf",
+        "700": "https://fonts.gstatic.com/s/hindmysuru/v1/sykq-yB3k7wiAJ-U5l_li8p5o3WQBVTqU4sY.ttf",
+        "regular": "https://fonts.gstatic.com/s/hindmysuru/v1/syk3-yB3k7wiAJ-U5l_li_LFjFGYLkjj.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/hindmysuru/v1/syk3-yB3k7wiAJ-U5l_li8LEhlU.ttf"
+    },
+    {
       "family": "Hind Siliguri",
       "variants": [
         "300",
@@ -14079,18 +14266,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwOs5juQtsyLLR5jN4cxBEoRDf44uEfKiGvxts.ttf",
-        "500": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwOs5juQtsyLLR5jN4cxBEoRG_54uEfKiGvxts.ttf",
-        "600": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwOs5juQtsyLLR5jN4cxBEoREP-4uEfKiGvxts.ttf",
-        "700": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwOs5juQtsyLLR5jN4cxBEoRCf_4uEfKiGvxts.ttf",
-        "regular": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwTs5juQtsyLLR5jN4cxBEofJvQxuk0Nig.ttf"
+        "300": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwOs5juQtsyLLR5jN4cxBEoRDf44uEfKiGvxts.ttf",
+        "500": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwOs5juQtsyLLR5jN4cxBEoRG_54uEfKiGvxts.ttf",
+        "600": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwOs5juQtsyLLR5jN4cxBEoREP-4uEfKiGvxts.ttf",
+        "700": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwOs5juQtsyLLR5jN4cxBEoRCf_4uEfKiGvxts.ttf",
+        "regular": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwTs5juQtsyLLR5jN4cxBEofJvQxuk0Nig.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hindsiliguri/v12/ijwTs5juQtsyLLR5jN4cxBEoTJrawg.ttf"
+      "menu": "https://fonts.gstatic.com/s/hindsiliguri/v13/ijwTs5juQtsyLLR5jN4cxBEoTJrawg.ttf"
     },
     {
       "family": "Hind Vadodara",
@@ -14106,18 +14293,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/hindvadodara/v13/neIQzCKvrIcn5pbuuuriV9tTSDn3iXM0oSOL2Yw.ttf",
-        "500": "https://fonts.gstatic.com/s/hindvadodara/v13/neIQzCKvrIcn5pbuuuriV9tTSGH2iXM0oSOL2Yw.ttf",
-        "600": "https://fonts.gstatic.com/s/hindvadodara/v13/neIQzCKvrIcn5pbuuuriV9tTSE3xiXM0oSOL2Yw.ttf",
-        "700": "https://fonts.gstatic.com/s/hindvadodara/v13/neIQzCKvrIcn5pbuuuriV9tTSCnwiXM0oSOL2Yw.ttf",
-        "regular": "https://fonts.gstatic.com/s/hindvadodara/v13/neINzCKvrIcn5pbuuuriV9tTcJXfrXsfvSo.ttf"
+        "300": "https://fonts.gstatic.com/s/hindvadodara/v15/neIQzCKvrIcn5pbuuuriV9tTSDn3iXM0oSOL2Yw.ttf",
+        "500": "https://fonts.gstatic.com/s/hindvadodara/v15/neIQzCKvrIcn5pbuuuriV9tTSGH2iXM0oSOL2Yw.ttf",
+        "600": "https://fonts.gstatic.com/s/hindvadodara/v15/neIQzCKvrIcn5pbuuuriV9tTSE3xiXM0oSOL2Yw.ttf",
+        "700": "https://fonts.gstatic.com/s/hindvadodara/v15/neIQzCKvrIcn5pbuuuriV9tTSCnwiXM0oSOL2Yw.ttf",
+        "regular": "https://fonts.gstatic.com/s/hindvadodara/v15/neINzCKvrIcn5pbuuuriV9tTcJXfrXsfvSo.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hindvadodara/v13/neINzCKvrIcn5pbuuuriV9tTQJTVqQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/hindvadodara/v15/neINzCKvrIcn5pbuuuriV9tTQJTVqQ.ttf"
     },
     {
       "family": "Holtwood One SC",
@@ -14183,14 +14370,14 @@
         "symbols",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/honk/v1/m8J7jftUea-XwTaemClumrBQbmvynOmXBji9zFhHRr8WFgVLo7tNepQKvg.ttf"
+        "regular": "https://fonts.gstatic.com/s/honk/v5/m8J7jftUea-XwTaemClumrBQbmvynOmXBji9zFhHRr8WFgVLo7tNepQKvg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/honk/v1/m8J7jftUea-XwTaemClumrBQbmvynOmXBji9zFhHRr8WFgV7orFJ.ttf",
+      "menu": "https://fonts.gstatic.com/s/honk/v5/m8J7jftUea-XwTaemClumrBQbmvynOmXBji9zFhHRr8WFgV7orFJ.ttf",
       "colorCapabilities": [
         "COLRv1"
       ]
@@ -14215,25 +14402,25 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-11-07",
+      "version": "v4",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PubnOzhap-j94InI.ttf",
-        "500": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PudXOzhap-j94InI.ttf",
-        "600": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuTnJzhap-j94InI.ttf",
-        "700": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuQDJzhap-j94InI.ttf",
-        "800": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuWfJzhap-j94InI.ttf",
-        "regular": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefOzhap-j94InI.ttf",
-        "300italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NeFWj_h19MnL2jg.ttf",
-        "italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NJlWj_h19MnL2jg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NFFWj_h19MnL2jg.ttf",
-        "600italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-N-FKj_h19MnL2jg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NwVKj_h19MnL2jg.ttf",
-        "800italic": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NplKj_h19MnL2jg.ttf"
+        "300": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PubnOzhap-j94InI.ttf",
+        "500": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PudXOzhap-j94InI.ttf",
+        "600": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuTnJzhap-j94InI.ttf",
+        "700": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuQDJzhap-j94InI.ttf",
+        "800": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuWfJzhap-j94InI.ttf",
+        "regular": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefOzhap-j94InI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NeFWj_h19MnL2jg.ttf",
+        "italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NJlWj_h19MnL2jg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NFFWj_h19MnL2jg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-N-FKj_h19MnL2jg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NwVKj_h19MnL2jg.ttf",
+        "800italic": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3SmWBnlCJ3U42vbbfdwMjZoULo4bgYM-BIrC-NplKj_h19MnL2jg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hostgrotesk/v1/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefO_hej_g.ttf"
+      "menu": "https://fonts.gstatic.com/s/hostgrotesk/v4/co3UmWBnlCJ3U42vbbfdwMjzqHAXOdFzqU5PuefO_hej_g.ttf"
     },
     {
       "family": "Hubballi",
@@ -14245,14 +14432,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v7",
-      "lastModified": "2024-09-04",
+      "version": "v8",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/hubballi/v7/o-0JIpUj3WIZ1RFN56B7yBBNYuSF.ttf"
+        "regular": "https://fonts.gstatic.com/s/hubballi/v8/o-0JIpUj3WIZ1RFN56B7yBBNYuSF.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hubballi/v7/o-0JIpUj3WIZ1RFN55B6whQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/hubballi/v8/o-0JIpUj3WIZ1RFN55B6whQ.ttf"
     },
     {
       "family": "Hubot Sans",
@@ -14279,29 +14466,29 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-11-05",
+      "version": "v4",
+      "lastModified": "2024-12-04",
       "files": {
-        "200": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7ZdgLDVwVqcXQ.ttf",
-        "300": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCubZdgLDVwVqcXQ.ttf",
-        "500": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC1bZdgLDVwVqcXQ.ttf",
-        "600": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCObFdgLDVwVqcXQ.ttf",
-        "700": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCALFdgLDVwVqcXQ.ttf",
-        "800": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7FdgLDVwVqcXQ.ttf",
-        "900": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCTrFdgLDVwVqcXQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZdgLDVwVqcXQ.ttf",
-        "200italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1w7rR41-MXUss.ttf",
-        "300italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_Xrw7rR41-MXUss.ttf",
-        "italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_W1w7rR41-MXUss.ttf",
-        "500italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_WHw7rR41-MXUss.ttf",
-        "600italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VrxLrR41-MXUss.ttf",
-        "700italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VSxLrR41-MXUss.ttf",
-        "800italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1xLrR41-MXUss.ttf",
-        "900italic": "https://fonts.gstatic.com/s/hubotsans/v1/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_UcxLrR41-MXUss.ttf"
+        "200": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7ZdgLDVwVqcXQ.ttf",
+        "300": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCubZdgLDVwVqcXQ.ttf",
+        "500": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC1bZdgLDVwVqcXQ.ttf",
+        "600": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCObFdgLDVwVqcXQ.ttf",
+        "700": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCALFdgLDVwVqcXQ.ttf",
+        "800": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCZ7FdgLDVwVqcXQ.ttf",
+        "900": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsCTrFdgLDVwVqcXQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZdgLDVwVqcXQ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1w7rR41-MXUss.ttf",
+        "300italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_Xrw7rR41-MXUss.ttf",
+        "italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_W1w7rR41-MXUss.ttf",
+        "500italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_WHw7rR41-MXUss.ttf",
+        "600italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VrxLrR41-MXUss.ttf",
+        "700italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_VSxLrR41-MXUss.ttf",
+        "800italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_U1xLrR41-MXUss.ttf",
+        "900italic": "https://fonts.gstatic.com/s/hubotsans/v4/pe0PMIiULYxOvxVLbVwhEtWACNaCm8WTUIR_y2-e41Q0S0srIrwXL_UcxLrR41-MXUss.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/hubotsans/v1/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZtgbrR.ttf"
+      "menu": "https://fonts.gstatic.com/s/hubotsans/v4/pe0BMIiULYxOvxVLbVwhONyy6zb7yFM9V5G3iZ3X0avsIiCxjLsC57ZtgbrR.ttf"
     },
     {
       "family": "Hurricane",
@@ -14373,18 +14560,18 @@
       "family": "IBM Plex Sans",
       "variants": [
         "100",
-        "100italic",
         "200",
-        "200italic",
         "300",
-        "300italic",
         "regular",
-        "italic",
         "500",
-        "500italic",
         "600",
-        "600italic",
         "700",
+        "100italic",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
         "700italic"
       ],
       "subsets": [
@@ -14395,27 +14582,27 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2025-02-05",
       "files": {
-        "100": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX-KVElMYYaJe8bpLHnCwDKjbLeEKxIedbzDw.ttf",
-        "200": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX9KVElMYYaJe8bpLHnCwDKjR7_MIZmdd_qFmo.ttf",
-        "300": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX9KVElMYYaJe8bpLHnCwDKjXr8MIZmdd_qFmo.ttf",
-        "500": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX9KVElMYYaJe8bpLHnCwDKjSL9MIZmdd_qFmo.ttf",
-        "600": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX9KVElMYYaJe8bpLHnCwDKjQ76MIZmdd_qFmo.ttf",
-        "700": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX9KVElMYYaJe8bpLHnCwDKjWr7MIZmdd_qFmo.ttf",
-        "100italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX8KVElMYYaJe8bpLHnCwDKhdTmdKZMW9PjD3N8.ttf",
-        "200italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX7KVElMYYaJe8bpLHnCwDKhdTm2Idscf3vBmpl8A.ttf",
-        "300italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX7KVElMYYaJe8bpLHnCwDKhdTmvIRscf3vBmpl8A.ttf",
-        "regular": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYXgKVElMYYaJe8bpLHnCwDKtdbUFI5NadY.ttf",
-        "italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX-KVElMYYaJe8bpLHnCwDKhdTeEKxIedbzDw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX7KVElMYYaJe8bpLHnCwDKhdTm5IVscf3vBmpl8A.ttf",
-        "600italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX7KVElMYYaJe8bpLHnCwDKhdTmyIJscf3vBmpl8A.ttf",
-        "700italic": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYX7KVElMYYaJe8bpLHnCwDKhdTmrINscf3vBmpl8A.ttf"
+        "100": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSD6lhzAKI5loa26g.ttf",
+        "200": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSDallzAKI5loa26g.ttf",
+        "300": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSDtFlzAKI5loa26g.ttf",
+        "500": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSD2FlzAKI5loa26g.ttf",
+        "600": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSDNF5zAKI5loa26g.ttf",
+        "700": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSDDV5zAKI5loa26g.ttf",
+        "regular": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSD6llzAKI5loa26g.ttf",
+        "100italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhqbQqg9tIOm6vje.ttf",
+        "200italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhobQ6g9tIOm6vje.ttf",
+        "300italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhrFQ6g9tIOm6vje.ttf",
+        "italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhqbQ6g9tIOm6vje.ttf",
+        "500italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhqpQ6g9tIOm6vje.ttf",
+        "600italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhpFRKg9tIOm6vje.ttf",
+        "700italic": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXEKVElMYYaJe8bpLHnCwDKhdTEG46kmUZQCX598fQbM4jw8V78x9OWIhp8RKg9tIOm6vje.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ibmplexsans/v19/zYXgKVElMYYaJe8bpLHnCwDKhdfeEA.ttf"
+      "menu": "https://fonts.gstatic.com/s/ibmplexsans/v21/zYXGKVElMYYaJe8bpLHnCwDKr932-G7dytD-Dmu1swZSAXcomDVmadSD6llDAag9.ttf"
     },
     {
       "family": "IBM Plex Sans Arabic",
@@ -14434,20 +14621,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3MZRtWPQCuHme67tEYUIx3Kh0PHR9N6YNe3PC5eMlAMg0.ttf",
-        "200": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPy_dCTVsVJKxTs.ttf",
-        "300": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YOW_tCTVsVJKxTs.ttf",
-        "500": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPO_9CTVsVJKxTs.ttf",
-        "600": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPi-NCTVsVJKxTs.ttf",
-        "700": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YOG-dCTVsVJKxTs.ttf",
-        "regular": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3CZRtWPQCuHme67tEYUIx3Kh0PHR9N6bs61vSbfdlA.ttf"
+        "100": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3MZRtWPQCuHme67tEYUIx3Kh0PHR9N6YNe3PC5eMlAMg0.ttf",
+        "200": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPy_dCTVsVJKxTs.ttf",
+        "300": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YOW_tCTVsVJKxTs.ttf",
+        "500": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPO_9CTVsVJKxTs.ttf",
+        "600": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YPi-NCTVsVJKxTs.ttf",
+        "700": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3NZRtWPQCuHme67tEYUIx3Kh0PHR9N6YOG-dCTVsVJKxTs.ttf",
+        "regular": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3CZRtWPQCuHme67tEYUIx3Kh0PHR9N6bs61vSbfdlA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ibmplexsansarabic/v12/Qw3CZRtWPQCuHme67tEYUIx3Kh0PHR9N6Ys73PA.ttf"
+      "menu": "https://fonts.gstatic.com/s/ibmplexsansarabic/v13/Qw3CZRtWPQCuHme67tEYUIx3Kh0PHR9N6Ys73PA.ttf"
     },
     {
       "family": "IBM Plex Sans Condensed",
@@ -14914,6 +15101,26 @@
       "menu": "https://fonts.gstatic.com/s/imfellgreatprimersc/v21/ga6daxBOxyt6sCqz3fjZCTFCTUDMHagsQKdDTIf8D3g.ttf"
     },
     {
+      "family": "Iansui",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "chinese-hongkong",
+        "latin",
+        "latin-ext",
+        "symbols2"
+      ],
+      "version": "v2",
+      "lastModified": "2025-03-04",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/iansui/v2/w8gbH2UoTuUp5bOajSGD1FcXoQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/iansui/v2/w8gbH2UoTuUp5bOqjCuH.ttf"
+    },
+    {
       "family": "Ibarra Real Nova",
       "variants": [
         "regular",
@@ -15054,23 +15261,39 @@
     {
       "family": "Inclusive Sans",
       "variants": [
+        "300",
         "regular",
-        "italic"
+        "500",
+        "600",
+        "700",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic"
       ],
       "subsets": [
         "latin",
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/inclusivesans/v1/0nkxC9biPuwflXcJ46P4PGWE0971owa2LB4i.ttf",
-        "italic": "https://fonts.gstatic.com/s/inclusivesans/v1/0nkzC9biPuwflXcJ46P4PGWE0-73qQKUKQ4iT6o.ttf"
+        "300": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtfLhtN7mxtc0bIsQ.ttf",
+        "500": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtfQhtN7mxtc0bIsQ.ttf",
+        "600": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtfrhxN7mxtc0bIsQ.ttf",
+        "700": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtflxxN7mxtc0bIsQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtfcBtN7mxtc0bIsQ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk-C9biPuwflXcJ46P4PGWE0-73swm22da-7KxKuFj7rWZpUUPYsTVx.ttf",
+        "italic": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk-C9biPuwflXcJ46P4PGWE0-73swm22da-7KxKuFilrWZpUUPYsTVx.ttf",
+        "500italic": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk-C9biPuwflXcJ46P4PGWE0-73swm22da-7KxKuFiXrWZpUUPYsTVx.ttf",
+        "600italic": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk-C9biPuwflXcJ46P4PGWE0-73swm22da-7KxKuFh7qmZpUUPYsTVx.ttf",
+        "700italic": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk-C9biPuwflXcJ46P4PGWE0-73swm22da-7KxKuFhCqmZpUUPYsTVx.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/inclusivesans/v1/0nkxC9biPuwflXcJ46P4PGWE0-70qQI.ttf"
+      "menu": "https://fonts.gstatic.com/s/inclusivesans/v2/0nk8C9biPuwflXcJ46P4PGWE08T-gfZusL0kQqtfcBt972Zp.ttf"
     },
     {
       "family": "Inconsolata",
@@ -15129,16 +15352,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/indieflower/v21/m8JVjfNVeKWVnh3QMuKkFcZlbkGG1dKEDw.ttf"
+        "regular": "https://fonts.gstatic.com/s/indieflower/v22/m8JVjfNVeKWVnh3QMuKkFcZlbkGG1dKEDw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/indieflower/v21/m8JVjfNVeKWVnh3QMuKkFcZVb0uC.ttf"
+      "menu": "https://fonts.gstatic.com/s/indieflower/v22/m8JVjfNVeKWVnh3QMuKkFcZVb0uC.ttf"
     },
     {
       "family": "Ingrid Darling",
@@ -15580,14 +15804,14 @@
         "math",
         "symbols"
       ],
-      "version": "v6",
-      "lastModified": "2024-09-04",
+      "version": "v7",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquard12/v6/vm8ydRLuXETEweL79J4rGc3JUnr34c9-.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquard12/v7/vm8ydRLuXETEweL79J4rGc3JUnr34c9-.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquard12/v6/vm8ydRLuXETEweL79J4rGf3IWH4.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquard12/v7/vm8ydRLuXETEweL79J4rGf3IWH4.ttf"
     },
     {
       "family": "Jacquard 12 Charted",
@@ -15600,14 +15824,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquard12charted/v2/i7dWIE97bzCOB9Q_Up6PQmYfKDPIb2HwT3StZ9jetKY.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquard12charted/v3/i7dWIE97bzCOB9Q_Up6PQmYfKDPIb2HwT3StZ9jetKY.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquard12charted/v2/i7dWIE97bzCOB9Q_Up6PQmYfKDPIb2Hwf3WnYw.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquard12charted/v3/i7dWIE97bzCOB9Q_Up6PQmYfKDPIb2Hwf3WnYw.ttf"
     },
     {
       "family": "Jacquard 24",
@@ -15618,14 +15842,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquard24/v2/jVyO7nf_B2zO5jVpUGU8lgQEdchf9xXp.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquard24/v3/jVyO7nf_B2zO5jVpUGU8lgQEdchf9xXp.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquard24/v2/jVyO7nf_B2zO5jVpUGU8ljQFf8w.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquard24/v3/jVyO7nf_B2zO5jVpUGU8ljQFf8w.ttf"
     },
     {
       "family": "Jacquard 24 Charted",
@@ -15636,14 +15860,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v3",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquard24charted/v3/mtGm4-dNK6HaudrE9VVKhENTsEXEYish0iRrMYJ_K-4.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquard24charted/v4/mtGm4-dNK6HaudrE9VVKhENTsEXEYish0iRrMYJ_K-4.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquard24charted/v3/mtGm4-dNK6HaudrE9VVKhENTsEXEYish4iVhNQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquard24charted/v4/mtGm4-dNK6HaudrE9VVKhENTsEXEYish4iVhNQ.ttf"
     },
     {
       "family": "Jacquarda Bastarda 9",
@@ -15656,14 +15880,14 @@
         "math",
         "symbols"
       ],
-      "version": "v4",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquardabastarda9/v4/f0Xp0fWr_8t6WFtKQJfOhaC0hcZ1HYAMAbwD1TB_JHHY.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquardabastarda9/v5/f0Xp0fWr_8t6WFtKQJfOhaC0hcZ1HYAMAbwD1TB_JHHY.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquardabastarda9/v4/f0Xp0fWr_8t6WFtKQJfOhaC0hcZ1HYAMAYwC3zQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquardabastarda9/v5/f0Xp0fWr_8t6WFtKQJfOhaC0hcZ1HYAMAYwC3zQ.ttf"
     },
     {
       "family": "Jacquarda Bastarda 9 Charted",
@@ -15676,14 +15900,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jacquardabastarda9charted/v2/Yq6D-KaMUyfq4qLgx19A_ocp43FeLd9m0vDxm-yf8JPuf0cPaL8pmQg.ttf"
+        "regular": "https://fonts.gstatic.com/s/jacquardabastarda9charted/v3/Yq6D-KaMUyfq4qLgx19A_ocp43FeLd9m0vDxm-yf8JPuf0cPaL8pmQg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jacquardabastarda9charted/v2/Yq6D-KaMUyfq4qLgx19A_ocp43FeLd9m0vDxm-yf8JPuT0YFbA.ttf"
+      "menu": "https://fonts.gstatic.com/s/jacquardabastarda9charted/v3/Yq6D-KaMUyfq4qLgx19A_ocp43FeLd9m0vDxm-yf8JPuT0YFbA.ttf"
     },
     {
       "family": "Jacques Francois",
@@ -15806,14 +16030,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey10/v2/GftH7vZKsggXMf9n_J5X-JLgy1wtSw.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey10/v3/GftH7vZKsggXMf9n_J5X-JLgy1wtSw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey10/v2/GftH7vZKsggXMf9n_J5n-Zjk.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey10/v3/GftH7vZKsggXMf9n_J5n-Zjk.ttf"
     },
     {
       "family": "Jersey 10 Charted",
@@ -15824,14 +16048,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey10charted/v2/oY1E8fPFr6XiNWqEp90XSbwUGfF8SnedKmeBvEYs.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey10charted/v3/oY1E8fPFr6XiNWqEp90XSbwUGfF8SnedKmeBvEYs.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey10charted/v2/oY1E8fPFr6XiNWqEp90XSbwUGfF8SkecIGM.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey10charted/v3/oY1E8fPFr6XiNWqEp90XSbwUGfF8SkecIGM.ttf"
     },
     {
       "family": "Jersey 15",
@@ -15842,14 +16066,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey15/v2/_6_9EDzuROGsUuk2TWjSYoohsCkvSQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey15/v3/_6_9EDzuROGsUuk2TWjSYoohsCkvSQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey15/v2/_6_9EDzuROGsUuk2TWjiY4Al.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey15/v3/_6_9EDzuROGsUuk2TWjiY4Al.ttf"
     },
     {
       "family": "Jersey 15 Charted",
@@ -15860,14 +16084,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey15charted/v2/nuFjD-rCQIjoVp1Sva2ToCTudGbLeRv4r2024gxi.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey15charted/v3/nuFjD-rCQIjoVp1Sva2ToCTudGbLeRv4r2024gxi.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey15charted/v2/nuFjD-rCQIjoVp1Sva2ToCTudGbLeSv5pWk.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey15charted/v3/nuFjD-rCQIjoVp1Sva2ToCTudGbLeSv5pWk.ttf"
     },
     {
       "family": "Jersey 20",
@@ -15878,14 +16102,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey20/v2/ZgNRjP1ON6jeW4D12z3crE_qP4mXuQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey20/v3/ZgNRjP1ON6jeW4D12z3crE_qP4mXuQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey20/v2/ZgNRjP1ON6jeW4D12z3srUXu.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey20/v3/ZgNRjP1ON6jeW4D12z3srUXu.ttf"
     },
     {
       "family": "Jersey 20 Charted",
@@ -15896,14 +16120,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey20charted/v2/JTUNjJMy9DKq5FzVaj9tpgYgvHqGn_Z1ji-rqnQ_.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey20charted/v3/JTUNjJMy9DKq5FzVaj9tpgYgvHqGn_Z1ji-rqnQ_.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey20charted/v2/JTUNjJMy9DKq5FzVaj9tpgYgvHqGn8Z0hCs.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey20charted/v3/JTUNjJMy9DKq5FzVaj9tpgYgvHqGn8Z0hCs.ttf"
     },
     {
       "family": "Jersey 25",
@@ -15914,14 +16138,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jersey25/v2/ll8-K2eeXj2tAs6F9BXIJ4AMng8ChA.ttf"
+        "regular": "https://fonts.gstatic.com/s/jersey25/v3/ll8-K2eeXj2tAs6F9BXIJ4AMng8ChA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jersey25/v2/ll8-K2eeXj2tAs6F9BX4JooI.ttf"
+      "menu": "https://fonts.gstatic.com/s/jersey25/v3/ll8-K2eeXj2tAs6F9BX4JooI.ttf"
     },
     {
       "family": "Jersey 25 Charted",
@@ -16071,18 +16295,17 @@
         "regular"
       ],
       "subsets": [
-        "arabic",
         "latin",
         "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jomhuria/v20/Dxxp8j-TMXf-llKur2b1MOGbC3Dh.ttf"
+        "regular": "https://fonts.gstatic.com/s/jomhuria/v21/Dxxp8j-TMXf-llKur2b1MOGbC3Dh.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jomhuria/v20/Dxxp8j-TMXf-llKur1b0OuU.ttf"
+      "menu": "https://fonts.gstatic.com/s/jomhuria/v21/Dxxp8j-TMXf-llKur1b0OuU.ttf"
     },
     {
       "family": "Jomolhari",
@@ -16093,14 +16316,14 @@
         "latin",
         "tibetan"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/jomolhari/v18/EvONzA1M1Iw_CBd2hsQCF1IZKq5INg.ttf"
+        "regular": "https://fonts.gstatic.com/s/jomolhari/v19/EvONzA1M1Iw_CBd2hsQCF1IZKq5INg.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/jomolhari/v18/EvONzA1M1Iw_CBd2hsQyFlgd.ttf"
+      "menu": "https://fonts.gstatic.com/s/jomolhari/v19/EvONzA1M1Iw_CBd2hsQyFlgd.ttf"
     },
     {
       "family": "Josefin Sans",
@@ -16168,27 +16391,27 @@
       "subsets": [
         "latin"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71mtd3k3K6CcEyI.ttf",
-        "200": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W79msd3k3K6CcEyI.ttf",
-        "300": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W7wesd3k3K6CcEyI.ttf",
-        "500": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W72usd3k3K6CcEyI.ttf",
-        "600": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W74erd3k3K6CcEyI.ttf",
-        "700": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W776rd3k3K6CcEyI.ttf",
-        "regular": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71msd3k3K6CcEyI.ttf",
-        "100italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvnzs9L4KZAyK43w.ttf",
-        "200italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvHzo9L4KZAyK43w.ttf",
-        "300italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvwTo9L4KZAyK43w.ttf",
-        "italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvnzo9L4KZAyK43w.ttf",
-        "500italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvrTo9L4KZAyK43w.ttf",
-        "600italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvQT09L4KZAyK43w.ttf",
-        "700italic": "https://fonts.gstatic.com/s/josefinslab/v26/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHveD09L4KZAyK43w.ttf"
+        "100": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71mtd3k3K6CcEyI.ttf",
+        "200": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W79msd3k3K6CcEyI.ttf",
+        "300": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W7wesd3k3K6CcEyI.ttf",
+        "500": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W72usd3k3K6CcEyI.ttf",
+        "600": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W74erd3k3K6CcEyI.ttf",
+        "700": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W776rd3k3K6CcEyI.ttf",
+        "regular": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71msd3k3K6CcEyI.ttf",
+        "100italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvnzs9L4KZAyK43w.ttf",
+        "200italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvHzo9L4KZAyK43w.ttf",
+        "300italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvwTo9L4KZAyK43w.ttf",
+        "italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvnzo9L4KZAyK43w.ttf",
+        "500italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvrTo9L4KZAyK43w.ttf",
+        "600italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHvQT09L4KZAyK43w.ttf",
+        "700italic": "https://fonts.gstatic.com/s/josefinslab/v27/lW-qwjwOK3Ps5GSJlNNkMalnrxShJj4wo7AR-pHveD09L4KZAyK43w.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/josefinslab/v26/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71msR3g9Lw.ttf"
+      "menu": "https://fonts.gstatic.com/s/josefinslab/v27/lW-swjwOK3Ps5GSJlNNkMalNpiZe_ldbOR4W71msR3g9Lw.ttf"
     },
     {
       "family": "Jost",
@@ -16393,16 +16616,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/justanotherhand/v19/845CNN4-AJyIGvIou-6yJKyptyOpOcr_BmmlS5aw.ttf"
+        "regular": "https://fonts.gstatic.com/s/justanotherhand/v20/845CNN4-AJyIGvIou-6yJKyptyOpOcr_BmmlS5aw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/justanotherhand/v19/845CNN4-AJyIGvIou-6yJKyptyOpOfr-DG0.ttf"
+      "menu": "https://fonts.gstatic.com/s/justanotherhand/v20/845CNN4-AJyIGvIou-6yJKyptyOpOfr-DG0.ttf"
     },
     {
       "family": "Just Me Again Down Here",
@@ -16501,17 +16725,18 @@
       ],
       "subsets": [
         "devanagari",
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/kadwa/v10/rnCr-x5V0g7ipix7auM-mHnOSOuk.ttf",
-        "regular": "https://fonts.gstatic.com/s/kadwa/v10/rnCm-x5V0g7iphTHRcc2s2XH.ttf"
+        "700": "https://fonts.gstatic.com/s/kadwa/v11/rnCr-x5V0g7ipix7auM-mHnOSOuk.ttf",
+        "regular": "https://fonts.gstatic.com/s/kadwa/v11/rnCm-x5V0g7iphTHRcc2s2XH.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kadwa/v10/rnCm-x5V0g7ipiTGT8M.ttf"
+      "menu": "https://fonts.gstatic.com/s/kadwa/v11/rnCm-x5V0g7ipiTGT8M.ttf"
     },
     {
       "family": "Kaisei Decol",
@@ -16526,16 +16751,16 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2024-12-04",
       "files": {
-        "500": "https://fonts.gstatic.com/s/kaiseidecol/v9/bMrvmSqP45sidWf3QmfFW6iKr3gr00i_qb57kA.ttf",
-        "700": "https://fonts.gstatic.com/s/kaiseidecol/v9/bMrvmSqP45sidWf3QmfFW6iK534r00i_qb57kA.ttf",
-        "regular": "https://fonts.gstatic.com/s/kaiseidecol/v9/bMrwmSqP45sidWf3QmfFW6iyW1EP22OjoA.ttf"
+        "500": "https://fonts.gstatic.com/s/kaiseidecol/v10/bMrvmSqP45sidWf3QmfFW6iKr3gr00i_qb57kA.ttf",
+        "700": "https://fonts.gstatic.com/s/kaiseidecol/v10/bMrvmSqP45sidWf3QmfFW6iK534r00i_qb57kA.ttf",
+        "regular": "https://fonts.gstatic.com/s/kaiseidecol/v10/bMrwmSqP45sidWf3QmfFW6iyW1EP22OjoA.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kaiseidecol/v9/bMrwmSqP45sidWf3QmfFW6iCWlsL.ttf"
+      "menu": "https://fonts.gstatic.com/s/kaiseidecol/v10/bMrwmSqP45sidWf3QmfFW6iCWlsL.ttf"
     },
     {
       "family": "Kaisei HarunoUmi",
@@ -16650,20 +16875,20 @@
         "latin-ext",
         "math"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9il2xRGNcykIZc.ttf",
-        "200": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW_ilmxRGNcykIZc.ttf",
-        "300": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW88lmxRGNcykIZc.ttf",
-        "500": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9QlmxRGNcykIZc.ttf",
-        "600": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW-8kWxRGNcykIZc.ttf",
-        "700": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW-FkWxRGNcykIZc.ttf",
-        "regular": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9ilmxRGNcykIZc.ttf"
+        "100": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9il2xRGNcykIZc.ttf",
+        "200": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW_ilmxRGNcykIZc.ttf",
+        "300": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW88lmxRGNcykIZc.ttf",
+        "500": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9QlmxRGNcykIZc.ttf",
+        "600": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW-8kWxRGNcykIZc.ttf",
+        "700": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW-FkWxRGNcykIZc.ttf",
+        "regular": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9ilmxRGNcykIZc.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kalnia/v2/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9illxQEtM.ttf"
+      "menu": "https://fonts.gstatic.com/s/kalnia/v5/11hqGpPCwUbbYwZZP0RBuDY62BQZhjvOytM_sLzi-TFWAW9illxQEtM.ttf"
     },
     {
       "family": "Kalnia Glaze",
@@ -16680,20 +16905,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL63nZKfhpVTvN.ttf",
-        "200": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYfL6nnZKfhpVTvN.ttf",
-        "300": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYcV6nnZKfhpVTvN.ttf",
-        "500": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYd56nnZKfhpVTvN.ttf",
-        "600": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYeV7XnZKfhpVTvN.ttf",
-        "700": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYes7XnZKfhpVTvN.ttf",
-        "regular": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL6nnZKfhpVTvN.ttf"
+        "100": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL63nZKfhpVTvN.ttf",
+        "200": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYfL6nnZKfhpVTvN.ttf",
+        "300": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYcV6nnZKfhpVTvN.ttf",
+        "500": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYd56nnZKfhpVTvN.ttf",
+        "600": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYeV7XnZKfhpVTvN.ttf",
+        "700": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYes7XnZKfhpVTvN.ttf",
+        "regular": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL6nnZKfhpVTvN.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kalniaglaze/v1/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL6knYI_w.ttf",
+      "menu": "https://fonts.gstatic.com/s/kalniaglaze/v4/wlpQgwHCBUNjrGrfu-hwowN1YyC-42Lu26VHf2LtOkAod0wTxm2tFYdL6knYI_w.ttf",
       "colorCapabilities": [
         "COLRv1"
       ]
@@ -17139,18 +17364,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/khand/v17/TwMN-IINQlQQ0bL5cFE3ZwaH__-C.ttf",
-        "500": "https://fonts.gstatic.com/s/khand/v17/TwMN-IINQlQQ0bKhcVE3ZwaH__-C.ttf",
-        "600": "https://fonts.gstatic.com/s/khand/v17/TwMN-IINQlQQ0bKNdlE3ZwaH__-C.ttf",
-        "700": "https://fonts.gstatic.com/s/khand/v17/TwMN-IINQlQQ0bLpd1E3ZwaH__-C.ttf",
-        "regular": "https://fonts.gstatic.com/s/khand/v17/TwMA-IINQlQQ0YpVWHU_TBqO.ttf"
+        "300": "https://fonts.gstatic.com/s/khand/v21/TwMN-IINQlQQ0bL5cFE3ZwaH__-C.ttf",
+        "500": "https://fonts.gstatic.com/s/khand/v21/TwMN-IINQlQQ0bKhcVE3ZwaH__-C.ttf",
+        "600": "https://fonts.gstatic.com/s/khand/v21/TwMN-IINQlQQ0bKNdlE3ZwaH__-C.ttf",
+        "700": "https://fonts.gstatic.com/s/khand/v21/TwMN-IINQlQQ0bLpd1E3ZwaH__-C.ttf",
+        "regular": "https://fonts.gstatic.com/s/khand/v21/TwMA-IINQlQQ0YpVWHU_TBqO.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/khand/v17/TwMA-IINQlQQ0bpUUnE.ttf"
+      "menu": "https://fonts.gstatic.com/s/khand/v21/TwMA-IINQlQQ0bpUUnE.ttf"
     },
     {
       "family": "Khmer",
@@ -17160,14 +17385,14 @@
       "subsets": [
         "khmer"
       ],
-      "version": "v29",
-      "lastModified": "2023-08-25",
+      "version": "v35",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/khmer/v29/MjQImit_vPPwpF-BpN2EeYmD.ttf"
+        "regular": "https://fonts.gstatic.com/s/khmer/v35/MjQImit_vPPwpF-BpN2EeYmD.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/khmer/v29/MjQImit_vPPwpG-Artk.ttf"
+      "menu": "https://fonts.gstatic.com/s/khmer/v35/MjQImit_vPPwpG-Artk.ttf"
     },
     {
       "family": "Khula",
@@ -17183,18 +17408,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v12",
-      "lastModified": "2024-08-12",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/khula/v12/OpNPnoEOns3V7G-ljCvUrC59XwXD.ttf",
-        "600": "https://fonts.gstatic.com/s/khula/v12/OpNPnoEOns3V7G_RiivUrC59XwXD.ttf",
-        "700": "https://fonts.gstatic.com/s/khula/v12/OpNPnoEOns3V7G-1iyvUrC59XwXD.ttf",
-        "800": "https://fonts.gstatic.com/s/khula/v12/OpNPnoEOns3V7G-piCvUrC59XwXD.ttf",
-        "regular": "https://fonts.gstatic.com/s/khula/v12/OpNCnoEOns3V7FcJpA_chzJ0.ttf"
+        "300": "https://fonts.gstatic.com/s/khula/v16/OpNPnoEOns3V7G-ljCvUrC59XwXD.ttf",
+        "600": "https://fonts.gstatic.com/s/khula/v16/OpNPnoEOns3V7G_RiivUrC59XwXD.ttf",
+        "700": "https://fonts.gstatic.com/s/khula/v16/OpNPnoEOns3V7G-1iyvUrC59XwXD.ttf",
+        "800": "https://fonts.gstatic.com/s/khula/v16/OpNPnoEOns3V7G-piCvUrC59XwXD.ttf",
+        "regular": "https://fonts.gstatic.com/s/khula/v16/OpNCnoEOns3V7FcJpA_chzJ0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/khula/v12/OpNCnoEOns3V7GcIrgs.ttf"
+      "menu": "https://fonts.gstatic.com/s/khula/v16/OpNCnoEOns3V7GcIrgs.ttf"
     },
     {
       "family": "Kings",
@@ -17264,16 +17489,16 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/kiwimaru/v15/R70djykGkuuDep-hRg6gNCi0Vxn9R5ShnA.ttf",
-        "500": "https://fonts.gstatic.com/s/kiwimaru/v15/R70djykGkuuDep-hRg6gbCm0Vxn9R5ShnA.ttf",
-        "regular": "https://fonts.gstatic.com/s/kiwimaru/v15/R70YjykGkuuDep-hRg6YmACQXzLhTg.ttf"
+        "300": "https://fonts.gstatic.com/s/kiwimaru/v19/R70djykGkuuDep-hRg6gNCi0Vxn9R5ShnA.ttf",
+        "500": "https://fonts.gstatic.com/s/kiwimaru/v19/R70djykGkuuDep-hRg6gbCm0Vxn9R5ShnA.ttf",
+        "regular": "https://fonts.gstatic.com/s/kiwimaru/v19/R70YjykGkuuDep-hRg6YmACQXzLhTg.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kiwimaru/v15/R70YjykGkuuDep-hRg6omQqU.ttf"
+      "menu": "https://fonts.gstatic.com/s/kiwimaru/v19/R70YjykGkuuDep-hRg6omQqU.ttf"
     },
     {
       "family": "Klee One",
@@ -17288,15 +17513,15 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2024-11-20",
       "files": {
-        "600": "https://fonts.gstatic.com/s/kleeone/v8/LDI2apCLNRc6A8oT4pbYF8Osc-bGkqIw.ttf",
-        "regular": "https://fonts.gstatic.com/s/kleeone/v8/LDIxapCLNRc6A8oT4q4AOeekWPrP.ttf"
+        "600": "https://fonts.gstatic.com/s/kleeone/v12/LDI2apCLNRc6A8oT4pbYF8Osc-bGkqIw.ttf",
+        "regular": "https://fonts.gstatic.com/s/kleeone/v12/LDIxapCLNRc6A8oT4q4AOeekWPrP.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kleeone/v8/LDIxapCLNRc6A8oT4p4BM-M.ttf"
+      "menu": "https://fonts.gstatic.com/s/kleeone/v12/LDIxapCLNRc6A8oT4p4BM-M.ttf"
     },
     {
       "family": "Knewave",
@@ -17437,18 +17662,18 @@
         "khmer",
         "latin"
       ],
-      "version": "v11",
-      "lastModified": "2024-08-12",
+      "version": "v14",
+      "lastModified": "2024-11-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMfW3p6SJbwyGj2rBZyeOrTjNuFHVyTtjNJUWU.ttf",
-        "300": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMeW3p6SJbwyGj2rBZyeOrTjNtNP3y5mD9ASHz5.ttf",
-        "700": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMeW3p6SJbwyGj2rBZyeOrTjNtdOHy5mD9ASHz5.ttf",
-        "900": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMeW3p6SJbwyGj2rBZyeOrTjNtlOny5mD9ASHz5.ttf",
-        "regular": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMdW3p6SJbwyGj2rBZyeOrTjOPhF1ixsyNJ.ttf"
+        "100": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMfW3p6SJbwyGj2rBZyeOrTjNuFHVyTtjNJUWU.ttf",
+        "300": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMeW3p6SJbwyGj2rBZyeOrTjNtNP3y5mD9ASHz5.ttf",
+        "700": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMeW3p6SJbwyGj2rBZyeOrTjNtdOHy5mD9ASHz5.ttf",
+        "900": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMeW3p6SJbwyGj2rBZyeOrTjNtlOny5mD9ASHz5.ttf",
+        "regular": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMdW3p6SJbwyGj2rBZyeOrTjOPhF1ixsyNJ.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kohsantepheap/v11/gNMdW3p6SJbwyGj2rBZyeOrTjNPgHVw.ttf"
+      "menu": "https://fonts.gstatic.com/s/kohsantepheap/v14/gNMdW3p6SJbwyGj2rBZyeOrTjNPgHVw.ttf"
     },
     {
       "family": "Kolker Brush",
@@ -17772,14 +17997,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/kumarone/v21/bMr1mS-P958wYi6YaGeGNO6WU3oT0g.ttf"
+        "regular": "https://fonts.gstatic.com/s/kumarone/v24/bMr1mS-P958wYi6YaGeGNO6WU3oT0g.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/kumarone/v21/bMr1mS-P958wYi6YaGe2NeSS.ttf"
+      "menu": "https://fonts.gstatic.com/s/kumarone/v24/bMr1mS-P958wYi6YaGe2NeSS.ttf"
     },
     {
       "family": "Kumar One Outline",
@@ -17921,16 +18146,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/labelleaurore/v20/RrQIbot8-mNYKnGNDkWlocovHeIIG-eFNVmULg.ttf"
+        "regular": "https://fonts.gstatic.com/s/labelleaurore/v21/RrQIbot8-mNYKnGNDkWlocovHeIIG-eFNVmULg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/labelleaurore/v20/RrQIbot8-mNYKnGNDkWlocovHeI4Gu2B.ttf"
+      "menu": "https://fonts.gstatic.com/s/labelleaurore/v21/RrQIbot8-mNYKnGNDkWlocovHeI4Gu2B.ttf"
     },
     {
       "family": "Labrada",
@@ -18016,18 +18242,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-11-20",
       "files": {
-        "300": "https://fonts.gstatic.com/s/laila/v15/LYjBdG_8nE8jDLzxogNAh14nVcfe.ttf",
-        "500": "https://fonts.gstatic.com/s/laila/v15/LYjBdG_8nE8jDLypowNAh14nVcfe.ttf",
-        "600": "https://fonts.gstatic.com/s/laila/v15/LYjBdG_8nE8jDLyFpANAh14nVcfe.ttf",
-        "700": "https://fonts.gstatic.com/s/laila/v15/LYjBdG_8nE8jDLzhpQNAh14nVcfe.ttf",
-        "regular": "https://fonts.gstatic.com/s/laila/v15/LYjMdG_8nE8jDIRdiidIrEIu.ttf"
+        "300": "https://fonts.gstatic.com/s/laila/v18/LYjBdG_8nE8jDLzxogNAh14nVcfe.ttf",
+        "500": "https://fonts.gstatic.com/s/laila/v18/LYjBdG_8nE8jDLypowNAh14nVcfe.ttf",
+        "600": "https://fonts.gstatic.com/s/laila/v18/LYjBdG_8nE8jDLyFpANAh14nVcfe.ttf",
+        "700": "https://fonts.gstatic.com/s/laila/v18/LYjBdG_8nE8jDLzhpQNAh14nVcfe.ttf",
+        "regular": "https://fonts.gstatic.com/s/laila/v18/LYjMdG_8nE8jDIRdiidIrEIu.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/laila/v15/LYjMdG_8nE8jDLRcgCM.ttf"
+      "menu": "https://fonts.gstatic.com/s/laila/v18/LYjMdG_8nE8jDLRcgCM.ttf"
     },
     {
       "family": "Lakki Reddy",
@@ -18038,14 +18264,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/lakkireddy/v21/S6u5w49MUSzD9jlCPmvLZQfox9k97-xZ.ttf"
+        "regular": "https://fonts.gstatic.com/s/lakkireddy/v24/S6u5w49MUSzD9jlCPmvLZQfox9k97-xZ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lakkireddy/v21/S6u5w49MUSzD9jlCPmvLZTfpzd0.ttf"
+      "menu": "https://fonts.gstatic.com/s/lakkireddy/v24/S6u5w49MUSzD9jlCPmvLZTfpzd0.ttf"
     },
     {
       "family": "Lalezar",
@@ -18120,20 +18346,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v30",
-      "lastModified": "2024-09-04",
+      "version": "v32",
+      "lastModified": "2024-12-04",
       "files": {
-        "200": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0bjygbqTb9nQ-RA.ttf",
-        "300": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0Cj-gbqTb9nQ-RA.ttf",
-        "500": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0Uj6gbqTb9nQ-RA.ttf",
-        "600": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0fjmgbqTb9nQ-RA.ttf",
-        "700": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0GjigbqTb9nQ-RA.ttf",
-        "800": "https://fonts.gstatic.com/s/lateef/v30/hESz6XVnNCxEvkb0BjugbqTb9nQ-RA.ttf",
-        "regular": "https://fonts.gstatic.com/s/lateef/v30/hESw6XVnNCxEvkbMpheEZo_H_w.ttf"
+        "200": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0bjygbqTb9nQ-RA.ttf",
+        "300": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0Cj-gbqTb9nQ-RA.ttf",
+        "500": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0Uj6gbqTb9nQ-RA.ttf",
+        "600": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0fjmgbqTb9nQ-RA.ttf",
+        "700": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0GjigbqTb9nQ-RA.ttf",
+        "800": "https://fonts.gstatic.com/s/lateef/v32/hESz6XVnNCxEvkb0BjugbqTb9nQ-RA.ttf",
+        "regular": "https://fonts.gstatic.com/s/lateef/v32/hESw6XVnNCxEvkbMpheEZo_H_w.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lateef/v30/hESw6XVnNCxEvkb8px2A.ttf"
+      "menu": "https://fonts.gstatic.com/s/lateef/v32/hESw6XVnNCxEvkb8px2A.ttf"
     },
     {
       "family": "Lato",
@@ -18383,22 +18609,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-30",
+      "version": "v24",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsX_LBte6KuGEo.ttf",
-        "200": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sW_LBte6KuGEo.ttf",
-        "300": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
-        "500": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
-        "600": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
-        "700": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC9wR_LBte6KuGEo.ttf",
-        "800": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sR_LBte6KuGEo.ttf",
-        "900": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WC5IR_LBte6KuGEo.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsW_LBte6KuGEo.ttf"
+        "100": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsX_LBte6KuGEo.ttf",
+        "200": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sW_LBte6KuGEo.ttf",
+        "300": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
+        "500": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
+        "600": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
+        "700": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC9wR_LBte6KuGEo.ttf",
+        "800": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC7sR_LBte6KuGEo.ttf",
+        "900": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WC5IR_LBte6KuGEo.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsW_LBte6KuGEo.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexend/v23/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsWzLFnfw.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexend/v24/wlptgwvFAVdoq2_F94zlCfv0bz1WCzsWzLFnfw.ttf"
     },
     {
       "family": "Lexend Deca",
@@ -18418,22 +18644,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48MxArBPCqLNflg.ttf",
-        "200": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4cM1ArBPCqLNflg.ttf",
-        "300": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4rs1ArBPCqLNflg.ttf",
-        "500": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4ws1ArBPCqLNflg.ttf",
-        "600": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4LspArBPCqLNflg.ttf",
-        "700": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4F8pArBPCqLNflg.ttf",
-        "800": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4cMpArBPCqLNflg.ttf",
-        "900": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4WcpArBPCqLNflg.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48M1ArBPCqLNflg.ttf"
+        "100": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48MxArBPCqLNflg.ttf",
+        "200": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4cM1ArBPCqLNflg.ttf",
+        "300": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4rs1ArBPCqLNflg.ttf",
+        "500": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4ws1ArBPCqLNflg.ttf",
+        "600": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4LspArBPCqLNflg.ttf",
+        "700": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4F8pArBPCqLNflg.ttf",
+        "800": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4cMpArBPCqLNflg.ttf",
+        "900": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U4WcpArBPCqLNflg.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48M1ArBPCqLNflg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexenddeca/v21/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48M1wrRnG.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexenddeca/v22/K2FifZFYk-dHSE0UPPuwQ7CrD94i-NCKm-U48M1wrRnG.ttf"
     },
     {
       "family": "Lexend Exa",
@@ -18453,22 +18679,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v30",
-      "lastModified": "2024-09-04",
+      "version": "v31",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7T6bHHJ8BRq0b.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9p7TqbHHJ8BRq0b.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9qlTqbHHJ8BRq0b.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9rJTqbHHJ8BRq0b.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9olSabHHJ8BRq0b.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9ocSabHHJ8BRq0b.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9p7SabHHJ8BRq0b.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9pSSabHHJ8BRq0b.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7TqbHHJ8BRq0b.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7T6bHHJ8BRq0b.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9p7TqbHHJ8BRq0b.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9qlTqbHHJ8BRq0b.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9rJTqbHHJ8BRq0b.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9olSabHHJ8BRq0b.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9ocSabHHJ8BRq0b.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9p7SabHHJ8BRq0b.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9pSSabHHJ8BRq0b.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7TqbHHJ8BRq0b.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendexa/v30/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7TpbGFps.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendexa/v31/UMBCrPdOoHOnxExyjdBeQCH18mulUxBvI9r7TpbGFps.ttf"
     },
     {
       "family": "Lexend Giga",
@@ -18488,22 +18714,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2LmE68oo6eepYQ.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCWLiE68oo6eepYQ.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRChriE68oo6eepYQ.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC6riE68oo6eepYQ.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCBr-E68oo6eepYQ.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCP7-E68oo6eepYQ.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCWL-E68oo6eepYQ.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCcb-E68oo6eepYQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2LiE68oo6eepYQ.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2LmE68oo6eepYQ.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCWLiE68oo6eepYQ.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRChriE68oo6eepYQ.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC6riE68oo6eepYQ.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCBr-E68oo6eepYQ.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCP7-E68oo6eepYQ.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCWL-E68oo6eepYQ.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRCcb-E68oo6eepYQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2LiE68oo6eepYQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendgiga/v25/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2Li06sAs.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendgiga/v26/PlIuFl67Mah5Y8yMHE7lkUZPlTBo4MWFfNRC2Li06sAs.ttf"
     },
     {
       "family": "Lexend Mega",
@@ -18523,22 +18749,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fivveyiq9EqQw.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLcfmvveyiq9EqQw.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLr_mvveyiq9EqQw.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLw_mvveyiq9EqQw.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLL_6vveyiq9EqQw.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLFv6vveyiq9EqQw.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLcf6vveyiq9EqQw.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLWP6vveyiq9EqQw.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fmvveyiq9EqQw.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fivveyiq9EqQw.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLcfmvveyiq9EqQw.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLr_mvveyiq9EqQw.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLw_mvveyiq9EqQw.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLL_6vveyiq9EqQw.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLFv6vveyiq9EqQw.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLcf6vveyiq9EqQw.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDLWP6vveyiq9EqQw.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fmvveyiq9EqQw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendmega/v25/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fmfvOam.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendmega/v26/qFdX35aBi5JtHD41zSTFEuTByuvYFuE9IbDL8fmfvOam.ttf"
     },
     {
       "family": "Lexend Peta",
@@ -18558,22 +18784,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-04",
+      "version": "v29",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SFyW1YuRTsnfw.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRaSByW1YuRTsnfw.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRtyByW1YuRTsnfw.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR2yByW1YuRTsnfw.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRNydyW1YuRTsnfw.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRDidyW1YuRTsnfw.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRaSdyW1YuRTsnfw.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRQCdyW1YuRTsnfw.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SByW1YuRTsnfw.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SFyW1YuRTsnfw.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRaSByW1YuRTsnfw.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRtyByW1YuRTsnfw.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR2yByW1YuRTsnfw.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRNydyW1YuRTsnfw.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRDidyW1YuRTsnfw.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRaSdyW1YuRTsnfw.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgRQCdyW1YuRTsnfw.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SByW1YuRTsnfw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendpeta/v27/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SBCWlwq.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendpeta/v29/BXR4vFPGjeLPh0kCfI4OkFX-UTQHSCaxvBgR6SBCWlwq.ttf"
     },
     {
       "family": "Lexend Tera",
@@ -18593,22 +18819,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-04",
+      "version": "v28",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zITdpz0fYxcrQ.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMZzMTdpz0fYxcrQ.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMuTMTdpz0fYxcrQ.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM1TMTdpz0fYxcrQ.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMOTQTdpz0fYxcrQ.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMADQTdpz0fYxcrQ.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMZzQTdpz0fYxcrQ.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMTjQTdpz0fYxcrQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zMTdpz0fYxcrQ.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zITdpz0fYxcrQ.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMZzMTdpz0fYxcrQ.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMuTMTdpz0fYxcrQ.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM1TMTdpz0fYxcrQ.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMOTQTdpz0fYxcrQ.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMADQTdpz0fYxcrQ.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMZzQTdpz0fYxcrQ.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiMTjQTdpz0fYxcrQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zMTdpz0fYxcrQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendtera/v27/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zMjd5bw.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendtera/v28/RrQDbo98_jt_IXnBPwCWtYJLZ3P4hnaGKFiM5zMjd5bw.ttf"
     },
     {
       "family": "Lexend Zetta",
@@ -18628,22 +18854,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v28",
-      "lastModified": "2024-09-04",
+      "version": "v29",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bH0z5jbs8qbts.ttf",
-        "200": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy1bG0z5jbs8qbts.ttf",
-        "300": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy4jG0z5jbs8qbts.ttf",
-        "500": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy-TG0z5jbs8qbts.ttf",
-        "600": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCywjB0z5jbs8qbts.ttf",
-        "700": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCyzHB0z5jbs8qbts.ttf",
-        "800": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy1bB0z5jbs8qbts.ttf",
-        "900": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy3_B0z5jbs8qbts.ttf",
-        "regular": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG0z5jbs8qbts.ttf"
+        "100": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bH0z5jbs8qbts.ttf",
+        "200": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy1bG0z5jbs8qbts.ttf",
+        "300": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy4jG0z5jbs8qbts.ttf",
+        "500": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy-TG0z5jbs8qbts.ttf",
+        "600": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCywjB0z5jbs8qbts.ttf",
+        "700": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCyzHB0z5jbs8qbts.ttf",
+        "800": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy1bB0z5jbs8qbts.ttf",
+        "900": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy3_B0z5jbs8qbts.ttf",
+        "regular": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG0z5jbs8qbts.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lexendzetta/v28/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG4z9pag.ttf"
+      "menu": "https://fonts.gstatic.com/s/lexendzetta/v29/ll8uK2KYXje7CdOFnEWcU8synQbuVYjYB3BCy9bG4z9pag.ttf"
     },
     {
       "family": "Libre Barcode 128",
@@ -18653,14 +18879,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v28",
-      "lastModified": "2024-08-12",
+      "version": "v29",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode128/v28/cIfnMbdUsUoiW3O_hVviCwVjuLtXeJ_A_gMk0izH.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode128/v29/cIfnMbdUsUoiW3O_hVviCwVjuLtXeJ_A_gMk0izH.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode128/v28/cIfnMbdUsUoiW3O_hVviCwVjuLtXeK_B9Ac.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode128/v29/cIfnMbdUsUoiW3O_hVviCwVjuLtXeK_B9Ac.ttf"
     },
     {
       "family": "Libre Barcode 128 Text",
@@ -18670,14 +18896,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v28",
-      "lastModified": "2024-08-12",
+      "version": "v29",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode128text/v28/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5cV3Y6M90w4k.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode128text/v29/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5cV3Y6M90w4k.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode128text/v28/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5QVzS7A.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode128text/v29/fdNv9tubt3ZEnz1Gu3I4-zppwZ9CWZ16Z0w5QVzS7A.ttf"
     },
     {
       "family": "Libre Barcode 39",
@@ -18687,14 +18913,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v21",
-      "lastModified": "2024-08-12",
+      "version": "v22",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode39/v21/-nFnOHM08vwC6h8Li1eQnP_AHzI2K_d709jy92k.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode39/v22/-nFnOHM08vwC6h8Li1eQnP_AHzI2K_d709jy92k.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode39/v21/-nFnOHM08vwC6h8Li1eQnP_AHzI2G_Zx1w.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode39/v22/-nFnOHM08vwC6h8Li1eQnP_AHzI2G_Zx1w.ttf"
     },
     {
       "family": "Libre Barcode 39 Extended",
@@ -18704,14 +18930,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v27",
-      "lastModified": "2024-08-12",
+      "version": "v28",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode39extended/v27/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgfNRCOZ1GOBw.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode39extended/v28/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgfNRCOZ1GOBw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode39extended/v27/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgTNVIPQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode39extended/v28/8At7Gt6_O5yNS0-K4Nf5U922qSzhJ3dUdfJpwNUgTNVIPQ.ttf"
     },
     {
       "family": "Libre Barcode 39 Extended Text",
@@ -18721,14 +18947,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v27",
-      "lastModified": "2024-08-12",
+      "version": "v28",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode39extendedtext/v27/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP68fLIiPopNNA.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode39extendedtext/v28/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP68fLIiPopNNA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode39extendedtext/v27/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP6Mfbgm.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode39extendedtext/v28/eLG1P_rwIgOiDA7yrs9LoKaYRVLQ1YldrrOnnL7xPO4jNP6Mfbgm.ttf"
     },
     {
       "family": "Libre Barcode 39 Text",
@@ -18738,14 +18964,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v28",
-      "lastModified": "2024-08-12",
+      "version": "v29",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcode39text/v28/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-031RRL-9rYaw.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcode39text/v29/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-031RRL-9rYaw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcode39text/v28/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-0H1B5P.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcode39text/v29/sJoa3KhViNKANw_E3LwoDXvs5Un0HQ1vT-0H1B5P.ttf"
     },
     {
       "family": "Libre Barcode EAN13 Text",
@@ -18755,14 +18981,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v21",
-      "lastModified": "2024-08-12",
+      "version": "v22",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/librebarcodeean13text/v21/wlpigxXFDU1_oCu9nfZytgIqSG0XRcJm_OQiB96PAGEki52WfA.ttf"
+        "regular": "https://fonts.gstatic.com/s/librebarcodeean13text/v22/wlpigxXFDU1_oCu9nfZytgIqSG0XRcJm_OQiB96PAGEki52WfA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/librebarcodeean13text/v21/wlpigxXFDU1_oCu9nfZytgIqSG0XRcJm_OQiB96_AWsg.ttf"
+      "menu": "https://fonts.gstatic.com/s/librebarcodeean13text/v22/wlpigxXFDU1_oCu9nfZytgIqSG0XRcJm_OQiB96_AWsg.ttf"
     },
     {
       "family": "Libre Baskerville",
@@ -19016,17 +19242,18 @@
         "italic"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/lindenhill/v24/-F61fjxoKSg9Yc3hZgO8ygFI7CwC009k.ttf",
-        "italic": "https://fonts.gstatic.com/s/lindenhill/v24/-F63fjxoKSg9Yc3hZgO8yjFK5igg1l9kn-s.ttf"
+        "regular": "https://fonts.gstatic.com/s/lindenhill/v25/-F61fjxoKSg9Yc3hZgO8ygFI7CwC009k.ttf",
+        "italic": "https://fonts.gstatic.com/s/lindenhill/v25/-F63fjxoKSg9Yc3hZgO8yjFK5igg1l9kn-s.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lindenhill/v24/-F61fjxoKSg9Yc3hZgO8yjFJ5ig.ttf"
+      "menu": "https://fonts.gstatic.com/s/lindenhill/v25/-F61fjxoKSg9Yc3hZgO8yjFJ5ig.ttf"
     },
     {
       "family": "Linefont",
@@ -19044,22 +19271,22 @@
       "subsets": [
         "latin"
       ],
-      "version": "v5",
-      "lastModified": "2024-08-12",
+      "version": "v8",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UNbu7tmdXux3U.ttf",
-        "200": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYwUMbu7tmdXux3U.ttf",
-        "300": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY9sMbu7tmdXux3U.ttf",
-        "500": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY7cMbu7tmdXux3U.ttf",
-        "600": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY1sLbu7tmdXux3U.ttf",
-        "700": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY2ILbu7tmdXux3U.ttf",
-        "800": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYwULbu7tmdXux3U.ttf",
-        "900": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYywLbu7tmdXux3U.ttf",
-        "regular": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UMbu7tmdXux3U.ttf"
+        "100": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UNbu7tmdXux3U.ttf",
+        "200": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYwUMbu7tmdXux3U.ttf",
+        "300": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY9sMbu7tmdXux3U.ttf",
+        "500": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY7cMbu7tmdXux3U.ttf",
+        "600": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY1sLbu7tmdXux3U.ttf",
+        "700": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY2ILbu7tmdXux3U.ttf",
+        "800": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYwULbu7tmdXux3U.ttf",
+        "900": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnYywLbu7tmdXux3U.ttf",
+        "regular": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UMbu7tmdXux3U.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/linefont/v5/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UMXu_nnQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/linefont/v8/dg4I_pzpoqcLKUIzVfFMh1TF2rkhli25jn7CKTTWSumsFuSnY4UMXu_nnQ.ttf"
     },
     {
       "family": "Lisu Bosa",
@@ -19109,6 +19336,25 @@
       "category": "serif",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/lisubosa/v2/3XFoErkv240fsdmJRJQflkHm.ttf"
+    },
+    {
+      "family": "Liter",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v3",
+      "lastModified": "2025-03-03",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/liter/v3/SLXGc1nX4GQ4d2ImRJqExst1.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/liter/v3/SLXGc1nX4GQ4d1InTp4.ttf"
     },
     {
       "family": "Literata",
@@ -19172,14 +19418,14 @@
         "chinese-simplified",
         "latin"
       ],
-      "version": "v20",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/liujianmaocao/v20/845DNN84HJrccNonurqXILGpvCOoferVKGWsUo8.ttf"
+        "regular": "https://fonts.gstatic.com/s/liujianmaocao/v23/845DNN84HJrccNonurqXILGpvCOoferVKGWsUo8.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/liujianmaocao/v20/845DNN84HJrccNonurqXILGpvCOoTevfLA.ttf"
+      "menu": "https://fonts.gstatic.com/s/liujianmaocao/v23/845DNN84HJrccNonurqXILGpvCOoTevfLA.ttf"
     },
     {
       "family": "Livvic",
@@ -19357,14 +19603,14 @@
         "chinese-simplified",
         "latin"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-12",
+      "version": "v20",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/longcang/v17/LYjAdGP8kkgoTec8zkRgrXArXN7HWQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/longcang/v20/LYjAdGP8kkgoTec8zkRgrXArXN7HWQ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/longcang/v17/LYjAdGP8kkgoTec8zkRQrHov.ttf"
+      "menu": "https://fonts.gstatic.com/s/longcang/v20/LYjAdGP8kkgoTec8zkRQrHov.ttf"
     },
     {
       "family": "Lora",
@@ -19446,16 +19692,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/lovedbytheking/v21/Gw6gwdP76VDVJNXerebZxUMeRXUF2PiNlXFu2R64.ttf"
+        "regular": "https://fonts.gstatic.com/s/lovedbytheking/v22/Gw6gwdP76VDVJNXerebZxUMeRXUF2PiNlXFu2R64.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/lovedbytheking/v21/Gw6gwdP76VDVJNXerebZxUMeRXUF2MiMn3U.ttf"
+      "menu": "https://fonts.gstatic.com/s/lovedbytheking/v22/Gw6gwdP76VDVJNXerebZxUMeRXUF2MiMn3U.ttf"
     },
     {
       "family": "Lovers Quarrel",
@@ -19482,16 +19729,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/luckiestguy/v22/_gP_1RrxsjcxVyin9l9n_j2RStR3qDpraA.ttf"
+        "regular": "https://fonts.gstatic.com/s/luckiestguy/v23/_gP_1RrxsjcxVyin9l9n_j2RStR3qDpraA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/luckiestguy/v22/_gP_1RrxsjcxVyin9l9n_j2hS95z.ttf"
+      "menu": "https://fonts.gstatic.com/s/luckiestguy/v23/_gP_1RrxsjcxVyin9l9n_j2hS95z.ttf"
     },
     {
       "family": "Lugrasimo",
@@ -19847,14 +20095,14 @@
         "chinese-simplified",
         "latin"
       ],
-      "version": "v10",
-      "lastModified": "2024-08-12",
+      "version": "v13",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXaRMTsDIRSfr0.ttf"
+        "regular": "https://fonts.gstatic.com/s/mashanzheng/v13/NaPecZTRCLxvwo41b4gvzkXaRMTsDIRSfr0.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mashanzheng/v10/NaPecZTRCLxvwo41b4gvzkXadMXmCA.ttf"
+      "menu": "https://fonts.gstatic.com/s/mashanzheng/v13/NaPecZTRCLxvwo41b4gvzkXadMXmCA.ttf"
     },
     {
       "family": "Macondo",
@@ -19969,16 +20217,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v29",
-      "lastModified": "2024-09-04",
+      "version": "v30",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/maidenorange/v29/kJE1BuIX7AUmhi2V4m08kb1XjOZdCZS8FY8.ttf"
+        "regular": "https://fonts.gstatic.com/s/maidenorange/v30/kJE1BuIX7AUmhi2V4m08kb1XjOZdCZS8FY8.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/maidenorange/v29/kJE1BuIX7AUmhi2V4m08kb1XvOdXDQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/maidenorange/v30/kJE1BuIX7AUmhi2V4m08kb1XvOdXDQ.ttf"
     },
     {
       "family": "Maitree",
@@ -20118,14 +20367,14 @@
         "sinhala",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-02-12",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/maname/v1/gNMFW3J8RpCx9my42FkGGI6q_Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/maname/v2/gNMFW3J8RpCx9my42FkGGI6q_Q.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/maname/v1/gNMFW3J8RpCx9myI2VMC.ttf"
+      "menu": "https://fonts.gstatic.com/s/maname/v2/gNMFW3J8RpCx9myI2VMC.ttf"
     },
     {
       "family": "Mandali",
@@ -20377,17 +20626,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/markazitext/v23/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtcaQT4MlBekmJLo.ttf",
-        "600": "https://fonts.gstatic.com/s/markazitext/v23/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtSqXT4MlBekmJLo.ttf",
-        "700": "https://fonts.gstatic.com/s/markazitext/v23/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtROXT4MlBekmJLo.ttf",
-        "regular": "https://fonts.gstatic.com/s/markazitext/v23/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQT4MlBekmJLo.ttf"
+        "500": "https://fonts.gstatic.com/s/markazitext/v26/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtcaQT4MlBekmJLo.ttf",
+        "600": "https://fonts.gstatic.com/s/markazitext/v26/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtSqXT4MlBekmJLo.ttf",
+        "700": "https://fonts.gstatic.com/s/markazitext/v26/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtROXT4MlBekmJLo.ttf",
+        "regular": "https://fonts.gstatic.com/s/markazitext/v26/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQT4MlBekmJLo.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/markazitext/v23/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQf4IvAQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/markazitext/v26/sykh-ydym6AtQaiEtX7yhqb_rV1k_81ZVYYZtfSQf4IvAQ.ttf"
     },
     {
       "family": "Marko One",
@@ -20593,14 +20842,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v3",
-      "lastModified": "2024-11-07",
+      "version": "v4",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/matemasie/v3/OD5BuMCN3ne3Gmr7dlL3rEq4DL6w2w.ttf"
+        "regular": "https://fonts.gstatic.com/s/matemasie/v4/OD5BuMCN3ne3Gmr7dlL3rEq4DL6w2w.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/matemasie/v3/OD5BuMCN3ne3Gmr7dlLHrUC8.ttf"
+      "menu": "https://fonts.gstatic.com/s/matemasie/v4/OD5BuMCN3ne3Gmr7dlLHrUC8.ttf"
     },
     {
       "family": "Material Icons",
@@ -20610,14 +20859,14 @@
       "subsets": [
         "latin"
       ],
-      "version": "v142",
-      "lastModified": "2024-08-12",
+      "version": "v143",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/materialicons/v142/flUhRq6tzZclQEJ-Vdg-IuiaDsNZIhI8tIHh.ttf"
+        "regular": "https://fonts.gstatic.com/s/materialicons/v143/flUhRq6tzZclQEJ-Vdg-IuiaDsNZIhI8tIHh.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialicons/v142/flUhRq6tzZclQEJ-Vdg-IuiaDvNYKBY.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialicons/v143/flUhRq6tzZclQEJ-Vdg-IuiaDvNYKBY.ttf"
     },
     {
       "family": "Material Icons Outlined",
@@ -20691,6 +20940,35 @@
       ]
     },
     {
+      "family": "Material Symbols",
+      "variants": [
+        "100",
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2025-03-20",
+      "files": {
+        "100": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVXEHuRbn3PT2vOA.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNV3EDuRbn3PT2vOA.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVAkDuRbn3PT2vOA.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVbkDuRbn3PT2vOA.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVgkfuRbn3PT2vOA.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVu0fuRbn3PT2vOA.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVXEDuRbn3PT2vOA.ttf"
+      },
+      "category": "monospace",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/materialsymbols/v2/d6kSkb-sS9m3-i1LgQNcsFOOuLQXvG559b5GLMxCWRtThFK5gn7xw7XblIl2peTfMb7ONaa2_wzcUHR1Ukiw2RYw2vadH3BFk0G4701x-cU0BaNVXEDeRLPz.ttf"
+    },
+    {
       "family": "Material Symbols Outlined",
       "variants": [
         "100",
@@ -20704,20 +20982,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v215",
-      "lastModified": "2024-11-01",
+      "version": "v232",
+      "lastModified": "2025-03-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeembd5zrTgt.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOembd5zrTgt.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOembd5zrTgt.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOembd5zrTgt.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-embd5zrTgt.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-embd5zrTgt.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOembd5zrTgt.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHeembd5zrTgt.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDAvHOembd5zrTgt.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDDxHOembd5zrTgt.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCdHOembd5zrTgt.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBxG-embd5zrTgt.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDBIG-embd5zrTgt.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOembd5zrTgt.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v215/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHNenZ9o.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolsoutlined/v232/kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHNenZ9o.ttf"
     },
     {
       "family": "Material Symbols Rounded",
@@ -20733,20 +21011,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v214",
-      "lastModified": "2024-11-01",
+      "version": "v232",
+      "lastModified": "2025-03-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxKJKJBjAa8.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxKJKJBjAa8.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxKJKJBjAa8.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxKJKJBjAa8.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxKJKJBjAa8.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxKJKJBjAa8.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxKJKJBjAa8.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIekXxKJKJBjAa8.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rAelXxKJKJBjAa8.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rNmlXxKJKJBjAa8.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rLWlXxKJKJBjAa8.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rFmiXxKJKJBjAa8.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rGCiXxKJKJBjAa8.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelXxKJKJBjAa8.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolsrounded/v214/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelbxODLA.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolsrounded/v232/syl0-zNym6YjUruM-QrEh7-nyTnjDwKNJ_190FjpZIvDmUSVOK7BDB_Qb9vUSzq3wzLK-P0J-V_Zs-QtQth3-jOcbTCVpeRL2w5rwZu2rIelbxODLA.ttf"
     },
     {
       "family": "Material Symbols Sharp",
@@ -20762,20 +21040,20 @@
       "subsets": [
         "latin"
       ],
-      "version": "v211",
-      "lastModified": "2024-11-01",
+      "version": "v228",
+      "lastModified": "2025-03-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCOJ1H7-knk.ttf",
-        "200": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCOJ1H7-knk.ttf",
-        "300": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCOJ1H7-knk.ttf",
-        "500": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCOJ1H7-knk.ttf",
-        "600": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCOJ1H7-knk.ttf",
-        "700": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCOJ1H7-knk.ttf",
-        "regular": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCOJ1H7-knk.ttf"
+        "100": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLozCOJ1H7-knk.ttf",
+        "200": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxMLojCOJ1H7-knk.ttf",
+        "300": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxPVojCOJ1H7-knk.ttf",
+        "500": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxO5ojCOJ1H7-knk.ttf",
+        "600": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNVpTCOJ1H7-knk.ttf",
+        "700": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxNspTCOJ1H7-knk.ttf",
+        "regular": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLojCOJ1H7-knk.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/materialsymbolssharp/v211/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLogCPLVU.ttf"
+      "menu": "https://fonts.gstatic.com/s/materialsymbolssharp/v228/gNNBW2J8Roq16WD5tFNRaeLQk6-SHQ_R00k4c2_whPnoY9ruReaU4bHmz74m0ZkGH-VBYe1x0TV6x4yFH8F-H5OdzEL3sVTgJtfbYxOLogCPLVU.ttf"
     },
     {
       "family": "Maven Pro",
@@ -20792,19 +21070,19 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v36",
-      "lastModified": "2024-09-04",
+      "version": "v39",
+      "lastModified": "2025-03-03",
       "files": {
-        "500": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Rf25nCpozp5GvU.ttf",
-        "600": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8fvx5nCpozp5GvU.ttf",
-        "700": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8cLx5nCpozp5GvU.ttf",
-        "800": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8aXx5nCpozp5GvU.ttf",
-        "900": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Yzx5nCpozp5GvU.ttf",
-        "regular": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX25nCpozp5GvU.ttf"
+        "500": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Rf25nCpozp5GvU.ttf",
+        "600": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8fvx5nCpozp5GvU.ttf",
+        "700": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8cLx5nCpozp5GvU.ttf",
+        "800": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8aXx5nCpozp5GvU.ttf",
+        "900": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8Yzx5nCpozp5GvU.ttf",
+        "regular": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX25nCpozp5GvU.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mavenpro/v36/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX21nGjpw.ttf"
+      "menu": "https://fonts.gstatic.com/s/mavenpro/v39/7Auup_AqnyWWAxW2Wk3swUz56MS91Eww8SX21nGjpw.ttf"
     },
     {
       "family": "McLaren",
@@ -20849,16 +21127,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/meddon/v24/kmK8ZqA2EgDNeHTZhBdB3y_Aow.ttf"
+        "regular": "https://fonts.gstatic.com/s/meddon/v25/kmK8ZqA2EgDNeHTZhBdB3y_Aow.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/meddon/v24/kmK8ZqA2EgDNeHTphR1F.ttf"
+      "menu": "https://fonts.gstatic.com/s/meddon/v25/kmK8ZqA2EgDNeHTphR1F.ttf"
     },
     {
       "family": "MedievalSharp",
@@ -20919,16 +21198,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/megrim/v16/46kulbz5WjvLqJZlbWXgd0RY1g.ttf"
+        "regular": "https://fonts.gstatic.com/s/megrim/v17/46kulbz5WjvLqJZlbWXgd0RY1g.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/megrim/v16/46kulbz5WjvLqJZVbG_k.ttf"
+      "menu": "https://fonts.gstatic.com/s/megrim/v17/46kulbz5WjvLqJZVbG_k.ttf"
     },
     {
       "family": "Meie Script",
@@ -21002,12 +21282,18 @@
       "family": "Merriweather",
       "variants": [
         "300",
-        "300italic",
         "regular",
-        "italic",
+        "500",
+        "600",
         "700",
-        "700italic",
+        "800",
         "900",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
         "900italic"
       ],
       "subsets": [
@@ -21017,21 +21303,27 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v30",
-      "lastModified": "2024-09-04",
+      "version": "v31",
+      "lastModified": "2025-03-05",
       "files": {
-        "300": "https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l521wRpX837pvjxPA.ttf",
-        "700": "https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l52xwNpX837pvjxPA.ttf",
-        "900": "https://fonts.gstatic.com/s/merriweather/v30/u-4n0qyriQwlOrhSvowK_l52_wFpX837pvjxPA.ttf",
-        "300italic": "https://fonts.gstatic.com/s/merriweather/v30/u-4l0qyriQwlOrhSvowK_l5-eR7lXcf_hP3hPGWH.ttf",
-        "regular": "https://fonts.gstatic.com/s/merriweather/v30/u-440qyriQwlOrhSvowK_l5OeyxNV-bnrw.ttf",
-        "italic": "https://fonts.gstatic.com/s/merriweather/v30/u-4m0qyriQwlOrhSvowK_l5-eSZJdeP3r-Ho.ttf",
-        "700italic": "https://fonts.gstatic.com/s/merriweather/v30/u-4l0qyriQwlOrhSvowK_l5-eR71Wsf_hP3hPGWH.ttf",
-        "900italic": "https://fonts.gstatic.com/s/merriweather/v30/u-4l0qyriQwlOrhSvowK_l5-eR7NWMf_hP3hPGWH.ttf"
+        "300": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDrgCcqE1f0KvXKYQ.ttf",
+        "500": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDr7CcqE1f0KvXKYQ.ttf",
+        "600": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDrACAqE1f0KvXKYQ.ttf",
+        "700": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDrOSAqE1f0KvXKYQ.ttf",
+        "800": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDrXiAqE1f0KvXKYQ.ttf",
+        "900": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDrdyAqE1f0KvXKYQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDr3icqE1f0KvXKYQ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmScUF3wCPDaYa_F.ttf",
+        "italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmTCUF3wCPDaYa_F.ttf",
+        "500italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmTwUF3wCPDaYa_F.ttf",
+        "600italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmQcV13wCPDaYa_F.ttf",
+        "700italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmQlV13wCPDaYa_F.ttf",
+        "800italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmRCV13wCPDaYa_F.ttf",
+        "900italic": "https://fonts.gstatic.com/s/merriweather/v31/u-4B0qyriQwlOrhSvowK_l5-eTxCVx0ZbwLvKH2Gk9hLmp0v5yA-xXPqCzLvPee1XYk_XSf-FmRrV13wCPDaYa_F.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/merriweather/v30/u-440qyriQwlOrhSvowK_l5-eiZJ.ttf"
+      "menu": "https://fonts.gstatic.com/s/merriweather/v31/u-4D0qyriQwlOrhSvowK_l5UcA6zuSYEqOzpPe3HOZJ5eX1WtLaQwmYiScCmDxhtNOKl8yDr3icaEl3w.ttf"
     },
     {
       "family": "Merriweather Sans",
@@ -21084,14 +21376,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v30",
-      "lastModified": "2024-08-12",
+      "version": "v31",
+      "lastModified": "2025-01-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/metal/v30/lW-wwjUJIXTo7i3nnoQAUdN2.ttf"
+        "regular": "https://fonts.gstatic.com/s/metal/v31/lW-wwjUJIXTo7i3nnoQAUdN2.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/metal/v30/lW-wwjUJIXTo7h3mlIA.ttf"
+      "menu": "https://fonts.gstatic.com/s/metal/v31/lW-wwjUJIXTo7h3mlIA.ttf"
     },
     {
       "family": "Metal Mania",
@@ -21177,14 +21469,14 @@
         "math",
         "symbols"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/micro5/v1/H4cnBX2MkcfEngTr0gYQ7LO5mqc.ttf"
+        "regular": "https://fonts.gstatic.com/s/micro5/v2/H4cnBX2MkcfEngTr0gYQ7LO5mqc.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/micro5/v1/H4cnBX2MkcfEngTr4gca6A.ttf"
+      "menu": "https://fonts.gstatic.com/s/micro5/v2/H4cnBX2MkcfEngTr4gca6A.ttf"
     },
     {
       "family": "Micro 5 Charted",
@@ -21197,14 +21489,14 @@
         "math",
         "symbols"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/micro5charted/v1/hESp6XxmPDtTtADZhn7oD_yrmxEGRUsJQAlbUA.ttf"
+        "regular": "https://fonts.gstatic.com/s/micro5charted/v2/hESp6XxmPDtTtADZhn7oD_yrmxEGRUsJQAlbUA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/micro5charted/v1/hESp6XxmPDtTtADZhn7oD_yrmxE2REEN.ttf"
+      "menu": "https://fonts.gstatic.com/s/micro5charted/v2/hESp6XxmPDtTtADZhn7oD_yrmxE2REEN.ttf"
     },
     {
       "family": "Milonga",
@@ -21289,14 +21581,14 @@
         "latin-ext",
         "lepcha"
       ],
-      "version": "v8",
-      "lastModified": "2023-09-13",
+      "version": "v9",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/mingzat/v8/0QIgMX5C-o-oWWyvBttkm_mv670.ttf"
+        "regular": "https://fonts.gstatic.com/s/mingzat/v9/0QIgMX5C-o-oWWyvBttkm_mv670.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mingzat/v8/0QIgMX5C-o-oWWyvNtpunw.ttf"
+      "menu": "https://fonts.gstatic.com/s/mingzat/v9/0QIgMX5C-o-oWWyvNtpunw.ttf"
     },
     {
       "family": "Miniver",
@@ -21353,17 +21645,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2025-01-23",
       "files": {
-        "500": "https://fonts.gstatic.com/s/mirza/v17/co3FmWlikiN5EtIpAeO4mafBomDi.ttf",
-        "600": "https://fonts.gstatic.com/s/mirza/v17/co3FmWlikiN5EtIFBuO4mafBomDi.ttf",
-        "700": "https://fonts.gstatic.com/s/mirza/v17/co3FmWlikiN5EtJhB-O4mafBomDi.ttf",
-        "regular": "https://fonts.gstatic.com/s/mirza/v17/co3ImWlikiN5EurdKMewsrvI.ttf"
+        "500": "https://fonts.gstatic.com/s/mirza/v18/co3FmWlikiN5EtIpAeO4mafBomDi.ttf",
+        "600": "https://fonts.gstatic.com/s/mirza/v18/co3FmWlikiN5EtIFBuO4mafBomDi.ttf",
+        "700": "https://fonts.gstatic.com/s/mirza/v18/co3FmWlikiN5EtJhB-O4mafBomDi.ttf",
+        "regular": "https://fonts.gstatic.com/s/mirza/v18/co3ImWlikiN5EurdKMewsrvI.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mirza/v17/co3ImWlikiN5EtrcIsM.ttf"
+      "menu": "https://fonts.gstatic.com/s/mirza/v18/co3ImWlikiN5EtrcIsM.ttf"
     },
     {
       "family": "Miss Fajardose",
@@ -21422,14 +21714,14 @@
         "japanese",
         "latin"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2025-01-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/mochiypopone/v10/QdVPSTA9Jh-gg-5XZP2UmU4O9kwwD3s6ZKAi.ttf"
+        "regular": "https://fonts.gstatic.com/s/mochiypopone/v11/QdVPSTA9Jh-gg-5XZP2UmU4O9kwwD3s6ZKAi.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mochiypopone/v10/QdVPSTA9Jh-gg-5XZP2UmU4O9nwxBX8.ttf"
+      "menu": "https://fonts.gstatic.com/s/mochiypopone/v11/QdVPSTA9Jh-gg-5XZP2UmU4O9nwxBX8.ttf"
     },
     {
       "family": "Mochiy Pop P One",
@@ -21440,14 +21732,14 @@
         "japanese",
         "latin"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2025-01-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/mochiypoppone/v10/Ktk2AKuPeY_td1-h9LayHYWCjAqyN4O3WYZB_sU.ttf"
+        "regular": "https://fonts.gstatic.com/s/mochiypoppone/v11/Ktk2AKuPeY_td1-h9LayHYWCjAqyN4O3WYZB_sU.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mochiypoppone/v10/Ktk2AKuPeY_td1-h9LayHYWCjAqyB4K9XQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/mochiypoppone/v11/Ktk2AKuPeY_td1-h9LayHYWCjAqyB4K9XQ.ttf"
     },
     {
       "family": "Modak",
@@ -21459,14 +21751,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2025-01-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/modak/v18/EJRYQgs1XtIEsnMH8BVZ76KU.ttf"
+        "regular": "https://fonts.gstatic.com/s/modak/v20/EJRYQgs1XtIEsnMH8BVZ76KU.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/modak/v18/EJRYQgs1XtIEskMG-hE.ttf"
+      "menu": "https://fonts.gstatic.com/s/modak/v20/EJRYQgs1XtIEskMG-hE.ttf"
     },
     {
       "family": "Modern Antiqua",
@@ -21527,14 +21819,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2025-01-23",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/mogra/v19/f0X40eSs8c95TBo4DvLmxtnG.ttf"
+        "regular": "https://fonts.gstatic.com/s/mogra/v21/f0X40eSs8c95TBo4DvLmxtnG.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mogra/v19/f0X40eSs8c95TCo5BPY.ttf"
+      "menu": "https://fonts.gstatic.com/s/mogra/v21/f0X40eSs8c95TCo5BPY.ttf"
     },
     {
       "family": "Mohave",
@@ -21554,23 +21846,23 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdif_HvCQopLSvBk.ttf",
-        "500": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdkv_HvCQopLSvBk.ttf",
-        "600": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdqf4HvCQopLSvBk.ttf",
-        "700": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdp74HvCQopLSvBk.ttf",
-        "regular": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdnn_HvCQopLSvBk.ttf",
-        "300italic": "https://fonts.gstatic.com/s/mohave/v9/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8qLOaprDXrBlSVw.ttf",
-        "italic": "https://fonts.gstatic.com/s/mohave/v9/7cH2v4ksjJunKqM_CdE36I75AIQkY7G89rOaprDXrBlSVw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/mohave/v9/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8xLOaprDXrBlSVw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/mohave/v9/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8KLSaprDXrBlSVw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/mohave/v9/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8EbSaprDXrBlSVw.ttf"
+        "300": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdif_HvCQopLSvBk.ttf",
+        "500": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdkv_HvCQopLSvBk.ttf",
+        "600": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdqf4HvCQopLSvBk.ttf",
+        "700": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdp74HvCQopLSvBk.ttf",
+        "regular": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdnn_HvCQopLSvBk.ttf",
+        "300italic": "https://fonts.gstatic.com/s/mohave/v12/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8qLOaprDXrBlSVw.ttf",
+        "italic": "https://fonts.gstatic.com/s/mohave/v12/7cH2v4ksjJunKqM_CdE36I75AIQkY7G89rOaprDXrBlSVw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/mohave/v12/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8xLOaprDXrBlSVw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/mohave/v12/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8KLSaprDXrBlSVw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/mohave/v12/7cH2v4ksjJunKqM_CdE36I75AIQkY7G8EbSaprDXrBlSVw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/mohave/v9/7cH0v4ksjJunKqMVAOPIMOeSmiojdnn_LvGapg.ttf"
+      "menu": "https://fonts.gstatic.com/s/mohave/v12/7cH0v4ksjJunKqMVAOPIMOeSmiojdnn_LvGapg.ttf"
     },
     {
       "family": "Moirai One",
@@ -21652,29 +21944,29 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v1",
-      "lastModified": "2024-11-05",
+      "version": "v3",
+      "lastModified": "2024-12-04",
       "files": {
-        "200": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
-        "300": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
-        "500": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
-        "600": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
-        "700": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
-        "800": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
-        "900": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
-        "regular": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
-        "200italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
-        "300italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
-        "italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
-        "500italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
-        "600italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
-        "700italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
-        "800italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
-        "900italic": "https://fonts.gstatic.com/s/monasans/v1/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
+        "200": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
+        "300": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
+        "500": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
+        "600": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
+        "700": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
+        "800": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
+        "900": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
+        "regular": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
+        "200italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
+        "italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
+        "500italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
+        "600italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
+        "700italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
+        "800italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
+        "900italic": "https://fonts.gstatic.com/s/monasans/v3/o-0kIpQmx24alC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/monasans/v1/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
+      "menu": "https://fonts.gstatic.com/s/monasans/v3/o-0mIpQmx24alC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
     },
     {
       "family": "Monda",
@@ -21689,17 +21981,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/monda/v17/TK3-WkYFABsmjuBtFuvTIFRAPpWsLXoMoWtGaA-Ijw.ttf",
-        "600": "https://fonts.gstatic.com/s/monda/v17/TK3-WkYFABsmjuBtFuvTIFRAPpWswX0MoWtGaA-Ijw.ttf",
-        "700": "https://fonts.gstatic.com/s/monda/v17/TK3-WkYFABsmjuBtFuvTIFRAPpWs-H0MoWtGaA-Ijw.ttf",
-        "regular": "https://fonts.gstatic.com/s/monda/v17/TK3-WkYFABsmjuBtFuvTIFRAPpWsH3oMoWtGaA-Ijw.ttf"
+        "500": "https://fonts.gstatic.com/s/monda/v18/TK3-WkYFABsmjuBtFuvTIFRAPpWsLXoMoWtGaA-Ijw.ttf",
+        "600": "https://fonts.gstatic.com/s/monda/v18/TK3-WkYFABsmjuBtFuvTIFRAPpWswX0MoWtGaA-Ijw.ttf",
+        "700": "https://fonts.gstatic.com/s/monda/v18/TK3-WkYFABsmjuBtFuvTIFRAPpWs-H0MoWtGaA-Ijw.ttf",
+        "regular": "https://fonts.gstatic.com/s/monda/v18/TK3-WkYFABsmjuBtFuvTIFRAPpWsH3oMoWtGaA-Ijw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/monda/v17/TK3-WkYFABsmjuBtFuvTIFRAPpWsH3o8oGFC.ttf"
+      "menu": "https://fonts.gstatic.com/s/monda/v18/TK3-WkYFABsmjuBtFuvTIFRAPpWsH3o8oGFC.ttf"
     },
     {
       "family": "Monofett",
@@ -21718,6 +22010,26 @@
       "category": "monospace",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/monofett/v23/mFTyWbofw6zc9NtnW73Tsxg.ttf"
+    },
+    {
+      "family": "Monomakh",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2025-02-12",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/monomakh/v1/Wnz4HAk3Yh_SC3FACTYdiArcPRKo.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/monomakh/v1/Wnz4HAk3Yh_SC3FACQYcgg4.ttf"
     },
     {
       "family": "Monomaniac One",
@@ -21744,16 +22056,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/monoton/v19/5h1aiZUrOngCibe4fkbBQ2S7FU8.ttf"
+        "regular": "https://fonts.gstatic.com/s/monoton/v20/5h1aiZUrOngCibe4fkbBQ2S7FU8.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/monoton/v19/5h1aiZUrOngCibe4TkfLRw.ttf"
+      "menu": "https://fonts.gstatic.com/s/monoton/v20/5h1aiZUrOngCibe4TkfLRw.ttf"
     },
     {
       "family": "Monsieur La Doulaise",
@@ -21806,20 +22119,20 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbE3P9Fs7bOSO7.ttf",
-        "200": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkBbEnP9Fs7bOSO7.ttf",
-        "300": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkCFEnP9Fs7bOSO7.ttf",
-        "500": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDpEnP9Fs7bOSO7.ttf",
-        "600": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkAFFXP9Fs7bOSO7.ttf",
-        "700": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkA8FXP9Fs7bOSO7.ttf",
-        "regular": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbEnP9Fs7bOSO7.ttf"
+        "100": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbE3P9Fs7bOSO7.ttf",
+        "200": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkBbEnP9Fs7bOSO7.ttf",
+        "300": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkCFEnP9Fs7bOSO7.ttf",
+        "500": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDpEnP9Fs7bOSO7.ttf",
+        "600": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkAFFXP9Fs7bOSO7.ttf",
+        "700": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkA8FXP9Fs7bOSO7.ttf",
+        "regular": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbEnP9Fs7bOSO7.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/montaguslab/v12/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbEkP8HMo.ttf"
+      "menu": "https://fonts.gstatic.com/s/montaguslab/v16/6qLhKZIQtB_zv0xUaXRDWkY_HXsphdLRZF40vm_jzR2jhk_n3T6ACkDbEkP8HMo.ttf"
     },
     {
       "family": "MonteCarlo",
@@ -21846,16 +22159,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/montez/v22/845ZNMk5GoGIX8lm1LDeSd-R_g.ttf"
+        "regular": "https://fonts.gstatic.com/s/montez/v23/845ZNMk5GoGIX8lm1LDeSd-R_g.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/montez/v22/845ZNMk5GoGIX8lW1bra.ttf"
+      "menu": "https://fonts.gstatic.com/s/montez/v23/845ZNMk5GoGIX8lW1bra.ttf"
     },
     {
       "family": "Montserrat",
@@ -21968,23 +22282,59 @@
       "menu": "https://fonts.gstatic.com/s/montserratalternates/v17/mFTvWacfw6zH4dthXcyms1lPpC8I_b0juU057afV.ttf"
     },
     {
-      "family": "Montserrat Subrayada",
+      "family": "Montserrat Underline",
       "variants": [
+        "100",
+        "200",
+        "300",
         "regular",
-        "700"
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "100italic",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
+        "900italic"
       ],
       "subsets": [
-        "latin"
+        "cyrillic",
+        "cyrillic-ext",
+        "latin",
+        "latin-ext",
+        "vietnamese"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2024-12-04",
       "files": {
-        "700": "https://fonts.gstatic.com/s/montserratsubrayada/v19/U9MM6c-o9H7PgjlTHThBnNHGVUORwteQQHe3TcMWg3j36Ebz.ttf",
-        "regular": "https://fonts.gstatic.com/s/montserratsubrayada/v19/U9MD6c-o9H7PgjlTHThBnNHGVUORwteQQE8LYuceqGT-.ttf"
+        "100": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5Wil8ubbffHtmMw.ttf",
+        "200": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F52ih8ubbffHtmMw.ttf",
+        "300": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5BCh8ubbffHtmMw.ttf",
+        "500": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5aCh8ubbffHtmMw.ttf",
+        "600": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5hC98ubbffHtmMw.ttf",
+        "700": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5vS98ubbffHtmMw.ttf",
+        "800": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F52i98ubbffHtmMw.ttf",
+        "900": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F58y98ubbffHtmMw.ttf",
+        "regular": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5Wih8ubbffHtmMw.ttf",
+        "100italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmuU-7zbXn52M1Mi.ttf",
+        "200italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmsU-rzbXn52M1Mi.ttf",
+        "300italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmvK-rzbXn52M1Mi.ttf",
+        "italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmuU-rzbXn52M1Mi.ttf",
+        "500italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmum-rzbXn52M1Mi.ttf",
+        "600italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmtK_bzbXn52M1Mi.ttf",
+        "700italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmtz_bzbXn52M1Mi.ttf",
+        "800italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskmsU_bzbXn52M1Mi.ttf",
+        "900italic": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTdWaYfw6zH4dthXcyms01NtC8I_7U5uS4r1ozd9EzeaWZskms9_bzbXn52M1Mi.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/montserratsubrayada/v19/U9MD6c-o9H7PgjlTHThBnNHGVUORwteQQH8KaOM.ttf"
+      "menu": "https://fonts.gstatic.com/s/montserratunderline/v2/mFTbWaYfw6zH4dthXcyms01NtC8I_7U5uQQi5HMFnSdEx2F5WihMuLzb.ttf"
     },
     {
       "family": "Moo Lah Lah",
@@ -22556,14 +22906,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v18",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/ntr/v15/RLpzK5Xy0ZjiGGhs5TA4bg.ttf"
+        "regular": "https://fonts.gstatic.com/s/ntr/v18/RLpzK5Xy0ZjiGGhs5TA4bg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ntr/v15/RLpzK5Xy0ZjSGWJo.ttf"
+      "menu": "https://fonts.gstatic.com/s/ntr/v18/RLpzK5Xy0ZjSGWJo.ttf"
     },
     {
       "family": "Nabla",
@@ -22577,14 +22927,14 @@
         "math",
         "vietnamese"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/nabla/v10/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRNRBUFFR_198.ttf"
+        "regular": "https://fonts.gstatic.com/s/nabla/v16/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRNRBUFFR_198.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nabla/v10/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRFeEA.ttf",
+      "menu": "https://fonts.gstatic.com/s/nabla/v16/j8_D6-LI0Lvpe7Makz5UhJt9C3uqg_X_75gyGS4jAxsNIjrRBRFeEA.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -22626,14 +22976,14 @@
         "korean",
         "latin"
       ],
-      "version": "v24",
-      "lastModified": "2024-11-07",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/nanumbrushscript/v24/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/nanumbrushscript/v25/wXK2E2wfpokopxzthSqPbcR5_gVaxazyjqBr1lO97Q.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanumbrushscript/v24/wXK2E2wfpokopxzthSqPbcR5_gVaxazCj6pv.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanumbrushscript/v25/wXK2E2wfpokopxzthSqPbcR5_gVaxazCj6pv.ttf"
     },
     {
       "family": "Nanum Gothic",
@@ -22646,16 +22996,16 @@
         "korean",
         "latin"
       ],
-      "version": "v23",
-      "lastModified": "2024-08-12",
+      "version": "v26",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/nanumgothic/v23/PN_oRfi-oW3hYwmKDpxS7F_LQv37zlEn14YEUQ.ttf",
-        "800": "https://fonts.gstatic.com/s/nanumgothic/v23/PN_oRfi-oW3hYwmKDpxS7F_LXv77zlEn14YEUQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/nanumgothic/v23/PN_3Rfi-oW3hYwmKDpxS7F_z_tLfxno73g.ttf"
+        "700": "https://fonts.gstatic.com/s/nanumgothic/v26/PN_oRfi-oW3hYwmKDpxS7F_LQv37zlEn14YEUQ.ttf",
+        "800": "https://fonts.gstatic.com/s/nanumgothic/v26/PN_oRfi-oW3hYwmKDpxS7F_LXv77zlEn14YEUQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/nanumgothic/v26/PN_3Rfi-oW3hYwmKDpxS7F_z_tLfxno73g.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanumgothic/v23/PN_3Rfi-oW3hYwmKDpxS7F_D_9jb.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanumgothic/v26/PN_3Rfi-oW3hYwmKDpxS7F_D_9jb.ttf"
     },
     {
       "family": "Nanum Gothic Coding",
@@ -22667,15 +23017,15 @@
         "korean",
         "latin"
       ],
-      "version": "v21",
-      "lastModified": "2024-08-12",
+      "version": "v26",
+      "lastModified": "2024-12-04",
       "files": {
-        "700": "https://fonts.gstatic.com/s/nanumgothiccoding/v21/8QIYdjzHisX_8vv59_xMxtPFW4IXROws8xgecsV88t5V9r4.ttf",
-        "regular": "https://fonts.gstatic.com/s/nanumgothiccoding/v21/8QIVdjzHisX_8vv59_xMxtPFW4IXROwsy6QxVs1X7tc.ttf"
+        "700": "https://fonts.gstatic.com/s/nanumgothiccoding/v26/8QIYdjzHisX_8vv59_xMxtPFW4IXROws8xgecsV88t5V9r4.ttf",
+        "regular": "https://fonts.gstatic.com/s/nanumgothiccoding/v26/8QIVdjzHisX_8vv59_xMxtPFW4IXROwsy6QxVs1X7tc.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanumgothiccoding/v21/8QIVdjzHisX_8vv59_xMxtPFW4IXROws-6U7Ug.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanumgothiccoding/v26/8QIVdjzHisX_8vv59_xMxtPFW4IXROws-6U7Ug.ttf"
     },
     {
       "family": "Nanum Myeongjo",
@@ -22688,16 +23038,16 @@
         "korean",
         "latin"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v30",
+      "lastModified": "2025-03-18",
       "files": {
-        "700": "https://fonts.gstatic.com/s/nanummyeongjo/v22/9Bty3DZF0dXLMZlywRbVRNhxy2pXV1A0pfCs5Kos.ttf",
-        "800": "https://fonts.gstatic.com/s/nanummyeongjo/v22/9Bty3DZF0dXLMZlywRbVRNhxy2pLVFA0pfCs5Kos.ttf",
-        "regular": "https://fonts.gstatic.com/s/nanummyeongjo/v22/9Btx3DZF0dXLMZlywRbVRNhxy1LreHQ8juyl.ttf"
+        "700": "https://fonts.gstatic.com/s/nanummyeongjo/v30/9Bty3DZF0dXLMZlywRbVRNhxy2pXV1A0pfCs5Kos.ttf",
+        "800": "https://fonts.gstatic.com/s/nanummyeongjo/v30/9Bty3DZF0dXLMZlywRbVRNhxy2pLVFA0pfCs5Kos.ttf",
+        "regular": "https://fonts.gstatic.com/s/nanummyeongjo/v30/9Btx3DZF0dXLMZlywRbVRNhxy1LreHQ8juyl.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanummyeongjo/v22/9Btx3DZF0dXLMZlywRbVRNhxy2LqcnA.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanummyeongjo/v30/9Btx3DZF0dXLMZlywRbVRNhxy2LqcnA.ttf"
     },
     {
       "family": "Nanum Pen Script",
@@ -22708,14 +23058,14 @@
         "korean",
         "latin"
       ],
-      "version": "v19",
-      "lastModified": "2024-08-12",
+      "version": "v25",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/nanumpenscript/v19/daaDSSYiLGqEal3MvdA_FOL_3FkN2z7-aMFCcTU.ttf"
+        "regular": "https://fonts.gstatic.com/s/nanumpenscript/v25/daaDSSYiLGqEal3MvdA_FOL_3FkN2z7-aMFCcTU.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nanumpenscript/v19/daaDSSYiLGqEal3MvdA_FOL_3FkN6z_0bA.ttf"
+      "menu": "https://fonts.gstatic.com/s/nanumpenscript/v25/daaDSSYiLGqEal3MvdA_FOL_3FkN6z_0bA.ttf"
     },
     {
       "family": "Narnoor",
@@ -22875,14 +23225,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/newtegomin/v11/SLXMc1fV7Gd9USdBAfPlqfN0Q3ptkDMN.ttf"
+        "regular": "https://fonts.gstatic.com/s/newtegomin/v12/SLXMc1fV7Gd9USdBAfPlqfN0Q3ptkDMN.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/newtegomin/v11/SLXMc1fV7Gd9USdBAfPlqcN1SX4.ttf"
+      "menu": "https://fonts.gstatic.com/s/newtegomin/v12/SLXMc1fV7Gd9USdBAfPlqcN1SX4.ttf"
     },
     {
       "family": "News Cycle",
@@ -22927,27 +23277,27 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438w-I_ADOxEPjCggA.ttf",
-        "300": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wJo_ADOxEPjCggA.ttf",
-        "500": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wSo_ADOxEPjCggA.ttf",
-        "600": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wpojADOxEPjCggA.ttf",
-        "700": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wn4jADOxEPjCggA.ttf",
-        "800": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438w-IjADOxEPjCggA.ttf",
-        "regular": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438weI_ADOxEPjCggA.ttf",
-        "200italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMyoT-ZAHDWwgECi.ttf",
-        "300italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMx2T-ZAHDWwgECi.ttf",
-        "italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMwoT-ZAHDWwgECi.ttf",
-        "500italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMwaT-ZAHDWwgECi.ttf",
-        "600italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMz2SOZAHDWwgECi.ttf",
-        "700italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMzPSOZAHDWwgECi.ttf",
-        "800italic": "https://fonts.gstatic.com/s/newsreader/v20/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMyoSOZAHDWwgECi.ttf"
+        "200": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438w-I_ADOxEPjCggA.ttf",
+        "300": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wJo_ADOxEPjCggA.ttf",
+        "500": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wSo_ADOxEPjCggA.ttf",
+        "600": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wpojADOxEPjCggA.ttf",
+        "700": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438wn4jADOxEPjCggA.ttf",
+        "800": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438w-IjADOxEPjCggA.ttf",
+        "regular": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438weI_ADOxEPjCggA.ttf",
+        "200italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMyoT-ZAHDWwgECi.ttf",
+        "300italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMx2T-ZAHDWwgECi.ttf",
+        "italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMwoT-ZAHDWwgECi.ttf",
+        "500italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMwaT-ZAHDWwgECi.ttf",
+        "600italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMz2SOZAHDWwgECi.ttf",
+        "700italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMzPSOZAHDWwgECi.ttf",
+        "800italic": "https://fonts.gstatic.com/s/newsreader/v25/cY9kfjOCX1hbuyalUrK439vogqC9yFZCYg7oRZaLP4obnf7fTXglsMyoSOZAHDWwgECi.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/newsreader/v20/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438weI_wDeZA.ttf"
+      "menu": "https://fonts.gstatic.com/s/newsreader/v25/cY9qfjOCX1hbuyalUrK49dLac06G1ZGsZBtoBCzBDXXD9JVF438weI_wDeZA.ttf"
     },
     {
       "family": "Niconne",
@@ -23067,18 +23417,18 @@
         "khmer",
         "latin"
       ],
-      "version": "v31",
-      "lastModified": "2024-08-12",
+      "version": "v32",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/nokora/v31/hYkKPuwgTubzaWxoXzALgPNw8QZN.ttf",
-        "300": "https://fonts.gstatic.com/s/nokora/v31/hYkLPuwgTubzaWxolxIrqt18-B9Uuw.ttf",
-        "700": "https://fonts.gstatic.com/s/nokora/v31/hYkLPuwgTubzaWxohxUrqt18-B9Uuw.ttf",
-        "900": "https://fonts.gstatic.com/s/nokora/v31/hYkLPuwgTubzaWxovxcrqt18-B9Uuw.ttf",
-        "regular": "https://fonts.gstatic.com/s/nokora/v31/hYkIPuwgTubzaWxQOzoPovZg8Q.ttf"
+        "100": "https://fonts.gstatic.com/s/nokora/v32/hYkKPuwgTubzaWxoXzALgPNw8QZN.ttf",
+        "300": "https://fonts.gstatic.com/s/nokora/v32/hYkLPuwgTubzaWxolxIrqt18-B9Uuw.ttf",
+        "700": "https://fonts.gstatic.com/s/nokora/v32/hYkLPuwgTubzaWxohxUrqt18-B9Uuw.ttf",
+        "900": "https://fonts.gstatic.com/s/nokora/v32/hYkLPuwgTubzaWxovxcrqt18-B9Uuw.ttf",
+        "regular": "https://fonts.gstatic.com/s/nokora/v32/hYkIPuwgTubzaWxQOzoPovZg8Q.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nokora/v31/hYkIPuwgTubzaWxgOjAL.ttf"
+      "menu": "https://fonts.gstatic.com/s/nokora/v32/hYkIPuwgTubzaWxgOjAL.ttf"
     },
     {
       "family": "Norican",
@@ -23183,14 +23533,14 @@
       "subsets": [
         "emoji"
       ],
-      "version": "v32",
-      "lastModified": "2024-09-03",
+      "version": "v34",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notocoloremoji/v32/Yq6P-KqIXTD0t4D9z1ESnKM3-HpFab5s79iz64w.ttf"
+        "regular": "https://fonts.gstatic.com/s/notocoloremoji/v34/Yq6P-KqIXTD0t4D9z1ESnKM3-HpFab5s79iz64w.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notocoloremoji/v32/Yq6P-KqIXTD0t4D9z1ESnKM3-HpFWb9m6w.ttf",
+      "menu": "https://fonts.gstatic.com/s/notocoloremoji/v34/Yq6P-KqIXTD0t4D9z1ESnKM3-HpFWb9m6w.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -23208,18 +23558,18 @@
       "subsets": [
         "emoji"
       ],
-      "version": "v51",
-      "lastModified": "2024-09-03",
+      "version": "v53",
+      "lastModified": "2024-11-26",
       "files": {
-        "300": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-FGJCMY.ttf",
-        "500": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-Z0jwvS-FGJCMY.ttf",
-        "600": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob911TwvS-FGJCMY.ttf",
-        "700": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-FGJCMY.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-FGJCMY.ttf"
+        "300": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob_10jwvS-FGJCMY.ttf",
+        "500": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-Z0jwvS-FGJCMY.ttf",
+        "600": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob911TwvS-FGJCMY.ttf",
+        "700": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob9M1TwvS-FGJCMY.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0jwvS-FGJCMY.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoemoji/v51/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0gwuQeU.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoemoji/v53/bMrnmSyK7YY-MEu6aWjPDs-ar6uWaGWuob-r0gwuQeU.ttf"
     },
     {
       "family": "Noto Kufi Arabic",
@@ -23397,31 +23747,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v37",
-      "lastModified": "2024-11-07",
+      "version": "v39",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9At9d41P6zHtY.ttf",
-        "200": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
-        "300": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
-        "500": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
-        "600": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
-        "700": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
-        "800": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
-        "900": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDcf6VfYyWtY1rI.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
-        "italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notosans/v37/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
+        "100": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9At9d41P6zHtY.ttf",
+        "200": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9A99d41P6zHtY.ttf",
+        "300": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyCjA99d41P6zHtY.ttf",
+        "500": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyDPA99d41P6zHtY.ttf",
+        "600": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAjBN9d41P6zHtY.ttf",
+        "700": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyAaBN9d41P6zHtY.ttf",
+        "800": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyB9BN9d41P6zHtY.ttf",
+        "900": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyBUBN9d41P6zHtY.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A99d41P6zHtY.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDcf6VfYyWtY1rI.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLce6VfYyWtY1rI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QGke6VfYyWtY1rI.ttf",
+        "italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QDce6VfYyWtY1rI.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QAUe6VfYyWtY1rI.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QOkZ6VfYyWtY1rI.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QNAZ6VfYyWtY1rI.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QLcZ6VfYyWtY1rI.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notosans/v39/o-0kIpQlx3QUlC5A4PNr4C5OaxRsfNNlKbCePevHtVtX57DGjDU1QJ4Z6VfYyWtY1rI.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosans/v37/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosans/v39/o-0mIpQlx3QUlC5A4PNB6Ryti20_6n1iPHjcz6L1SoM-jCpoiyD9A-9c6Vc.ttf"
     },
     {
       "family": "Noto Sans Adlam",
@@ -23436,17 +23786,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2023-09-14",
+      "version": "v26",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/notosansadlam/v22/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufkn0TGnBZLwhuvk.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansadlam/v22/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufqXzTGnBZLwhuvk.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansadlam/v22/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufpzzTGnBZLwhuvk.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansadlam/v22/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufnv0TGnBZLwhuvk.ttf"
+        "500": "https://fonts.gstatic.com/s/notosansadlam/v26/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufkn0TGnBZLwhuvk.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansadlam/v26/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufqXzTGnBZLwhuvk.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansadlam/v26/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufpzzTGnBZLwhuvk.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansadlam/v26/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufnv0TGnBZLwhuvk.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansadlam/v22/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufnv0fGjLYA.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansadlam/v26/neIczCCpqp0s5pPusPamd81eMfjPonvqdbYxxpgufnv0fGjLYA.ttf"
     },
     {
       "family": "Noto Sans Adlam Unjoined",
@@ -23506,24 +23856,28 @@
         "900"
       ],
       "subsets": [
-        "arabic"
+        "arabic",
+        "latin",
+        "latin-ext",
+        "math",
+        "symbols"
       ],
-      "version": "v18",
-      "lastModified": "2022-06-01",
+      "version": "v29",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyG2vu3CBFQLaig.ttf",
-        "200": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfSGyvu3CBFQLaig.ttf",
-        "300": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCflmyvu3CBFQLaig.ttf",
-        "500": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCf-myvu3CBFQLaig.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfFmuvu3CBFQLaig.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfL2uvu3CBFQLaig.ttf",
-        "800": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfSGuvu3CBFQLaig.ttf",
-        "900": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfYWuvu3CBFQLaig.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyGyvu3CBFQLaig.ttf"
+        "100": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyG2vu3CBFQLaig.ttf",
+        "200": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfSGyvu3CBFQLaig.ttf",
+        "300": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCflmyvu3CBFQLaig.ttf",
+        "500": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCf-myvu3CBFQLaig.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfFmuvu3CBFQLaig.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfL2uvu3CBFQLaig.ttf",
+        "800": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfSGuvu3CBFQLaig.ttf",
+        "900": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfYWuvu3CBFQLaig.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyGyvu3CBFQLaig.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansarabic/v18/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyGyfunqF.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansarabic/v29/nwpxtLGrOAZMl5nJ_wfgRg3DrWFZWsnVBJ_sS6tlqHHFlhQ5l3sQWIHPqzCfyGyfunqF.ttf"
     },
     {
       "family": "Noto Sans Armenian",
@@ -23592,17 +23946,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2023-05-02",
+      "version": "v26",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/notosansbalinese/v24/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov4XdhE5Vd222PPY.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansbalinese/v24/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov2nahE5Vd222PPY.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansbalinese/v24/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov1DahE5Vd222PPY.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansbalinese/v24/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov7fdhE5Vd222PPY.ttf"
+        "500": "https://fonts.gstatic.com/s/notosansbalinese/v26/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov4XdhE5Vd222PPY.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansbalinese/v26/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov2nahE5Vd222PPY.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansbalinese/v26/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov1DahE5Vd222PPY.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansbalinese/v26/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov7fdhE5Vd222PPY.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansbalinese/v24/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov7fdtE9fcw.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansbalinese/v26/NaPwcYvSBuhTirw6IaFn6UrRDaqje-lpbbRtYf-Fwu2Ov7fdtE9fcw.ttf"
     },
     {
       "family": "Noto Sans Bamum",
@@ -23691,22 +24045,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2022-09-22",
+      "version": "v26",
+      "lastModified": "2024-11-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolKudCk8izI0lc.ttf",
-        "200": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsglLudCk8izI0lc.ttf",
-        "300": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmstdLudCk8izI0lc.ttf",
-        "500": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsrtLudCk8izI0lc.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsldMudCk8izI0lc.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6Kmsm5MudCk8izI0lc.ttf",
-        "800": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsglMudCk8izI0lc.ttf",
-        "900": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsiBMudCk8izI0lc.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolLudCk8izI0lc.ttf"
+        "100": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolKudCk8izI0lc.ttf",
+        "200": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsglLudCk8izI0lc.ttf",
+        "300": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmstdLudCk8izI0lc.ttf",
+        "500": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsrtLudCk8izI0lc.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsldMudCk8izI0lc.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6Kmsm5MudCk8izI0lc.ttf",
+        "800": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsglMudCk8izI0lc.ttf",
+        "900": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsiBMudCk8izI0lc.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolLudCk8izI0lc.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansbengali/v20/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolLidGu9g.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansbengali/v26/Cn-SJsCGWQxOjaGwMQ6fIiMywrNJIky6nvd8BjzVMvJx2mcSPVFpVEqE-6KmsolLidGu9g.ttf"
     },
     {
       "family": "Noto Sans Bhaiksuki",
@@ -23806,22 +24160,22 @@
         "math",
         "symbols"
       ],
-      "version": "v26",
-      "lastModified": "2024-05-02",
+      "version": "v27",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLj_yAsg0q0uhQ.ttf",
-        "200": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig2Ln_yAsg0q0uhQ.ttf",
-        "300": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigBrn_yAsg0q0uhQ.ttf",
-        "500": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigarn_yAsg0q0uhQ.ttf",
-        "600": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzighr7_yAsg0q0uhQ.ttf",
-        "700": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigv77_yAsg0q0uhQ.ttf",
-        "800": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig2L7_yAsg0q0uhQ.ttf",
-        "900": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig8b7_yAsg0q0uhQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLn_yAsg0q0uhQ.ttf"
+        "100": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLj_yAsg0q0uhQ.ttf",
+        "200": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig2Ln_yAsg0q0uhQ.ttf",
+        "300": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigBrn_yAsg0q0uhQ.ttf",
+        "500": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigarn_yAsg0q0uhQ.ttf",
+        "600": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzighr7_yAsg0q0uhQ.ttf",
+        "700": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigv77_yAsg0q0uhQ.ttf",
+        "800": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig2L7_yAsg0q0uhQ.ttf",
+        "900": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzig8b7_yAsg0q0uhQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLn_yAsg0q0uhQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v26/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLnPyQEk.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanscanadianaboriginal/v27/4C_TLjTuEqPj-8J01CwaGkiZ9os0iGVkezM1mUT-j_Lmlzda6uH_nnX1bzigWLnPyQEk.ttf"
     },
     {
       "family": "Noto Sans Carian",
@@ -23898,22 +24252,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v31",
-      "lastModified": "2024-07-30",
+      "version": "v32",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcER0cv7GykboaLg.ttf",
-        "200": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfckRwcv7GykboaLg.ttf",
-        "300": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcTxwcv7GykboaLg.ttf",
-        "500": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcIxwcv7GykboaLg.ttf",
-        "600": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfczxscv7GykboaLg.ttf",
-        "700": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfc9hscv7GykboaLg.ttf",
-        "800": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfckRscv7GykboaLg.ttf",
-        "900": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcuBscv7GykboaLg.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcERwcv7GykboaLg.ttf"
+        "100": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcER0cv7GykboaLg.ttf",
+        "200": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfckRwcv7GykboaLg.ttf",
+        "300": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcTxwcv7GykboaLg.ttf",
+        "500": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcIxwcv7GykboaLg.ttf",
+        "600": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfczxscv7GykboaLg.ttf",
+        "700": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfc9hscv7GykboaLg.ttf",
+        "800": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfckRscv7GykboaLg.ttf",
+        "900": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcuBscv7GykboaLg.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcERwcv7GykboaLg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanscham/v31/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcERwsvru2.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanscham/v32/pe06MIySN5pO62Z5YkFyQb_bbuRhe6D4yip43qfcERwsvru2.ttf"
     },
     {
       "family": "Noto Sans Cherokee",
@@ -24132,31 +24486,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v26",
-      "lastModified": "2023-09-14",
+      "version": "v27",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cLVTGQ2iHrvWM.ttf",
-        "200": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp__cKVTGQ2iHrvWM.ttf",
-        "300": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_ykKVTGQ2iHrvWM.ttf",
-        "500": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_0UKVTGQ2iHrvWM.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_6kNVTGQ2iHrvWM.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_5ANVTGQ2iHrvWM.ttf",
-        "800": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp__cNVTGQ2iHrvWM.ttf",
-        "900": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_94NVTGQ2iHrvWM.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cKVTGQ2iHrvWM.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JvXOa3gPurWM9uQ.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JPXKa3gPurWM9uQ.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9J43Ka3gPurWM9uQ.ttf",
-        "italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JvXKa3gPurWM9uQ.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9Jj3Ka3gPurWM9uQ.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JY3Wa3gPurWM9uQ.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JWnWa3gPurWM9uQ.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JPXWa3gPurWM9uQ.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JFHWa3gPurWM9uQ.ttf"
+        "100": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cLVTGQ2iHrvWM.ttf",
+        "200": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp__cKVTGQ2iHrvWM.ttf",
+        "300": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_ykKVTGQ2iHrvWM.ttf",
+        "500": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_0UKVTGQ2iHrvWM.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_6kNVTGQ2iHrvWM.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_5ANVTGQ2iHrvWM.ttf",
+        "800": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp__cNVTGQ2iHrvWM.ttf",
+        "900": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_94NVTGQ2iHrvWM.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cKVTGQ2iHrvWM.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JvXOa3gPurWM9uQ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JPXKa3gPurWM9uQ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9J43Ka3gPurWM9uQ.ttf",
+        "italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JvXKa3gPurWM9uQ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9Jj3Ka3gPurWM9uQ.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JY3Wa3gPurWM9uQ.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JWnWa3gPurWM9uQ.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JPXWa3gPurWM9uQ.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpZK4fy6r6tOBEJg0IAKzqdFZVZxrktbnDB5UzBIup9PwAcHtEsOFNBZqyu6r9JFHWa3gPurWM9uQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansdisplay/v26/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cKZTCa3g.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansdisplay/v27/RLpbK4fy6r6tOBEJg0IAKzqdFZVZxpMkXJMhnB9XjO1o90LuV-PT4Doq_AKp_3cKZTCa3g.ttf"
     },
     {
       "family": "Noto Sans Duployan",
@@ -24450,22 +24804,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v26",
-      "lastModified": "2023-04-27",
+      "version": "v28",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1Oe3bxZ_trdp7h.ttf",
-        "200": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3OenbxZ_trdp7h.ttf",
-        "300": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG0QenbxZ_trdp7h.ttf",
-        "500": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG18enbxZ_trdp7h.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG2QfXbxZ_trdp7h.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG2pfXbxZ_trdp7h.ttf",
-        "800": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3OfXbxZ_trdp7h.ttf",
-        "900": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3nfXbxZ_trdp7h.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1OenbxZ_trdp7h.ttf"
+        "100": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1Oe3bxZ_trdp7h.ttf",
+        "200": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3OenbxZ_trdp7h.ttf",
+        "300": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG0QenbxZ_trdp7h.ttf",
+        "500": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG18enbxZ_trdp7h.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG2QfXbxZ_trdp7h.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG2pfXbxZ_trdp7h.ttf",
+        "800": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3OfXbxZ_trdp7h.ttf",
+        "900": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG3nfXbxZ_trdp7h.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1OenbxZ_trdp7h.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansgurmukhi/v26/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1Oekbwbf8.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansgurmukhi/v28/w8g9H3EvQP81sInb43inmyN9zZ7hb7ATbSWo4q8dJ74a3cVrYFQ_bogT0-gPeG1Oekbwbf8.ttf"
     },
     {
       "family": "Noto Sans HK",
@@ -25361,17 +25715,17 @@
         "latin-ext",
         "medefaidrin"
       ],
-      "version": "v23",
-      "lastModified": "2023-09-14",
+      "version": "v28",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/notosansmedefaidrin/v23/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmHjWlT318e5A3rw.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansmedefaidrin/v23/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmJTRlT318e5A3rw.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansmedefaidrin/v23/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmK3RlT318e5A3rw.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansmedefaidrin/v23/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmErWlT318e5A3rw.ttf"
+        "500": "https://fonts.gstatic.com/s/notosansmedefaidrin/v28/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmHjWlT318e5A3rw.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansmedefaidrin/v28/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmJTRlT318e5A3rw.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansmedefaidrin/v28/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmK3RlT318e5A3rw.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansmedefaidrin/v28/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmErWlT318e5A3rw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansmedefaidrin/v23/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmErWpTz_9Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansmedefaidrin/v28/WwkzxOq6Dk-wranENynkfeVsNbRZtbOIdLb1exeM4ZeuabBfmErWpTz_9Q.ttf"
     },
     {
       "family": "Noto Sans Meetei Mayek",
@@ -25477,14 +25831,14 @@
         "latin-ext",
         "modi"
       ],
-      "version": "v23",
-      "lastModified": "2023-09-27",
+      "version": "v24",
+      "lastModified": "2025-03-11",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notosansmodi/v23/pe03MIySN5pO62Z5YkFyT7jeav5qWVAgVol-.ttf"
+        "regular": "https://fonts.gstatic.com/s/notosansmodi/v24/pe03MIySN5pO62Z5YkFyT7jeav5qWVAgVol-.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansmodi/v23/pe03MIySN5pO62Z5YkFyT7jeas5rU1Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansmodi/v24/pe03MIySN5pO62Z5YkFyT7jeas5rU1Q.ttf"
     },
     {
       "family": "Noto Sans Mongolian",
@@ -25529,22 +25883,22 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v30",
-      "lastModified": "2023-10-25",
+      "version": "v32",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNI49rXVEQQL8Y.ttf",
-        "200": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_NNJ49rXVEQQL8Y.ttf",
-        "300": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_A1J49rXVEQQL8Y.ttf",
-        "500": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_GFJ49rXVEQQL8Y.ttf",
-        "600": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_I1O49rXVEQQL8Y.ttf",
-        "700": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_LRO49rXVEQQL8Y.ttf",
-        "800": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_NNO49rXVEQQL8Y.ttf",
-        "900": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_PpO49rXVEQQL8Y.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNJ49rXVEQQL8Y.ttf"
+        "100": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNI49rXVEQQL8Y.ttf",
+        "200": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_NNJ49rXVEQQL8Y.ttf",
+        "300": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_A1J49rXVEQQL8Y.ttf",
+        "500": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_GFJ49rXVEQQL8Y.ttf",
+        "600": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_I1O49rXVEQQL8Y.ttf",
+        "700": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_LRO49rXVEQQL8Y.ttf",
+        "800": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_NNO49rXVEQQL8Y.ttf",
+        "900": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_PpO49rXVEQQL8Y.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNJ49rXVEQQL8Y.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansmono/v30/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNJ09vdUA.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansmono/v32/BngrUXNETWXI6LwhGYvaxZikqZqK6fBq6kPvUce2oAZcdthSBUsYck4-_FNJ09vdUA.ttf"
     },
     {
       "family": "Noto Sans Mro",
@@ -26115,21 +26469,25 @@
       "menu": "https://fonts.gstatic.com/s/notosanspaucinhau/v20/x3d-cl3IZKmUqiMg_9wBLLtzl22EayN7ehItjU-u.ttf"
     },
     {
-      "family": "Noto Sans Phags Pa",
+      "family": "Noto Sans PhagsPa",
       "variants": [
         "regular"
       ],
       "subsets": [
-        "phags-pa"
+        "latin",
+        "latin-ext",
+        "math",
+        "phags-pa",
+        "symbols"
       ],
-      "version": "v15",
-      "lastModified": "2022-05-10",
+      "version": "v23",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notosansphagspa/v15/pxiZyoo6v8ZYyWh5WuPeJzMkd4SrGChkqkSsrvNXiA.ttf"
+        "regular": "https://fonts.gstatic.com/s/notosansphagspa/v23/XLY8IYr5bJNDGYxPGjyYbaEjwQR-LFlsYMYHGGeT.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosansphagspa/v15/pxiZyoo6v8ZYyWh5WuPeJzMkd4SrGChUq06o.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosansphagspa/v23/XLY8IYr5bJNDGYxPGjyYbaEjwQR-LGltasI.ttf"
     },
     {
       "family": "Noto Sans Phoenician",
@@ -26376,22 +26734,22 @@
         "latin-ext",
         "sinhala"
       ],
-      "version": "v26",
-      "lastModified": "2022-09-28",
+      "version": "v34",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2b5lgLpJwbQRM.ttf",
-        "200": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwo2a5lgLpJwbQRM.ttf",
-        "300": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwlOa5lgLpJwbQRM.ttf",
-        "500": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwj-a5lgLpJwbQRM.ttf",
-        "600": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwtOd5lgLpJwbQRM.ttf",
-        "700": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwuqd5lgLpJwbQRM.ttf",
-        "800": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwo2d5lgLpJwbQRM.ttf",
-        "900": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwqSd5lgLpJwbQRM.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2a5lgLpJwbQRM.ttf"
+        "100": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2b5lgLpJwbQRM.ttf",
+        "200": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwo2a5lgLpJwbQRM.ttf",
+        "300": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwlOa5lgLpJwbQRM.ttf",
+        "500": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwj-a5lgLpJwbQRM.ttf",
+        "600": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwtOd5lgLpJwbQRM.ttf",
+        "700": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwuqd5lgLpJwbQRM.ttf",
+        "800": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwo2d5lgLpJwbQRM.ttf",
+        "900": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwqSd5lgLpJwbQRM.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2a5lgLpJwbQRM.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanssinhala/v26/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2a1lkBoA.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanssinhala/v34/yMJ2MJBya43H0SUF_WmcBEEf4rQVO2P524V5N_MxQzQtb-tf5dJbC30Fu9zUwg2a1lkBoA.ttf"
     },
     {
       "family": "Noto Sans Sogdian",
@@ -26491,14 +26849,14 @@
         "latin-ext",
         "syloti-nagri"
       ],
-      "version": "v23",
-      "lastModified": "2024-08-12",
+      "version": "v24",
+      "lastModified": "2025-03-11",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notosanssylotinagri/v23/uU9eCAQZ75uhfF9UoWDRiY3q7Sf_VFV3m4dGFVfxN87gsj0.ttf"
+        "regular": "https://fonts.gstatic.com/s/notosanssylotinagri/v24/uU9eCAQZ75uhfF9UoWDRiY3q7Sf_VFV3m4dGFVfxN87gsj0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanssylotinagri/v23/uU9eCAQZ75uhfF9UoWDRiY3q7Sf_VFV3m4dGJVb7Mw.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanssylotinagri/v24/uU9eCAQZ75uhfF9UoWDRiY3q7Sf_VFV3m4dGJVb7Mw.ttf"
     },
     {
       "family": "Noto Sans Symbols",
@@ -26518,22 +26876,22 @@
         "latin-ext",
         "symbols"
       ],
-      "version": "v43",
-      "lastModified": "2024-09-04",
+      "version": "v44",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ4gavVFRkzrbQ.ttf",
-        "200": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g_Q8gavVFRkzrbQ.ttf",
-        "300": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gIw8gavVFRkzrbQ.ttf",
-        "500": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gTw8gavVFRkzrbQ.ttf",
-        "600": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gowggavVFRkzrbQ.ttf",
-        "700": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gmgggavVFRkzrbQ.ttf",
-        "800": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g_QggavVFRkzrbQ.ttf",
-        "900": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g1AggavVFRkzrbQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8gavVFRkzrbQ.ttf"
+        "100": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ4gavVFRkzrbQ.ttf",
+        "200": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g_Q8gavVFRkzrbQ.ttf",
+        "300": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gIw8gavVFRkzrbQ.ttf",
+        "500": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gTw8gavVFRkzrbQ.ttf",
+        "600": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gowggavVFRkzrbQ.ttf",
+        "700": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gmgggavVFRkzrbQ.ttf",
+        "800": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g_QggavVFRkzrbQ.ttf",
+        "900": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3g1AggavVFRkzrbQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8gavVFRkzrbQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanssymbols/v43/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8Qa_9B.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanssymbols/v44/rP2up3q65FkAtHfwd-eIS2brbDN6gxP34F9jRRCe4W3gfQ8Qa_9B.ttf"
     },
     {
       "family": "Noto Sans Symbols 2",
@@ -26610,22 +26968,22 @@
         "latin-ext",
         "syriac"
       ],
-      "version": "v1",
-      "lastModified": "2023-07-13",
+      "version": "v2",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-eszCL5ep1QPQ.ttf",
-        "200": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPq-fszCL5ep1QPQ.ttf",
-        "300": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPnGfszCL5ep1QPQ.ttf",
-        "500": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPh2fszCL5ep1QPQ.ttf",
-        "600": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPvGYszCL5ep1QPQ.ttf",
-        "700": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPsiYszCL5ep1QPQ.ttf",
-        "800": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPq-YszCL5ep1QPQ.ttf",
-        "900": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPoaYszCL5ep1QPQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-fszCL5ep1QPQ.ttf"
+        "100": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-eszCL5ep1QPQ.ttf",
+        "200": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPq-fszCL5ep1QPQ.ttf",
+        "300": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPnGfszCL5ep1QPQ.ttf",
+        "500": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPh2fszCL5ep1QPQ.ttf",
+        "600": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPvGYszCL5ep1QPQ.ttf",
+        "700": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPsiYszCL5ep1QPQ.ttf",
+        "800": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPq-YszCL5ep1QPQ.ttf",
+        "900": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPoaYszCL5ep1QPQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-fszCL5ep1QPQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notosanssyriaceastern/v1/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-fgzGB4Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/notosanssyriaceastern/v2/Noac6Vj_wIWFbTTCrYmvy8AjVU8aslWRHHvRYxS-Ro3yS0FDacnHPi-fgzGB4Q.ttf"
     },
     {
       "family": "Noto Sans TC",
@@ -27211,31 +27569,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v23",
-      "lastModified": "2023-10-25",
+      "version": "v28",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFGjwM0Lhq_Szw.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZKFCjwM0Lhq_Szw.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZ9lCjwM0Lhq_Szw.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZmlCjwM0Lhq_Szw.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZdlejwM0Lhq_Szw.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZT1ejwM0Lhq_Szw.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZKFejwM0Lhq_Szw.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZAVejwM0Lhq_Szw.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFCjwM0Lhq_Szw.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBNLgscPpKrCzyUi.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPLg8cPpKrCzyUi.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBMVg8cPpKrCzyUi.ttf",
-        "italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBNLg8cPpKrCzyUi.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBN5g8cPpKrCzyUi.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBOVhMcPpKrCzyUi.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBOshMcPpKrCzyUi.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPLhMcPpKrCzyUi.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notoserif/v23/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPihMcPpKrCzyUi.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFGjwM0Lhq_Szw.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZKFCjwM0Lhq_Szw.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZ9lCjwM0Lhq_Szw.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZmlCjwM0Lhq_Szw.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZdlejwM0Lhq_Szw.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZT1ejwM0Lhq_Szw.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZKFejwM0Lhq_Szw.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZAVejwM0Lhq_Szw.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFCjwM0Lhq_Szw.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBNLgscPpKrCzyUi.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPLg8cPpKrCzyUi.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBMVg8cPpKrCzyUi.ttf",
+        "italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBNLg8cPpKrCzyUi.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBN5g8cPpKrCzyUi.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBOVhMcPpKrCzyUi.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBOshMcPpKrCzyUi.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPLhMcPpKrCzyUi.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notoserif/v28/ga6saw1J5X9T9RW6j9bNfFIMZhhWnFTyNZIQD1-_FXP0RgnaOg9MYBPihMcPpKrCzyUi.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserif/v23/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFCTwccP.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserif/v28/ga6iaw1J5X9T9RW6j9bNVls-hfgvz8JcMofYTa32J4wsL2JAlAhZqFCTwccP.ttf"
     },
     {
       "family": "Noto Serif Ahom",
@@ -27328,22 +27686,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2022-09-22",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAH3qn4LjQH8yD.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfeAHnqn4LjQH8yD.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfdeHnqn4LjQH8yD.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcyHnqn4LjQH8yD.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JffeGXqn4LjQH8yD.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JffnGXqn4LjQH8yD.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfeAGXqn4LjQH8yD.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfepGXqn4LjQH8yD.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAHnqn4LjQH8yD.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAH3qn4LjQH8yD.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfeAHnqn4LjQH8yD.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfdeHnqn4LjQH8yD.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcyHnqn4LjQH8yD.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JffeGXqn4LjQH8yD.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JffnGXqn4LjQH8yD.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfeAGXqn4LjQH8yD.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfepGXqn4LjQH8yD.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAHnqn4LjQH8yD.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifbengali/v19/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAHkqm6rw.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifbengali/v25/hYkuPvggTvnzO14VSXltirUdnnkt1pwmWrprmO7RjE0a5BtdATYU1crFaM_5JfcAHkqm6rw.ttf"
     },
     {
       "family": "Noto Serif Devanagari",
@@ -27363,22 +27721,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v30",
-      "lastModified": "2024-07-01",
+      "version": "v31",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-og-HMUe1u_dv.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTC-ow-HMUe1u_dv.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTBgow-HMUe1u_dv.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTAMow-HMUe1u_dv.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTDgpA-HMUe1u_dv.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTDZpA-HMUe1u_dv.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTC-pA-HMUe1u_dv.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTCXpA-HMUe1u_dv.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-ow-HMUe1u_dv.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-og-HMUe1u_dv.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTC-ow-HMUe1u_dv.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTBgow-HMUe1u_dv.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTAMow-HMUe1u_dv.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTDgpA-HMUe1u_dv.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTDZpA-HMUe1u_dv.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTC-pA-HMUe1u_dv.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTCXpA-HMUe1u_dv.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-ow-HMUe1u_dv.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifdevanagari/v30/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-oz-GO0M.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifdevanagari/v31/x3dYcl3IZKmUqiMk48ZHXJ5jwU-DZGRSaQ4Hh2dGyFzPLcQPVbnRNeFsw0xRWb6uxTA-oz-GO0M.ttf"
     },
     {
       "family": "Noto Serif Display",
@@ -27411,31 +27769,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v24",
-      "lastModified": "2023-08-25",
+      "version": "v26",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd49gKaDU9hvzC.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVrd4tgKaDU9hvzC.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVoD4tgKaDU9hvzC.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpv4tgKaDU9hvzC.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVqD5dgKaDU9hvzC.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVq65dgKaDU9hvzC.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVrd5dgKaDU9hvzC.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVr05dgKaDU9hvzC.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd4tgKaDU9hvzC.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoTBIYjEfg-zCmf4.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VobBJYjEfg-zCmf4.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoW5JYjEfg-zCmf4.ttf",
-        "italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoTBJYjEfg-zCmf4.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoQJJYjEfg-zCmf4.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-Voe5OYjEfg-zCmf4.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoddOYjEfg-zCmf4.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VobBOYjEfg-zCmf4.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoZlOYjEfg-zCmf4.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd49gKaDU9hvzC.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVrd4tgKaDU9hvzC.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVoD4tgKaDU9hvzC.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpv4tgKaDU9hvzC.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVqD5dgKaDU9hvzC.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVq65dgKaDU9hvzC.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVrd5dgKaDU9hvzC.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVr05dgKaDU9hvzC.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd4tgKaDU9hvzC.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoTBIYjEfg-zCmf4.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VobBJYjEfg-zCmf4.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoW5JYjEfg-zCmf4.ttf",
+        "italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoTBJYjEfg-zCmf4.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoQJJYjEfg-zCmf4.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-Voe5OYjEfg-zCmf4.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoddOYjEfg-zCmf4.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VobBOYjEfg-zCmf4.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buEPppa9f8_vkXaZLAgP0G5Wi6QmA1QwcLRCOrN8uo7t6FBJOJTQit-N33sQOk-VoZlOYjEfg-zCmf4.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifdisplay/v24/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd4ugLYjE.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifdisplay/v26/buERppa9f8_vkXaZLAgP0G5Wi6QmA1QaeYah2sovLCDq_ZgLyt3idQfktOG-PVpd4ugLYjE.ttf"
     },
     {
       "family": "Noto Serif Dogra",
@@ -27474,22 +27832,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v30",
-      "lastModified": "2023-09-14",
+      "version": "v31",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSQjkaO9UVLyiw.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCTSUjkaO9UVLyiw.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCkyUjkaO9UVLyiw.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxC_yUjkaO9UVLyiw.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCEyIjkaO9UVLyiw.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCKiIjkaO9UVLyiw.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCTSIjkaO9UVLyiw.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCZCIjkaO9UVLyiw.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSUjkaO9UVLyiw.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSQjkaO9UVLyiw.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCTSUjkaO9UVLyiw.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCkyUjkaO9UVLyiw.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxC_yUjkaO9UVLyiw.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCEyIjkaO9UVLyiw.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCKiIjkaO9UVLyiw.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCTSIjkaO9UVLyiw.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCZCIjkaO9UVLyiw.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSUjkaO9UVLyiw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifethiopic/v30/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSUTkKm5.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifethiopic/v31/V8mjoR7-XjwJ8_Au3Ti5tXj5Rd83frpWLK4d-taxqWw2HMWjDxBAg5S_0QsrggxCzSUTkKm5.ttf"
     },
     {
       "family": "Noto Serif Georgian",
@@ -27509,22 +27867,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v26",
-      "lastModified": "2023-11-28",
+      "version": "v28",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvsfdzTw-FgZxQ.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSzvofdzTw-FgZxQ.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSEPofdzTw-FgZxQ.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSfPofdzTw-FgZxQ.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSkP0fdzTw-FgZxQ.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSqf0fdzTw-FgZxQ.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSzv0fdzTw-FgZxQ.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aS5_0fdzTw-FgZxQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvofdzTw-FgZxQ.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvsfdzTw-FgZxQ.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSzvofdzTw-FgZxQ.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSEPofdzTw-FgZxQ.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSfPofdzTw-FgZxQ.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSkP0fdzTw-FgZxQ.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSqf0fdzTw-FgZxQ.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSzv0fdzTw-FgZxQ.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aS5_0fdzTw-FgZxQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvofdzTw-FgZxQ.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifgeorgian/v26/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvovdj70.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifgeorgian/v28/VEMXRpd8s4nv8hG_qOzL7HOAw4nt0Sl_XxyaEduNMvi7T6Y4etRnmGhyLop-R3aSTvovdj70.ttf"
     },
     {
       "family": "Noto Serif Grantha",
@@ -27600,22 +27958,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2023-04-27",
+      "version": "v21",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eBTNmqVU7y6l.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4-eRTNmqVU7y6l.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr7geRTNmqVU7y6l.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6MeRTNmqVU7y6l.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr5gfhTNmqVU7y6l.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr5ZfhTNmqVU7y6l.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4-fhTNmqVU7y6l.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4XfhTNmqVU7y6l.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eRTNmqVU7y6l.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eBTNmqVU7y6l.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4-eRTNmqVU7y6l.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr7geRTNmqVU7y6l.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6MeRTNmqVU7y6l.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr5gfhTNmqVU7y6l.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr5ZfhTNmqVU7y6l.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4-fhTNmqVU7y6l.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr4XfhTNmqVU7y6l.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eRTNmqVU7y6l.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifgurmukhi/v20/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eSTMkKE.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifgurmukhi/v21/92z-tA9LNqsg7tCYlXdCV1VPnAEeDU0vLoYMbylXk0xTCr6-eSTMkKE.ttf"
     },
     {
       "family": "Noto Serif HK",
@@ -27686,6 +28044,39 @@
       "category": "serif",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/notoserifhebrew/v28/k3k0o9MMPvpLmixYH7euCwmkS9DohjX1-kRyiqyBqIxnoLbp93i9IKrXKF_qVAwSMG41ug.ttf"
+    },
+    {
+      "family": "Noto Serif Hentaigana",
+      "variants": [
+        "200",
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900"
+      ],
+      "subsets": [
+        "kana-extended",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v16",
+      "lastModified": "2025-03-18",
+      "files": {
+        "200": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzgwGqxEZWEARdDE.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hztIGqxEZWEARdDE.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzr4GqxEZWEARdDE.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzlIBqxEZWEARdDE.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzmsBqxEZWEARdDE.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzgwBqxEZWEARdDE.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hziUBqxEZWEARdDE.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzowGqxEZWEARdDE.ttf"
+      },
+      "category": "serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/notoserifhentaigana/v16/uk-OEHi3o6EruUbj3pGaDj3siVARn-kqgu1eOHk7wYK23O0hzowGmxATXA.ttf"
     },
     {
       "family": "Noto Serif JP",
@@ -27829,22 +28220,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v25",
-      "lastModified": "2023-10-25",
+      "version": "v28",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B4wXEZK9Xo4xg.ttf",
-        "200": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNaB8wXEZK9Xo4xg.ttf",
-        "300": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNth8wXEZK9Xo4xg.ttf",
-        "500": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN2h8wXEZK9Xo4xg.ttf",
-        "600": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNNhgwXEZK9Xo4xg.ttf",
-        "700": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNDxgwXEZK9Xo4xg.ttf",
-        "800": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNaBgwXEZK9Xo4xg.ttf",
-        "900": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNQRgwXEZK9Xo4xg.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B8wXEZK9Xo4xg.ttf"
+        "100": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B4wXEZK9Xo4xg.ttf",
+        "200": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNaB8wXEZK9Xo4xg.ttf",
+        "300": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNth8wXEZK9Xo4xg.ttf",
+        "500": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN2h8wXEZK9Xo4xg.ttf",
+        "600": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNNhgwXEZK9Xo4xg.ttf",
+        "700": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNDxgwXEZK9Xo4xg.ttf",
+        "800": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNaBgwXEZK9Xo4xg.ttf",
+        "900": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdNQRgwXEZK9Xo4xg.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B8wXEZK9Xo4xg.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoserifkhmer/v25/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B8AXUxO.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoserifkhmer/v28/-F6UfidqLzI2JPCkXAO2hmogq0146FxtbwKEr951z5s6lI40sDRH_AVhUKdN6B8AXUxO.ttf"
     },
     {
       "family": "Noto Serif Khojki",
@@ -28212,31 +28603,31 @@
         "latin-ext",
         "tamil"
       ],
-      "version": "v28",
-      "lastModified": "2023-04-27",
+      "version": "v30",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN6R8Pz3v8Etew.ttf",
-        "200": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatNN-R8Pz3v8Etew.ttf",
-        "300": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecat6t-R8Pz3v8Etew.ttf",
-        "500": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatht-R8Pz3v8Etew.ttf",
-        "600": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatatiR8Pz3v8Etew.ttf",
-        "700": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatU9iR8Pz3v8Etew.ttf",
-        "800": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatNNiR8Pz3v8Etew.ttf",
-        "900": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatHdiR8Pz3v8Etew.ttf",
-        "regular": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN-R8Pz3v8Etew.ttf",
-        "100italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJx5svbzncQ9e3wx.ttf",
-        "200italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJz5s_bzncQ9e3wx.ttf",
-        "300italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJwns_bzncQ9e3wx.ttf",
-        "italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJx5s_bzncQ9e3wx.ttf",
-        "500italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJxLs_bzncQ9e3wx.ttf",
-        "600italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJyntPbzncQ9e3wx.ttf",
-        "700italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJyetPbzncQ9e3wx.ttf",
-        "800italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJz5tPbzncQ9e3wx.ttf",
-        "900italic": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJzQtPbzncQ9e3wx.ttf"
+        "100": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN6R8Pz3v8Etew.ttf",
+        "200": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatNN-R8Pz3v8Etew.ttf",
+        "300": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecat6t-R8Pz3v8Etew.ttf",
+        "500": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatht-R8Pz3v8Etew.ttf",
+        "600": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatatiR8Pz3v8Etew.ttf",
+        "700": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatU9iR8Pz3v8Etew.ttf",
+        "800": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatNNiR8Pz3v8Etew.ttf",
+        "900": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecatHdiR8Pz3v8Etew.ttf",
+        "regular": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN-R8Pz3v8Etew.ttf",
+        "100italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJx5svbzncQ9e3wx.ttf",
+        "200italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJz5s_bzncQ9e3wx.ttf",
+        "300italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJwns_bzncQ9e3wx.ttf",
+        "italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJx5s_bzncQ9e3wx.ttf",
+        "500italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJxLs_bzncQ9e3wx.ttf",
+        "600italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJyntPbzncQ9e3wx.ttf",
+        "700italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJyetPbzncQ9e3wx.ttf",
+        "800italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJz5tPbzncQ9e3wx.ttf",
+        "900italic": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjldHr-klIgTfc40komjQ5OObazSJaI_D5kV8k_WLwFBmWrypghjeOa18G4fJzQtPbzncQ9e3wx.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoseriftamil/v28/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN-h8fbz.ttf"
+      "menu": "https://fonts.gstatic.com/s/notoseriftamil/v30/LYjndHr-klIgTfc40komjQ5OObazYp-6H94dBF-RX6nNRJfi-Gf55IgAecattN-h8fbz.ttf"
     },
     {
       "family": "Noto Serif Tangut",
@@ -28363,6 +28754,25 @@
       "menu": "https://fonts.gstatic.com/s/notoseriftibetan/v22/gokGH7nwAEdtF9N45n0Vaz7O-pk0wsvxHeDXMfqguoCmIrYcDS_hcQ.ttf"
     },
     {
+      "family": "Noto Serif Todhri",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext",
+        "todhri"
+      ],
+      "version": "v3",
+      "lastModified": "2025-01-23",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/notoseriftodhri/v3/dFalZeyY-aYz1YVbjMoBWml1nBz7N3ByX6n0fnNk.ttf"
+      },
+      "category": "serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/notoseriftodhri/v3/dFalZeyY-aYz1YVbjMoBWml1nBz7N0BzVa0.ttf"
+    },
+    {
       "family": "Noto Serif Toto",
       "variants": [
         "regular",
@@ -28451,18 +28861,18 @@
         "latin-ext",
         "nushu"
       ],
-      "version": "v17",
-      "lastModified": "2023-05-23",
+      "version": "v22",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXvy1tnPa7QoqirI.ttf",
-        "500": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXue1tnPa7QoqirI.ttf",
-        "600": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXty0dnPa7QoqirI.ttf",
-        "700": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXtL0dnPa7QoqirI.ttf",
-        "regular": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXus1tnPa7QoqirI.ttf"
+        "300": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXvy1tnPa7QoqirI.ttf",
+        "500": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXue1tnPa7QoqirI.ttf",
+        "600": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXty0dnPa7QoqirI.ttf",
+        "700": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXtL0dnPa7QoqirI.ttf",
+        "regular": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXus1tnPa7QoqirI.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/nototraditionalnushu/v17/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXus1unOYbA.ttf"
+      "menu": "https://fonts.gstatic.com/s/nototraditionalnushu/v22/SZcV3EDkJ7q9FaoMPlmF4Su8hlIjoGh5aj67PUZX6ADm6oa8IXus1unOYbA.ttf"
     },
     {
       "family": "Noto Znamenny Musical Notation",
@@ -28476,14 +28886,14 @@
         "symbols",
         "znamenny"
       ],
-      "version": "v3",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/notoznamennymusicalnotation/v3/CSRW4ylQnPyaDwAMK1U_AolTaJ4Lz41GcgaIZV9YO2rO88jvtpqqdoWa7g.ttf"
+        "regular": "https://fonts.gstatic.com/s/notoznamennymusicalnotation/v4/CSRW4ylQnPyaDwAMK1U_AolTaJ4Lz41GcgaIZV9YO2rO88jvtpqqdoWa7g.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/notoznamennymusicalnotation/v3/CSRW4ylQnPyaDwAMK1U_AolTaJ4Lz41GcgaIZV9YO2rO88jft5Cu.ttf",
+      "menu": "https://fonts.gstatic.com/s/notoznamennymusicalnotation/v4/CSRW4ylQnPyaDwAMK1U_AolTaJ4Lz41GcgaIZV9YO2rO88jft5Cu.ttf",
       "colorCapabilities": [
         "COLRv0"
       ]
@@ -28494,16 +28904,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novacut/v24/KFOkCnSYu8mL-39LkWxPKTM1K9nz.ttf"
+        "regular": "https://fonts.gstatic.com/s/novacut/v25/KFOkCnSYu8mL-39LkWxPKTM1K9nz.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novacut/v24/KFOkCnSYu8mL-39LkVxOIzc.ttf"
+      "menu": "https://fonts.gstatic.com/s/novacut/v25/KFOkCnSYu8mL-39LkVxOIzc.ttf"
     },
     {
       "family": "Nova Flat",
@@ -28511,16 +28922,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novaflat/v24/QdVUSTc-JgqpytEbVebEuStkm20oJA.ttf"
+        "regular": "https://fonts.gstatic.com/s/novaflat/v25/QdVUSTc-JgqpytEbVebEuStkm20oJA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novaflat/v24/QdVUSTc-JgqpytEbVeb0uCFg.ttf"
+      "menu": "https://fonts.gstatic.com/s/novaflat/v25/QdVUSTc-JgqpytEbVeb0uCFg.ttf"
     },
     {
       "family": "Nova Mono",
@@ -28529,16 +28941,17 @@
       ],
       "subsets": [
         "greek",
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novamono/v20/Cn-0JtiGWQ5Ajb--MRKfYGxYrdM9Sg.ttf"
+        "regular": "https://fonts.gstatic.com/s/novamono/v21/Cn-0JtiGWQ5Ajb--MRKfYGxYrdM9Sg.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novamono/v20/Cn-0JtiGWQ5Ajb--MRKvYWZc.ttf"
+      "menu": "https://fonts.gstatic.com/s/novamono/v21/Cn-0JtiGWQ5Ajb--MRKvYWZc.ttf"
     },
     {
       "family": "Nova Oval",
@@ -28546,16 +28959,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novaoval/v24/jAnEgHdmANHvPenMaswCMY-h3cWkWg.ttf"
+        "regular": "https://fonts.gstatic.com/s/novaoval/v25/jAnEgHdmANHvPenMaswCMY-h3cWkWg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novaoval/v24/jAnEgHdmANHvPenMaswyMIWl.ttf"
+      "menu": "https://fonts.gstatic.com/s/novaoval/v25/jAnEgHdmANHvPenMaswyMIWl.ttf"
     },
     {
       "family": "Nova Round",
@@ -28563,16 +28977,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novaround/v21/flU9Rqquw5UhEnlwTJYTYYfeeetYEBc.ttf"
+        "regular": "https://fonts.gstatic.com/s/novaround/v22/flU9Rqquw5UhEnlwTJYTYYfeeetYEBc.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novaround/v21/flU9Rqquw5UhEnlwTJYTUYbUfQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/novaround/v22/flU9Rqquw5UhEnlwTJYTUYbUfQ.ttf"
     },
     {
       "family": "Nova Script",
@@ -28580,16 +28995,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novascript/v25/7Au7p_IpkSWSTWaFWkumvmQNEl0O0kEx.ttf"
+        "regular": "https://fonts.gstatic.com/s/novascript/v26/7Au7p_IpkSWSTWaFWkumvmQNEl0O0kEx.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novascript/v25/7Au7p_IpkSWSTWaFWkumvlQMGFk.ttf"
+      "menu": "https://fonts.gstatic.com/s/novascript/v26/7Au7p_IpkSWSTWaFWkumvlQMGFk.ttf"
     },
     {
       "family": "Nova Slim",
@@ -28597,16 +29013,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novaslim/v24/Z9XUDmZNQAuem8jyZcn-yMOInrib9Q.ttf"
+        "regular": "https://fonts.gstatic.com/s/novaslim/v25/Z9XUDmZNQAuem8jyZcn-yMOInrib9Q.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novaslim/v24/Z9XUDmZNQAuem8jyZcnOycmM.ttf"
+      "menu": "https://fonts.gstatic.com/s/novaslim/v25/Z9XUDmZNQAuem8jyZcnOycmM.ttf"
     },
     {
       "family": "Nova Square",
@@ -28614,16 +29031,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/novasquare/v24/RrQUbo9-9DV7b06QHgSWsZhARYMgGtWA.ttf"
+        "regular": "https://fonts.gstatic.com/s/novasquare/v25/RrQUbo9-9DV7b06QHgSWsZhARYMgGtWA.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/novasquare/v24/RrQUbo9-9DV7b06QHgSWsahBT4c.ttf"
+      "menu": "https://fonts.gstatic.com/s/novasquare/v25/RrQUbo9-9DV7b06QHgSWsahBT4c.ttf"
     },
     {
       "family": "Numans",
@@ -28789,14 +29207,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v27",
-      "lastModified": "2024-08-12",
+      "version": "v30",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/odormeanchey/v27/raxkHiKDttkTe1aOGcJMR1A_4mrY2zqUKafv.ttf"
+        "regular": "https://fonts.gstatic.com/s/odormeanchey/v30/raxkHiKDttkTe1aOGcJMR1A_4mrY2zqUKafv.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/odormeanchey/v27/raxkHiKDttkTe1aOGcJMR1A_4lrZ0T4.ttf"
+      "menu": "https://fonts.gstatic.com/s/odormeanchey/v30/raxkHiKDttkTe1aOGcJMR1A_4lrZ0T4.ttf"
     },
     {
       "family": "Offside",
@@ -28822,6 +29240,7 @@
         "regular"
       ],
       "subsets": [
+        "arabic",
         "cyrillic",
         "cyrillic-ext",
         "greek",
@@ -28830,14 +29249,14 @@
         "tamil",
         "vietnamese"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/oi/v19/w8gXH2EuRqtaut6yjBOG.ttf"
+        "regular": "https://fonts.gstatic.com/s/oi/v20/w8gXH2EuRqtaut6yjBOG.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/oi/v19/w8gXH2EuRptbsNo.ttf"
+      "menu": "https://fonts.gstatic.com/s/oi/v20/w8gXH2EuRptbsNo.ttf"
     },
     {
       "family": "Ojuju",
@@ -28857,20 +29276,20 @@
         "symbols",
         "vietnamese"
       ],
-      "version": "v3",
-      "lastModified": "2024-09-04",
+      "version": "v4",
+      "lastModified": "2025-03-18",
       "files": {
-        "200": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_ypk552FRLYeruQ.ttf",
-        "300": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_FJk552FRLYeruQ.ttf",
-        "500": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_eJk552FRLYeruQ.ttf",
-        "600": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_lJ4552FRLYeruQ.ttf",
-        "700": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_rZ4552FRLYeruQ.ttf",
-        "800": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_yp4552FRLYeruQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_Spk552FRLYeruQ.ttf"
+        "200": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_ypk552FRLYeruQ.ttf",
+        "300": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_FJk552FRLYeruQ.ttf",
+        "500": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_eJk552FRLYeruQ.ttf",
+        "600": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_lJ4552FRLYeruQ.ttf",
+        "700": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_rZ4552FRLYeruQ.ttf",
+        "800": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_yp4552FRLYeruQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_Spk552FRLYeruQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ojuju/v3/7r3bqXF7v9ApbrMih3jYQBVm9-n_SpkJ5mtV.ttf"
+      "menu": "https://fonts.gstatic.com/s/ojuju/v4/7r3bqXF7v9ApbrMih3jYQBVm9-n_SpkJ5mtV.ttf"
     },
     {
       "family": "Old Standard TT",
@@ -28993,22 +29412,22 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v6",
-      "lastModified": "2024-09-04",
+      "version": "v8",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R6ZshFMQWXgSQ.ttf",
-        "200": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhdR-ZshFMQWXgSQ.ttf",
-        "300": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhqx-ZshFMQWXgSQ.ttf",
-        "500": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhxx-ZshFMQWXgSQ.ttf",
-        "600": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhKxiZshFMQWXgSQ.ttf",
-        "700": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhEhiZshFMQWXgSQ.ttf",
-        "800": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhdRiZshFMQWXgSQ.ttf",
-        "900": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPhXBiZshFMQWXgSQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R-ZshFMQWXgSQ.ttf"
+        "100": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R6ZshFMQWXgSQ.ttf",
+        "200": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhdR-ZshFMQWXgSQ.ttf",
+        "300": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhqx-ZshFMQWXgSQ.ttf",
+        "500": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhxx-ZshFMQWXgSQ.ttf",
+        "600": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhKxiZshFMQWXgSQ.ttf",
+        "700": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhEhiZshFMQWXgSQ.ttf",
+        "800": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhdRiZshFMQWXgSQ.ttf",
+        "900": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPhXBiZshFMQWXgSQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R-ZshFMQWXgSQ.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/onest/v6/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R-psxtI.ttf"
+      "menu": "https://fonts.gstatic.com/s/onest/v8/gNMZW3F-SZuj7zOT0IfSjTS16cPh9R-psxtI.ttf"
     },
     {
       "family": "Oooh Baby",
@@ -29207,16 +29626,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/originalsurfer/v22/RWmQoKGZ9vIirYntXJ3_MbekzNMiDEtvAlaMKw.ttf"
+        "regular": "https://fonts.gstatic.com/s/originalsurfer/v23/RWmQoKGZ9vIirYntXJ3_MbekzNMiDEtvAlaMKw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/originalsurfer/v22/RWmQoKGZ9vIirYntXJ3_MbekzNMSDUFr.ttf"
+      "menu": "https://fonts.gstatic.com/s/originalsurfer/v23/RWmQoKGZ9vIirYntXJ3_MbekzNMSDUFr.ttf"
     },
     {
       "family": "Oswald",
@@ -29289,16 +29709,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/overtherainbow/v20/11haGoXG1k_HKhMLUWz7Mc7vvW5upvOm9NA2XG0.ttf"
+        "regular": "https://fonts.gstatic.com/s/overtherainbow/v21/11haGoXG1k_HKhMLUWz7Mc7vvW5upvOm9NA2XG0.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/overtherainbow/v20/11haGoXG1k_HKhMLUWz7Mc7vvW5ulvKs8A.ttf"
+      "menu": "https://fonts.gstatic.com/s/overtherainbow/v21/11haGoXG1k_HKhMLUWz7Mc7vvW5ulvKs8A.ttf"
     },
     {
       "family": "Overlock",
@@ -29732,20 +30153,20 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "100": "https://fonts.gstatic.com/s/palanquin/v13/9XUhlJ90n1fBFg7ceXwUEltI7rWmZzTH.ttf",
-        "200": "https://fonts.gstatic.com/s/palanquin/v13/9XUilJ90n1fBFg7ceXwUvnpoxJuqbi3ezg.ttf",
-        "300": "https://fonts.gstatic.com/s/palanquin/v13/9XUilJ90n1fBFg7ceXwU2nloxJuqbi3ezg.ttf",
-        "500": "https://fonts.gstatic.com/s/palanquin/v13/9XUilJ90n1fBFg7ceXwUgnhoxJuqbi3ezg.ttf",
-        "600": "https://fonts.gstatic.com/s/palanquin/v13/9XUilJ90n1fBFg7ceXwUrn9oxJuqbi3ezg.ttf",
-        "700": "https://fonts.gstatic.com/s/palanquin/v13/9XUilJ90n1fBFg7ceXwUyn5oxJuqbi3ezg.ttf",
-        "regular": "https://fonts.gstatic.com/s/palanquin/v13/9XUnlJ90n1fBFg7ceXwsdlFMzLC2Zw.ttf"
+        "100": "https://fonts.gstatic.com/s/palanquin/v16/9XUhlJ90n1fBFg7ceXwUEltI7rWmZzTH.ttf",
+        "200": "https://fonts.gstatic.com/s/palanquin/v16/9XUilJ90n1fBFg7ceXwUvnpoxJuqbi3ezg.ttf",
+        "300": "https://fonts.gstatic.com/s/palanquin/v16/9XUilJ90n1fBFg7ceXwU2nloxJuqbi3ezg.ttf",
+        "500": "https://fonts.gstatic.com/s/palanquin/v16/9XUilJ90n1fBFg7ceXwUgnhoxJuqbi3ezg.ttf",
+        "600": "https://fonts.gstatic.com/s/palanquin/v16/9XUilJ90n1fBFg7ceXwUrn9oxJuqbi3ezg.ttf",
+        "700": "https://fonts.gstatic.com/s/palanquin/v16/9XUilJ90n1fBFg7ceXwUyn5oxJuqbi3ezg.ttf",
+        "regular": "https://fonts.gstatic.com/s/palanquin/v16/9XUnlJ90n1fBFg7ceXwsdlFMzLC2Zw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/palanquin/v13/9XUnlJ90n1fBFg7ceXwcd1tI.ttf"
+      "menu": "https://fonts.gstatic.com/s/palanquin/v16/9XUnlJ90n1fBFg7ceXwcd1tI.ttf"
     },
     {
       "family": "Palanquin Dark",
@@ -29760,17 +30181,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v16",
+      "lastModified": "2024-11-20",
       "files": {
-        "500": "https://fonts.gstatic.com/s/palanquindark/v14/xn76YHgl1nqmANMB-26xC7yuF8Z6ZW41fcvN2KT4.ttf",
-        "600": "https://fonts.gstatic.com/s/palanquindark/v14/xn76YHgl1nqmANMB-26xC7yuF8ZWYm41fcvN2KT4.ttf",
-        "700": "https://fonts.gstatic.com/s/palanquindark/v14/xn76YHgl1nqmANMB-26xC7yuF8YyY241fcvN2KT4.ttf",
-        "regular": "https://fonts.gstatic.com/s/palanquindark/v14/xn75YHgl1nqmANMB-26xC7yuF_6OTEo9VtfE.ttf"
+        "500": "https://fonts.gstatic.com/s/palanquindark/v16/xn76YHgl1nqmANMB-26xC7yuF8Z6ZW41fcvN2KT4.ttf",
+        "600": "https://fonts.gstatic.com/s/palanquindark/v16/xn76YHgl1nqmANMB-26xC7yuF8ZWYm41fcvN2KT4.ttf",
+        "700": "https://fonts.gstatic.com/s/palanquindark/v16/xn76YHgl1nqmANMB-26xC7yuF8YyY241fcvN2KT4.ttf",
+        "regular": "https://fonts.gstatic.com/s/palanquindark/v16/xn75YHgl1nqmANMB-26xC7yuF_6OTEo9VtfE.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/palanquindark/v14/xn75YHgl1nqmANMB-26xC7yuF86PRk4.ttf"
+      "menu": "https://fonts.gstatic.com/s/palanquindark/v16/xn75YHgl1nqmANMB-26xC7yuF86PRk4.ttf"
     },
     {
       "family": "Palette Mosaic",
@@ -29846,6 +30267,34 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/parisienne/v13/E21i_d3kivvAkxhLEVZpQy5wCg.ttf"
+    },
+    {
+      "family": "Parkinsans",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-20",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gSI6R8K-8Z_dt-E.ttf",
+        "500": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gTk6R8K-8Z_dt-E.ttf",
+        "600": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gQI7h8K-8Z_dt-E.ttf",
+        "700": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gQx7h8K-8Z_dt-E.ttf",
+        "800": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gRW7h8K-8Z_dt-E.ttf",
+        "regular": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gTW6R8K-8Z_dt-E.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/parkinsans/v1/-W_uXJXvQyPb1QfpBpRrVEgjj0W4zSUk4gTW6S8L8cI.ttf"
     },
     {
       "family": "Passero One",
@@ -30100,14 +30549,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v20",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/peddana/v20/aFTU7PBhaX89UcKWhh2aBYyMcKw.ttf"
+        "regular": "https://fonts.gstatic.com/s/peddana/v23/aFTU7PBhaX89UcKWhh2aBYyMcKw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/peddana/v20/aFTU7PBhaX89UcKWthyQAQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/peddana/v23/aFTU7PBhaX89UcKWthyQAQ.ttf"
     },
     {
       "family": "Peralta",
@@ -30235,6 +30684,25 @@
       "menu": "https://fonts.gstatic.com/s/petrona/v32/mtGl4_NXL7bZo9XXq35wRLONYyOjFk6NsTRAFYo.ttf"
     },
     {
+      "family": "Phetsarath",
+      "variants": [
+        "regular",
+        "700"
+      ],
+      "subsets": [
+        "lao"
+      ],
+      "version": "v1",
+      "lastModified": "2024-11-20",
+      "files": {
+        "700": "https://fonts.gstatic.com/s/phetsarath/v1/N0bT2SpTP-plK0uWayAYOWLSudf7ZZlIHD0.ttf",
+        "regular": "https://fonts.gstatic.com/s/phetsarath/v1/N0bQ2SpTP-plK0uWayAYAd79nd_QeZA.ttf"
+      },
+      "category": "serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/phetsarath/v1/N0bQ2SpTP-plK0uWayAYMd_3mQ.ttf"
+    },
+    {
       "family": "Philosopher",
       "variants": [
         "regular",
@@ -30278,20 +30746,20 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v4",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkK62zUSwWuz38Tgg.ttf",
-        "500": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKh2zUSwWuz38Tgg.ttf",
-        "600": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKa2vUSwWuz38Tgg.ttf",
-        "700": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKUmvUSwWuz38Tgg.ttf",
-        "800": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKNWvUSwWuz38Tgg.ttf",
-        "900": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKHGvUSwWuz38Tgg.ttf",
-        "regular": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKtWzUSwWuz38Tgg.ttf"
+        "300": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkK62zUSwWuz38Tgg.ttf",
+        "500": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKh2zUSwWuz38Tgg.ttf",
+        "600": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKa2vUSwWuz38Tgg.ttf",
+        "700": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKUmvUSwWuz38Tgg.ttf",
+        "800": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKNWvUSwWuz38Tgg.ttf",
+        "900": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKHGvUSwWuz38Tgg.ttf",
+        "regular": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKtWzUSwWuz38Tgg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/phudu/v4/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKtWzkSg-q.ttf"
+      "menu": "https://fonts.gstatic.com/s/phudu/v5/0FlJVPSHk0ya-7OUeO_U-Lwm7PkKtWzkSg-q.ttf"
     },
     {
       "family": "Piazzolla",
@@ -30557,27 +31025,27 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v9",
+      "lastModified": "2025-01-28",
       "files": {
-        "300": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPlKetgdoSMw5ifm.ttf",
-        "500": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkmetgdoSMw5ifm.ttf",
-        "600": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPnKfdgdoSMw5ifm.ttf",
-        "700": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPnzfdgdoSMw5ifm.ttf",
-        "800": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPmUfdgdoSMw5ifm.ttf",
-        "900": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPm9fdgdoSMw5ifm.ttf",
-        "regular": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkUetgdoSMw5ifm.ttf",
-        "300italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOW5eqycS4zfmNrE.ttf",
-        "italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOTBeqycS4zfmNrE.ttf",
-        "500italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOQJeqycS4zfmNrE.ttf",
-        "600italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOe5ZqycS4zfmNrE.ttf",
-        "700italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOddZqycS4zfmNrE.ttf",
-        "800italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcObBZqycS4zfmNrE.ttf",
-        "900italic": "https://fonts.gstatic.com/s/playfair/v2/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOZlZqycS4zfmNrE.ttf"
+        "300": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPlKetgdoSMw5ifm.ttf",
+        "500": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkmetgdoSMw5ifm.ttf",
+        "600": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPnKfdgdoSMw5ifm.ttf",
+        "700": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPnzfdgdoSMw5ifm.ttf",
+        "800": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPmUfdgdoSMw5ifm.ttf",
+        "900": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPm9fdgdoSMw5ifm.ttf",
+        "regular": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkUetgdoSMw5ifm.ttf",
+        "300italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOW5eqycS4zfmNrE.ttf",
+        "italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOTBeqycS4zfmNrE.ttf",
+        "500italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOQJeqycS4zfmNrE.ttf",
+        "600italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOe5ZqycS4zfmNrE.ttf",
+        "700italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOddZqycS4zfmNrE.ttf",
+        "800italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcObBZqycS4zfmNrE.ttf",
+        "900italic": "https://fonts.gstatic.com/s/playfair/v9/0nkSC9D7PO4KhmUJ59baVQ_iWhg0cgSrLQZDFpFUsLCFf_1ubkfQeG9KkBAQcOsAs-zcOZlZqycS4zfmNrE.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playfair/v2/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkUeugcqyc.ttf"
+      "menu": "https://fonts.gstatic.com/s/playfair/v9/0nkQC9D7PO4KhmUJ5_zTZ_4MYQXznAK-TUcZXKO3UMnW6VNpe4-SiiZ4b8h5G3GutPkUeugcqyc.ttf"
     },
     {
       "family": "Playfair Display",
@@ -30697,17 +31165,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritear/v1/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-fteqf-ES67xIO8.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritear/v1/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-Xtfqf-ES67xIO8.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritear/v1/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-aVfqf-ES67xIO8.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritear/v1/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-ftfqf-ES67xIO8.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritear/v5/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-fteqf-ES67xIO8.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritear/v5/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-Xtfqf-ES67xIO8.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritear/v5/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-aVfqf-ES67xIO8.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritear/v5/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-ftfqf-ES67xIO8.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritear/v1/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-ftfmf6OTw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritear/v5/VEMjRohisJz5pTCzruCNjWbfp_N-aNWqYgKS-ftfmf6OTw.ttf"
+    },
+    {
+      "family": "Playwrite AR Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v5",
+      "lastModified": "2025-03-03",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritearguides/v5/iJWYBWqKZTrYS9uv-Ry6kDf-q_0Xq67mcGUaW4_MiYQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritearguides/v5/iJWYBWqKZTrYS9uv-Ry6kDf-q_0Xq67mQGQQXw.ttf"
     },
     {
       "family": "Playwrite AT",
@@ -30724,21 +31209,40 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M77d03MLIHJ-rk.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2E76d03MLIHJ-rk.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2JD6d03MLIHJ-rk.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M76d03MLIHJ-rk.ttf",
-        "100italic": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5nw_GKKPM6rkyVg.ttf",
-        "200italic": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5Hw7GKKPM6rkyVg.ttf",
-        "300italic": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5wQ7GKKPM6rkyVg.ttf",
-        "italic": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5nw7GKKPM6rkyVg.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M77d03MLIHJ-rk.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2E76d03MLIHJ-rk.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2JD6d03MLIHJ-rk.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M76d03MLIHJ-rk.ttf",
+        "100italic": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5nw_GKKPM6rkyVg.ttf",
+        "200italic": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5Hw7GKKPM6rkyVg.ttf",
+        "300italic": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5wQ7GKKPM6rkyVg.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6uwc7n6kfJN4fVoKON7HIuDCZgtyxdIs5hzQa5nw7GKKPM6rkyVg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteat/v1/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M76R0zGKA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteat/v5/Gw6owc7n6kfJN4fVoKON7HIEBRSfb0U2uGBm2M76R0zGKA.ttf"
+    },
+    {
+      "family": "Playwrite AT Guides",
+      "variants": [
+        "regular",
+        "italic"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteatguides/v1/QdVKSS0gJR2xneUeQPfE-FVA1BlZQRpBRbgJdhapcUU.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwriteatguides/v1/QdVISS0gJR2xneUeQPfE-FVA1BlZQRpBdboDcjSsYUVUjg.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteatguides/v1/QdVKSS0gJR2xneUeQPfE-FVA1BlZQRpBdbkDcg.ttf"
     },
     {
       "family": "Playwrite AU NSW",
@@ -30751,17 +31255,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteaunsw/v4/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjML96TD2dC1gS.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteaunsw/v4/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xbjMb96TD2dC1gS.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteaunsw/v4/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xY9Mb96TD2dC1gS.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteaunsw/v4/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjMb96TD2dC1gS.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteaunsw/v10/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjML96TD2dC1gS.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteaunsw/v10/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xbjMb96TD2dC1gS.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteaunsw/v10/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xY9Mb96TD2dC1gS.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteaunsw/v10/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjMb96TD2dC1gS.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteaunsw/v4/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjMY97Rjk.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteaunsw/v10/6qLWKY4NtxD-qVlIPUIPenElWCCEWRgilpupBXi19xZjMY97Rjk.ttf"
+    },
+    {
+      "family": "Playwrite AU NSW Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteaunswguides/v1/LDIiao-QNRMmVPcU8-sgUraMF7GZs_1Emk3v8tPbZeQ3YBXs.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteaunswguides/v1/LDIiao-QNRMmVPcU8-sgUraMF7GZs_1Emk3v8uPab-A.ttf"
     },
     {
       "family": "Playwrite AU QLD",
@@ -30774,17 +31295,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteauqld/v4/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yMY2fqm1BV-XS.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteauqld/v4/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA68yMI2fqm1BV-XS.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteauqld/v4/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6_sMI2fqm1BV-XS.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteauqld/v4/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yMI2fqm1BV-XS.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteauqld/v10/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yMY2fqm1BV-XS.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteauqld/v10/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA68yMI2fqm1BV-XS.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteauqld/v10/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6_sMI2fqm1BV-XS.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteauqld/v10/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yMI2fqm1BV-XS.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteauqld/v4/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yML2eoGk.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteauqld/v10/SlGGmR-Yo5oYZX5BFVcEwSFSOXBRWADAWbgjmLBhA6-yML2eoGk.ttf"
+    },
+    {
+      "family": "Playwrite AU QLD Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteauqldguides/v1/TuGBUUJtX5tTUfQi_7kbiZZFVhl0FIKnvy00LDxlIzIU5RwD.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteauqldguides/v1/TuGBUUJtX5tTUfQi_7kbiZZFVhl0FIKnvy00LAxkKTY.ttf"
     },
     {
       "family": "Playwrite AU SA",
@@ -30797,17 +31335,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteausa/v4/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgQcuVjCoV0bbE.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteausa/v4/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpRgRcuVjCoV0bbE.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteausa/v4/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpcYRcuVjCoV0bbE.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteausa/v4/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgRcuVjCoV0bbE.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteausa/v10/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgQcuVjCoV0bbE.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteausa/v10/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpRgRcuVjCoV0bbE.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteausa/v10/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpcYRcuVjCoV0bbE.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteausa/v10/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgRcuVjCoV0bbE.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteausa/v4/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgRQuRpDg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteausa/v10/YcmhsZpNS1SdgmHbGgtRuUElnR3CmSC5bVQVlrclpZgRQuRpDg.ttf"
+    },
+    {
+      "family": "Playwrite AU SA Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteausaguides/v1/3JnsSCLj03y8jUv7aFWBCCglBaFjl54aVBAovcgEP-Z3054.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteausaguides/v1/3JnsSCLj03y8jUv7aFWBCCglBaFjl54aVBAojckOOw.ttf"
     },
     {
       "family": "Playwrite AU TAS",
@@ -30820,17 +31375,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteautas/v4/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEHqK6Hl9WrXm4.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteautas/v4/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLWEH6K6Hl9WrXm4.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteautas/v4/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLVaH6K6Hl9WrXm4.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteautas/v4/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEH6K6Hl9WrXm4.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteautas/v10/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEHqK6Hl9WrXm4.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteautas/v10/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLWEH6K6Hl9WrXm4.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteautas/v10/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLVaH6K6Hl9WrXm4.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteautas/v10/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEH6K6Hl9WrXm4.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteautas/v4/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEH5K7FFs.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteautas/v10/GftT7u9QuxsdI_QuuctXue3ElxxmcBb3ih0opvWiLLUEH5K7FFs.ttf"
+    },
+    {
+      "family": "Playwrite AU TAS Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteautasguides/v1/cY9Vfi6cVk5RvjGtQrLqjozy3ekUDtDMDX-NNjbKL4UbaDZD.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteautasguides/v1/cY9Vfi6cVk5RvjGtQrLqjozy3ekUDtDMDX-NNgbLJYE.ttf"
     },
     {
       "family": "Playwrite AU VIC",
@@ -30843,17 +31415,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteauvic/v4/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTaLK0CBIDKNvl.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteauvic/v4/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4dTabK0CBIDKNvl.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteauvic/v4/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4eNabK0CBIDKNvl.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteauvic/v4/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTabK0CBIDKNvl.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteauvic/v10/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTaLK0CBIDKNvl.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteauvic/v10/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4dTabK0CBIDKNvl.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteauvic/v10/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4eNabK0CBIDKNvl.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteauvic/v10/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTabK0CBIDKNvl.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteauvic/v4/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTaYK1AhY.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteauvic/v10/bWtu7enUfwn0Hf1zjprKOJdcDy8rxwC1ltAeNDAAd4fTaYK1AhY.ttf"
+    },
+    {
+      "family": "Playwrite AU VIC Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteauvicguides/v1/ll8sK3mEVy6nEMXMskXIZv8owEdZpVIWaQEnuD6F2TpBa98q.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteauvicguides/v1/ll8sK3mEVy6nEMXMskXIZv8owEdZpVIWaQEnuA6E0z4.ttf"
     },
     {
       "family": "Playwrite BE VLG",
@@ -30866,17 +31455,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritebevlg/v1/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vfCMMiyBIkNg.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritebevlg/v1/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blJ8vPCMMiyBIkNg.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritebevlg/v1/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blKivPCMMiyBIkNg.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritebevlg/v1/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vPCMMiyBIkNg.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritebevlg/v5/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vfCMMiyBIkNg.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritebevlg/v5/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blJ8vPCMMiyBIkNg.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritebevlg/v5/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blKivPCMMiyBIkNg.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritebevlg/v5/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vPCMMiyBIkNg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritebevlg/v1/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vMCNOCg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritebevlg/v5/GFD8WBdug3mQSvrAT9AL6fd4ZkB-a2sDmg3dy2W0blL8vMCNOCg.ttf"
+    },
+    {
+      "family": "Playwrite BE VLG Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritebevlgguides/v2/EYqjmb1Mz6hO4edaU9qKGFZMDd_Q-zwwK__U1u9GK3nNgEoc.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritebevlgguides/v2/EYqjmb1Mz6hO4edaU9qKGFZMDd_Q-zwwK__U1t9HIX0.ttf"
     },
     {
       "family": "Playwrite BE WAL",
@@ -30889,17 +31495,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v6",
+      "lastModified": "2025-03-18",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritebewal/v1/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGfugHxwiSZp8.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritebewal/v1/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsUCGPugHxwiSZp8.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritebewal/v1/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsXcGPugHxwiSZp8.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritebewal/v1/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGPugHxwiSZp8.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritebewal/v6/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGfugHxwiSZp8.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritebewal/v6/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsUCGPugHxwiSZp8.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritebewal/v6/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsXcGPugHxwiSZp8.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritebewal/v6/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGPugHxwiSZp8.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritebewal/v1/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGMuhFRg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritebewal/v6/DtV1Jwq5QbIzyrA6DHdJ2BksuUmanQtEYjAlv96WFsWCGMuhFRg.ttf"
+    },
+    {
+      "family": "Playwrite BE WAL Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritebewalguides/v1/l7gPbiR5yM62ycwevWCt02rrTFoEJvY4kyrrUzHlVJabaOSA.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritebewalguides/v1/l7gPbiR5yM62ycwevWCt02rrTFoEJvY4kyrrUwHkXpI.ttf"
     },
     {
       "family": "Playwrite BR",
@@ -30912,17 +31535,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritebr/v4/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOOFsfjAOVZBgs.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritebr/v4/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmNOPFsfjAOVZBgs.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritebr/v4/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmA2PFsfjAOVZBgs.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritebr/v4/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOPFsfjAOVZBgs.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritebr/v10/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOOFsfjAOVZBgs.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritebr/v10/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmNOPFsfjAOVZBgs.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritebr/v10/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmA2PFsfjAOVZBgs.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritebr/v10/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOPFsfjAOVZBgs.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritebr/v4/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOPJsbpBA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritebr/v10/kJEhBuMK4Q07lDHc2Xp9vYgIp-6D3QEGCpthmFOPJsbpBA.ttf"
+    },
+    {
+      "family": "Playwrite BR Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritebrguides/v1/tssxAohQaiQS-wrnJz-F5CqW4dOezRwp-9cCOxBu_BM.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritebrguides/v1/tssxAohQaiQS-wrnJz-F5CqW4dOezRwpy9YIPw.ttf"
     },
     {
       "family": "Playwrite CA",
@@ -30935,17 +31575,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteca/v4/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiquYp261AIQU98.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteca/v4/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHqqvYp261AIQU98.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteca/v4/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHnSvYp261AIQU98.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteca/v4/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiqvYp261AIQU98.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteca/v10/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiquYp261AIQU98.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteca/v10/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHqqvYp261AIQU98.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteca/v10/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHnSvYp261AIQU98.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteca/v10/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiqvYp261AIQU98.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteca/v4/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiqvUpyw0A.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteca/v10/z7NGdR_4cT0NOrEAIElil93uR_VhfhYaYOijHiqvUpyw0A.ttf"
+    },
+    {
+      "family": "Playwrite CA Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritecaguides/v1/MjQamj1kuP_soQ3o-rysO9Ci_8oJlIUUInch3bTfcxs.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritecaguides/v1/MjQamj1kuP_soQ3o-rysO9Ci_8oJlIUUEnYr2Q.ttf"
     },
     {
       "family": "Playwrite CL",
@@ -30958,17 +31615,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritecl/v1/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JbvLq3DyPNbus.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritecl/v1/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU0JavLq3DyPNbus.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritecl/v1/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU5xavLq3DyPNbus.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritecl/v1/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JavLq3DyPNbus.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritecl/v5/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JbvLq3DyPNbus.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritecl/v5/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU0JavLq3DyPNbus.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritecl/v5/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU5xavLq3DyPNbus.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritecl/v5/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JavLq3DyPNbus.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritecl/v1/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JajLu9Cw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritecl/v5/-zk391m7wssz_XLkGgu8hy3tqrcOhnbf6ForU8JajLu9Cw.ttf"
+    },
+    {
+      "family": "Playwrite CL Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteclguides/v2/Z9XKDnxTQxyGzOn3eMH-i6Ws0czqkE-hrNpVuw5_BAM.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteclguides/v2/Z9XKDnxTQxyGzOn3eMH-i6Ws0czqkE-hnNtfvw.ttf"
     },
     {
       "family": "Playwrite CO",
@@ -30981,17 +31655,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v6",
-      "lastModified": "2024-08-12",
+      "version": "v12",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteco/v6/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZJo-dOEhxX3Iw.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteco/v6/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqxzZIo-dOEhxX3Iw.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteco/v6/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx-hIo-dOEhxX3Iw.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteco/v6/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZIo-dOEhxX3Iw.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteco/v12/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZJo-dOEhxX3Iw.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteco/v12/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqxzZIo-dOEhxX3Iw.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteco/v12/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx-hIo-dOEhxX3Iw.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteco/v12/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZIo-dOEhxX3Iw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteco/v6/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZIk-ZEFg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteco/v12/0FlGVP2Hl1iH-fv2BH4kJkgb8vH-rbJPTDqqx7ZIk-ZEFg.ttf"
+    },
+    {
+      "family": "Playwrite CO Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v5",
+      "lastModified": "2025-03-03",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritecoguides/v5/AYCXpWvtftIVXepC5AzjAx1KgYPugOK0TqxTJw_GOM0.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritecoguides/v5/AYCXpWvtftIVXepC5AzjAx1KgYPugOK0fq1ZIw.ttf"
     },
     {
       "family": "Playwrite CU",
@@ -31004,17 +31695,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritecu/v1/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmwZeT7m2YIByI.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritecu/v1/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseZmxZeT7m2YIByI.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritecu/v1/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseUexZeT7m2YIByI.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritecu/v1/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmxZeT7m2YIByI.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritecu/v5/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmwZeT7m2YIByI.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritecu/v5/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseZmxZeT7m2YIByI.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritecu/v5/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseUexZeT7m2YIByI.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritecu/v5/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmxZeT7m2YIByI.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritecu/v1/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmxVeXxnw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritecu/v5/VuJjdNDb2p7tvoFGLMPdf9xcahOpb9ZuoyXseRmxVeXxnw.ttf"
+    },
+    {
+      "family": "Playwrite CU Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritecuguides/v1/c4m81mZtG8v6p3iAoFBJ2dJdu9fWPSaOFooIDQtJbok.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritecuguides/v1/c4m81mZtG8v6p3iAoFBJ2dJdu9fWPSaOJosCCQ.ttf"
     },
     {
       "family": "Playwrite CZ",
@@ -31027,17 +31735,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritecz/v1/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4aTqT_VkAS5X4.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritecz/v1/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCA4bTqT_VkAS5X4.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritecz/v1/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCNAbTqT_VkAS5X4.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritecz/v1/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4bTqT_VkAS5X4.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritecz/v5/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4aTqT_VkAS5X4.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritecz/v5/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCA4bTqT_VkAS5X4.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritecz/v5/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCNAbTqT_VkAS5X4.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritecz/v5/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4bTqT_VkAS5X4.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritecz/v1/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4bfqX1Ug.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritecz/v5/8vIa7wYp22pt_BUChSHeVxxlOPUEKoMfap_FCI4bfqX1Ug.ttf"
+    },
+    {
+      "family": "Playwrite CZ Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteczguides/v1/6qLcKY0NtxD-qVlIPUIPeH4lUQa6B3ZZQkseuneh7xc.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteczguides/v1/6qLcKY0NtxD-qVlIPUIPeH4lUQa6B3ZZckoUvg.ttf"
     },
     {
       "family": "Playwrite DE Grund",
@@ -31050,17 +31775,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedegrund/v4/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qGZwCUOfSwZTM.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedegrund/v4/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz-qHZwCUOfSwZTM.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedegrund/v4/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZzzSHZwCUOfSwZTM.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedegrund/v4/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qHZwCUOfSwZTM.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedegrund/v10/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qGZwCUOfSwZTM.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedegrund/v10/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz-qHZwCUOfSwZTM.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedegrund/v10/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZzzSHZwCUOfSwZTM.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedegrund/v10/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qHZwCUOfSwZTM.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedegrund/v4/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qHVwGePQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedegrund/v10/EJR-QhwoXdccriFurnRxqv-1MFyKy696-4VufrEGGbTZz2qHVwGePQ.ttf"
+    },
+    {
+      "family": "Playwrite DE Grund Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedegrundguides/v1/OD5RuNCQ02KrAHnha1L36CWcQ83dtK5BLxqexnduX98TJlnjHAA.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedegrundguides/v1/OD5RuNCQ02KrAHnha1L36CWcQ83dtK5BLxqexndub94ZIg.ttf"
     },
     {
       "family": "Playwrite DE LA",
@@ -31073,17 +31815,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedela/v4/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnrPgcigC5Ph2w.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedela/v4/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2NnqPgcigC5Ph2w.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedela/v4/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2AfqPgcigC5Ph2w.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedela/v4/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnqPgcigC5Ph2w.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedela/v10/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnrPgcigC5Ph2w.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedela/v10/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2NnqPgcigC5Ph2w.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedela/v10/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2AfqPgcigC5Ph2w.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedela/v10/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnqPgcigC5Ph2w.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedela/v4/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnqDgYohA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedela/v10/oY1J8e3fprboJ2HN4ogXTpFVJ8QjJV9p0P4yukst2FnqDgYohA.ttf"
+    },
+    {
+      "family": "Playwrite DE LA Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedelaguides/v2/1q2XY42fB0V64O4aSe1OjKs_yAXBOfDI5wE56g2M62M1AXs.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedelaguides/v2/1q2XY42fB0V64O4aSe1OjKs_yAXBOfDI5wE52gyG7w.ttf"
     },
     {
       "family": "Playwrite DE SAS",
@@ -31096,17 +31855,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedesas/v4/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVg-6lSyVPgRkJ.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedesas/v4/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTcVgu6lSyVPgRkJ.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedesas/v4/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTfLgu6lSyVPgRkJ.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedesas/v4/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVgu6lSyVPgRkJ.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedesas/v10/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVg-6lSyVPgRkJ.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedesas/v10/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTcVgu6lSyVPgRkJ.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedesas/v10/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTfLgu6lSyVPgRkJ.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedesas/v10/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVgu6lSyVPgRkJ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedesas/v4/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVgt6kQSE.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedesas/v10/1Pt4g9vaRvmWghDdrE8IDuRPVrHN_1AaFXASpbMqJTeVgt6kQSE.ttf"
+    },
+    {
+      "family": "Playwrite DE SAS Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedesasguides/v1/8At5GtCjPp-GWR2h9cC6ePzz2l6LJ3VZaPNi15BEdtBgPI1G.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedesasguides/v1/8At5GtCjPp-GWR2h9cC6ePzz2l6LJ3VZaPNi16BFfNQ.ttf"
     },
     {
       "family": "Playwrite DE VA",
@@ -31119,17 +31895,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedeva/v4/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSyTv24jGyvutu4.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedeva/v4/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRaySv24jGyvutu4.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedeva/v4/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRXKSv24jGyvutu4.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedeva/v4/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSySv24jGyvutu4.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedeva/v10/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSyTv24jGyvutu4.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedeva/v10/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRaySv24jGyvutu4.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedeva/v10/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRXKSv24jGyvutu4.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedeva/v10/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSySv24jGyvutu4.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedeva/v4/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSySj28pHw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedeva/v10/VuJmdNPb2p7tvoFGLMPdeMxGN1pntEMhdK1XfsTyRSySj28pHw.ttf"
+    },
+    {
+      "family": "Playwrite DE VA Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedevaguides/v1/WwkPxOmkDVqm-ojMLT_kdMUoBpMYm6KTeb28UB9SNQIUdqQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedevaguides/v1/WwkPxOmkDVqm-ojMLT_kdMUoBpMYm6KTeb28YB5YMQ.ttf"
     },
     {
       "family": "Playwrite DK Loopet",
@@ -31142,17 +31935,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedkloopet/v1/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwOgRuQovSE8_.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedkloopet/v1/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75LJwegRuQovSE8_.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedkloopet/v1/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75IXwegRuQovSE8_.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedkloopet/v1/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwegRuQovSE8_.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedkloopet/v5/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwOgRuQovSE8_.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedkloopet/v5/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75LJwegRuQovSE8_.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedkloopet/v5/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75IXwegRuQovSE8_.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedkloopet/v5/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwegRuQovSE8_.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedkloopet/v1/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwdgQsw4.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedkloopet/v5/memVYbuzy2qb3rtJGfM1FvY-GacDcsPvtaDfqfgbBWmV75JJwdgQsw4.ttf"
+    },
+    {
+      "family": "Playwrite DK Loopet Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedkloopetguides/v1/4iC46LlmYsRPlQ1zDEvT8weoW-sI8-h9xxN83W-Cb5tmElj-b0nB.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedkloopetguides/v1/4iC46LlmYsRPlQ1zDEvT8weoW-sI8-h9xxN83W-Cb6tnGFw.ttf"
     },
     {
       "family": "Playwrite DK Uloopet",
@@ -31165,17 +31975,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritedkuloopet/v1/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lQrKeng6LUzAA.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritedkuloopet/v1/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K0alUrKeng6LUzAA.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritedkuloopet/v1/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K0tFUrKeng6LUzAA.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritedkuloopet/v1/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lUrKeng6LUzAA.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritedkuloopet/v5/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lQrKeng6LUzAA.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritedkuloopet/v5/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K0alUrKeng6LUzAA.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritedkuloopet/v5/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K0tFUrKeng6LUzAA.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritedkuloopet/v5/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lUrKeng6LUzAA.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritedkuloopet/v1/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lUbKOPk.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritedkuloopet/v5/bWtS7e3Ufwn0Hf1zjprKPYlcDAoHknvYFjqIh8PF6jwcP5K06lUbKOPk.ttf"
+    },
+    {
+      "family": "Playwrite DK Uloopet Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritedkuloopetguides/v1/WwkKxOSkDVqm-ojMLT_kdMsoBb5Xs6efafiIBXYcVHk1bo9bkIONtA.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritedkuloopetguides/v1/WwkKxOSkDVqm-ojMLT_kdMsoBb5Xs6efafiIBXYcVHkFb4Vf.ttf"
     },
     {
       "family": "Playwrite ES",
@@ -31188,17 +32015,17 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritees/v4/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOOFsfjAOVZBgs.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritees/v4/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmNOPFsfjAOVZBgs.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritees/v4/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmA2PFsfjAOVZBgs.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritees/v4/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOPFsfjAOVZBgs.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritees/v10/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOOFsfjAOVZBgs.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritees/v10/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmNOPFsfjAOVZBgs.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritees/v10/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmA2PFsfjAOVZBgs.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritees/v10/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOPFsfjAOVZBgs.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritees/v4/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOPJsbpBA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritees/v10/kJEhBuMK4Q07lDHc2Xp9uokIp-6D3QEGCpthmFOPJsbpBA.ttf"
     },
     {
       "family": "Playwrite ES Deco",
@@ -31211,17 +32038,51 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteesdeco/v4/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrZxOQ9p5Cljpw.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteesdeco/v4/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4SrdxOQ9p5Cljpw.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteesdeco/v4/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4lLdxOQ9p5Cljpw.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteesdeco/v4/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrdxOQ9p5Cljpw.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteesdeco/v10/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrZxOQ9p5Cljpw.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteesdeco/v10/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4SrdxOQ9p5Cljpw.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteesdeco/v10/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4lLdxOQ9p5Cljpw.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteesdeco/v10/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrdxOQ9p5Cljpw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteesdeco/v4/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrdBOAVt.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteesdeco/v10/7AuWp-g3kjKKGkePXEf2jxctfDxlvGM7-RllW8uEsjJ4yrdBOAVt.ttf"
+    },
+    {
+      "family": "Playwrite ES Deco Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteesdecoguides/v1/flUrRriwwII5RVl2TZ1XBNTUOYY6ZzZzwPCEKtwqYEyDBQWJ7Q.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteesdecoguides/v1/flUrRriwwII5RVl2TZ1XBNTUOYY6ZzZzwPCEKtwaYUaH.ttf"
+    },
+    {
+      "family": "Playwrite ES Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteesguides/v1/VuJtdM_b2p7tvoFGLMPdedpGJm402y6mhDDGfdnzXeU.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteesguides/v1/VuJtdM_b2p7tvoFGLMPdedpGJm402y6mtDHMeQ.ttf"
     },
     {
       "family": "Playwrite FR Moderne",
@@ -31234,17 +32095,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritefrmoderne/v4/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAOvAl74XSpRjw.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritefrmoderne/v4/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJOAKvAl74XSpRjw.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritefrmoderne/v4/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJ5gKvAl74XSpRjw.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritefrmoderne/v4/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAKvAl74XSpRjw.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritefrmoderne/v10/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAOvAl74XSpRjw.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritefrmoderne/v10/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJOAKvAl74XSpRjw.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritefrmoderne/v10/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJ5gKvAl74XSpRjw.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritefrmoderne/v10/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAKvAl74XSpRjw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritefrmoderne/v4/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAKfA1T8.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritefrmoderne/v10/3y9L6awucz3w5m4FFTzKolJRXhUk_u1yWtWmFCJcqUBvK5aJuAKfA1T8.ttf"
+    },
+    {
+      "family": "Playwrite FR Moderne Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritefrmoderneguides/v2/CSRr4yxOn-mMWCgLPl16KrUKBbwa2ZZLdkrvXllIP22HnIzLvrG2fw.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritefrmoderneguides/v2/CSRr4yxOn-mMWCgLPl16KrUKBbwa2ZZLdkrvXllIP223nYbP.ttf"
     },
     {
       "family": "Playwrite FR Trad",
@@ -31257,17 +32135,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v6",
-      "lastModified": "2024-08-12",
+      "version": "v12",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritefrtrad/v6/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogrNdt-fwzTS5A.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritefrtrad/v6/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAIgvNdt-fwzTS5A.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritefrtrad/v6/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvA_AvNdt-fwzTS5A.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritefrtrad/v6/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogvNdt-fwzTS5A.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritefrtrad/v12/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogrNdt-fwzTS5A.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritefrtrad/v12/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAIgvNdt-fwzTS5A.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritefrtrad/v12/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvA_AvNdt-fwzTS5A.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritefrtrad/v12/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogvNdt-fwzTS5A.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritefrtrad/v6/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogv9d9Wb.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritefrtrad/v12/sJot3KxJjdGLJV3vyatrJE2pkQisWWMBP23HSIVI5tvAogv9d9Wb.ttf"
+    },
+    {
+      "family": "Playwrite FR Trad Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritefrtradguides/v1/l7gMbit5yM62ycwevWCt133rT2kpYpEKjyfqRWLFfriXYf2ZXw.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritefrtradguides/v1/l7gMbit5yM62ycwevWCt133rT2kpYpEKjyfqRWL1f7KT.ttf"
     },
     {
       "family": "Playwrite GB J",
@@ -31284,21 +32179,40 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc5HaN7X9HFR8Q.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheG9c9HaN7X9HFR8Q.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGK89HaN7X9HFR8Q.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc9HaN7X9HFR8Q.ttf",
-        "100italic": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYyvKtTT1nRB8S9t.ttf",
-        "200italic": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYwvK9TT1nRB8S9t.ttf",
-        "300italic": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYzxK9TT1nRB8S9t.ttf",
-        "italic": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYyvK9TT1nRB8S9t.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc5HaN7X9HFR8Q.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheG9c9HaN7X9HFR8Q.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGK89HaN7X9HFR8Q.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc9HaN7X9HFR8Q.ttf",
+        "100italic": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYyvKtTT1nRB8S9t.ttf",
+        "200italic": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYwvK9TT1nRB8S9t.ttf",
+        "300italic": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYzxK9TT1nRB8S9t.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kGo8wSPe9dzQ1UGbvobAPhY7KPywT2BnwHoBCTvYyvK9TT1nRB8S9t.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritegbj/v4/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc93adTT.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritegbj/v10/k3kEo8wSPe9dzQ1UGbvobAPhY5iG-fsubxedDheGdc93adTT.ttf"
+    },
+    {
+      "family": "Playwrite GB J Guides",
+      "variants": [
+        "regular",
+        "italic"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritegbjguides/v2/CSRh4yJOn-mMWCgLPl16K6UKAvM5yY1BdhmIKxooUh-_nQ.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwritegbjguides/v2/CSRv4yJOn-mMWCgLPl16K6UKAvM5yY1Bdhm4KRAscBqvnb7O.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritegbjguides/v2/CSRh4yJOn-mMWCgLPl16K6UKAvM5yY1Bdhm4KhAs.ttf"
     },
     {
       "family": "Playwrite GB S",
@@ -31315,21 +32229,40 @@
       "subsets": [
         "latin"
       ],
-      "version": "v5",
-      "lastModified": "2024-08-12",
+      "version": "v11",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhH8x5eMaTk8AQ.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6OhD8x5eMaTk8AQ.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU65BD8x5eMaTk8AQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhD8x5eMaTk8AQ.ttf",
-        "100italic": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclMUhZ2ISzwsAReZ.ttf",
-        "200italic": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclOUhJ2ISzwsAReZ.ttf",
-        "300italic": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclNKhJ2ISzwsAReZ.ttf",
-        "italic": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclMUhJ2ISzwsAReZ.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhH8x5eMaTk8AQ.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6OhD8x5eMaTk8AQ.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU65BD8x5eMaTk8AQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhD8x5eMaTk8AQ.ttf",
+        "100italic": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclMUhZ2ISzwsAReZ.ttf",
+        "200italic": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclOUhJ2ISzwsAReZ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclNKhJ2ISzwsAReZ.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWZ_kFkk-s1Xclhmlemy7jsNS51fHeeOptJs2IvclMUhJ2ISzwsAReZ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritegbs/v5/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhDMxp2I.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritegbs/v11/oPWb_kFkk-s1Xclhmlemy7jsNQR8TohGU_DTHWU6uhDMxp2I.ttf"
+    },
+    {
+      "family": "Playwrite GB S Guides",
+      "variants": [
+        "regular",
+        "italic"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritegbsguides/v1/0FlKVOSHl1iH-fv2BH4kIkUBqtlNCEaQLlyKx1QPi-Z8Fw.ttf",
+        "italic": "https://fonts.gstatic.com/s/playwritegbsguides/v1/0FlEVOSHl1iH-fv2BH4kIkUBqtlNCEaQLly6xV4LqeNsFwxX.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritegbsguides/v1/0FlKVOSHl1iH-fv2BH4kIkUBqtlNCEaQLly6xl4L.ttf"
     },
     {
       "family": "Playwrite HR",
@@ -31342,17 +32275,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritehr/v1/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoA9YHXAHC7tvg.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritehr/v1/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPkoB9YHXAHC7tvg.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritehr/v1/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPpQB9YHXAHC7tvg.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritehr/v1/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoB9YHXAHC7tvg.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritehr/v5/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoA9YHXAHC7tvg.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritehr/v5/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPkoB9YHXAHC7tvg.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritehr/v5/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPpQB9YHXAHC7tvg.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritehr/v5/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoB9YHXAHC7tvg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritehr/v1/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoBxYDdBA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritehr/v5/WWXAljmQYQCZM5qaU_dwQYcybAQ7GFn1mFNJPsoBxYDdBA.ttf"
+    },
+    {
+      "family": "Playwrite HR Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritehrguides/v1/6NUK8EedKwOcfRjj8ukv_L4kjqAoGrjdWmA08mCgdfM.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritehrguides/v1/6NUK8EedKwOcfRjj8ukv_L4kjqAoGrjdamE-9g.ttf"
     },
     {
       "family": "Playwrite HR Lijeva",
@@ -31365,17 +32315,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritehrlijeva/v1/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zB8aUy4_lxmKl.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritehrlijeva/v1/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d6zBsaUy4_lxmKl.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritehrlijeva/v1/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d5tBsaUy4_lxmKl.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritehrlijeva/v1/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zBsaUy4_lxmKl.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritehrlijeva/v5/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zB8aUy4_lxmKl.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritehrlijeva/v5/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d6zBsaUy4_lxmKl.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritehrlijeva/v5/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d5tBsaUy4_lxmKl.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritehrlijeva/v5/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zBsaUy4_lxmKl.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritehrlijeva/v1/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zBvaVwYs.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritehrlijeva/v5/gNMvW2dhS5-p7HvxrBYiWN2SsKqLWCrYiDBAvbRl82ZY0d4zBvaVwYs.ttf"
+    },
+    {
+      "family": "Playwrite HR Lijeva Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritehrlijevaguides/v1/uU9aCAgH7I63K35cu3bRkqamzjr8EW133LJaXDO-QObhgDgMKYJO.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritehrlijevaguides/v1/uU9aCAgH7I63K35cu3bRkqamzjr8EW133LJaXDO-QNbgijw.ttf"
     },
     {
       "family": "Playwrite HU",
@@ -31388,17 +32355,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritehu/v1/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL7TO2dH3B2Xx4.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritehu/v1/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1HL6TO2dH3B2Xx4.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritehu/v1/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1Kz6TO2dH3B2Xx4.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritehu/v1/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL6TO2dH3B2Xx4.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritehu/v5/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL7TO2dH3B2Xx4.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritehu/v5/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1HL6TO2dH3B2Xx4.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritehu/v5/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1Kz6TO2dH3B2Xx4.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritehu/v5/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL6TO2dH3B2Xx4.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritehu/v1/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL6fOyXGw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritehu/v5/A2BIn59A0g0xA3zDhFw-0vfPWJtlaFKmrETx1PL6fOyXGw.ttf"
+    },
+    {
+      "family": "Playwrite HU Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritehuguides/v1/AYCXpWvtftIVXepC5AzjCAdKgYPugOK0TqxTJw_GOM0.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritehuguides/v1/AYCXpWvtftIVXepC5AzjCAdKgYPugOK0fq1ZIw.ttf"
     },
     {
       "family": "Playwrite ID",
@@ -31411,17 +32395,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteid/v4/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-QB_JbFi0pLlg.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteid/v4/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl8-RB_JbFi0pLlg.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteid/v4/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUlxGRB_JbFi0pLlg.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteid/v4/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-RB_JbFi0pLlg.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteid/v10/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-QB_JbFi0pLlg.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteid/v10/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl8-RB_JbFi0pLlg.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteid/v10/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUlxGRB_JbFi0pLlg.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteid/v10/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-RB_JbFi0pLlg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteid/v4/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-RN_NREg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteid/v10/Cn-kJt2YWhlY2oC4KxifKQJmrtrRm-sKkQqUl0-RN_NREg.ttf"
+    },
+    {
+      "family": "Playwrite ID Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteidguides/v1/MjQamj1kuP_soQ3o-rysMdWi_8oJlIUUInch3bTfcxs.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteidguides/v1/MjQamj1kuP_soQ3o-rysMdWi_8oJlIUUEnYr2Q.ttf"
     },
     {
       "family": "Playwrite IE",
@@ -31434,17 +32435,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteie/v4/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzipBpIu30AZbUY.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteie/v4/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMy7ioBpIu30AZbUY.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteie/v4/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMy2aoBpIu30AZbUY.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteie/v4/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzioBpIu30AZbUY.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteie/v10/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzipBpIu30AZbUY.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteie/v10/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMy7ioBpIu30AZbUY.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteie/v10/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMy2aoBpIu30AZbUY.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteie/v10/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzioBpIu30AZbUY.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteie/v4/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzioNpMk2w.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteie/v10/fC1zPYtWYWnH0hvndYd6GCGWXCAxfsUebXFMyzioNpMk2w.ttf"
+    },
+    {
+      "family": "Playwrite IE Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteieguides/v1/LhW5MULFNP8PI-1UADw_Kbp9daTx5ovUaNojN9_8IVQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteieguides/v1/LhW5MULFNP8PI-1UADw_Kbp9daTx5ovUWNspMw.ttf"
     },
     {
       "family": "Playwrite IN",
@@ -31457,17 +32475,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritein/v4/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mNMR8n3_Ag1kU.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritein/v4/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkMzmMMR8n3_Ag1kU.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritein/v4/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM-eMMR8n3_Ag1kU.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritein/v4/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mMMR8n3_Ag1kU.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritein/v10/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mNMR8n3_Ag1kU.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritein/v10/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkMzmMMR8n3_Ag1kU.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritein/v10/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM-eMMR8n3_Ag1kU.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritein/v10/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mMMR8n3_Ag1kU.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritein/v4/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mMAR4t2w.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritein/v10/uk-xEGGpoLQ97mfv2J3cZzuz7CyEJhPw65lkM7mMAR4t2w.ttf"
+    },
+    {
+      "family": "Playwrite IN Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteinguides/v1/GFD2WBRug3mQSvrAT9AL4vx4d3lQNQV4Tt1qdGqgdlM.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteinguides/v1/GFD2WBRug3mQSvrAT9AL4vx4d3lQNQV4ftxgcA.ttf"
     },
     {
       "family": "Playwrite IS",
@@ -31480,17 +32515,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteis/v3/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R8aX9-p7K5ILg.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteis/v3/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jqyR9aX9-p7K5ILg.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteis/v3/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq_p9aX9-p7K5ILg.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteis/v3/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R9aX9-p7K5ILg.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteis/v9/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R8aX9-p7K5ILg.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteis/v9/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jqyR9aX9-p7K5ILg.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteis/v9/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq_p9aX9-p7K5ILg.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteis/v9/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R9aX9-p7K5ILg.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteis/v3/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R9WX50ow.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteis/v9/JTUFjI4o_SGg9lecLGptrD17xQYXK0vOoz6jq6R9WX50ow.ttf"
+    },
+    {
+      "family": "Playwrite IS Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteisguides/v1/5aUp9-GkphaVExwxdX6SwWF-uigk3Cglrm9ptxu7HZ0.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteisguides/v1/5aUp9-GkphaVExwxdX6SwWF-uigk3Cglnm5jsw.ttf"
     },
     {
       "family": "Playwrite IT Moderna",
@@ -31503,17 +32555,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteitmoderna/v4/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5Wil8ubbffHtmMw.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteitmoderna/v4/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F52ih8ubbffHtmMw.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteitmoderna/v4/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5BCh8ubbffHtmMw.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteitmoderna/v4/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5Wih8ubbffHtmMw.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteitmoderna/v10/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5Wil8ubbffHtmMw.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteitmoderna/v10/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F52ih8ubbffHtmMw.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteitmoderna/v10/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5BCh8ubbffHtmMw.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteitmoderna/v10/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5Wih8ubbffHtmMw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteitmoderna/v4/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5WihMuLzb.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteitmoderna/v10/mFTbWaYCwKPK5cx6W8jy2kwDnSUe9q45vQQi5HMFnSdEx2F5WihMuLzb.ttf"
+    },
+    {
+      "family": "Playwrite IT Moderna Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteitmodernaguides/v1/2sDKZHBJg5rCj6fz_QgDJhGcTtJ5AVu-1w5jRQjRv9qPpOVtBhB5gQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteitmodernaguides/v1/2sDKZHBJg5rCj6fz_QgDJhGcTtJ5AVu-1w5jRQjRv9q_pe9p.ttf"
     },
     {
       "family": "Playwrite IT Trad",
@@ -31526,17 +32595,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteittrad/v4/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u--_gENNXvzL2Q.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteittrad/v4/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96O-6_gENNXvzL2Q.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteittrad/v4/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq965e6_gENNXvzL2Q.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteittrad/v4/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u-6_gENNXvzL2Q.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteittrad/v10/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u--_gENNXvzL2Q.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteittrad/v10/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96O-6_gENNXvzL2Q.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteittrad/v10/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq965e6_gENNXvzL2Q.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteittrad/v10/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u-6_gENNXvzL2Q.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteittrad/v4/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u-6PgUlJ.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteittrad/v10/SlG5mR6Yo5oYZX5BFVcEySBSPE50BjHDpZxuvgxzFq96u-6PgUlJ.ttf"
+    },
+    {
+      "family": "Playwrite IT Trad Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteittradguides/v2/SlGDmReYo5oYZX5BFVcEySBSPE50BiuP2AHaRsRUA4V-e6yHgQ.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteittradguides/v2/SlGDmReYo5oYZX5BFVcEySBSPE50BiuP2AHaRsRkAo96.ttf"
     },
     {
       "family": "Playwrite MX",
@@ -31549,17 +32635,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v12",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritemx/v4/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnc5xYfXDWXDu8.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritemx/v4/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr94nd5xYfXDWXDu8.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritemx/v4/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr91fd5xYfXDWXDu8.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritemx/v4/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnd5xYfXDWXDu8.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritemx/v12/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnc5xYfXDWXDu8.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritemx/v12/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr94nd5xYfXDWXDu8.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritemx/v12/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr91fd5xYfXDWXDu8.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritemx/v12/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnd5xYfXDWXDu8.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritemx/v4/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnd1xcVWA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritemx/v12/6xK9dSNbKtCe7KfhXg7RYSwyQ-oO7xNblyJr9wnd1xcVWA.ttf"
+    },
+    {
+      "family": "Playwrite MX Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritemxguides/v1/k3kMo9ESPe9dzQ1UGbvoZhnhbtfklWqN0qywHx-HpY0.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritemxguides/v1/k3kMo9ESPe9dzQ1UGbvoZhnhbtfklWqN4q26Gw.ttf"
     },
     {
       "family": "Playwrite NG Modern",
@@ -31572,17 +32675,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritengmodern/v4/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPQbi5GswWJNE.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritengmodern/v4/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V15tPAbi5GswWJNE.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritengmodern/v4/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V16zPAbi5GswWJNE.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritengmodern/v4/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPAbi5GswWJNE.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritengmodern/v10/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPQbi5GswWJNE.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritengmodern/v10/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V15tPAbi5GswWJNE.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritengmodern/v10/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V16zPAbi5GswWJNE.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritengmodern/v10/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPAbi5GswWJNE.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritengmodern/v4/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPDbj7m8.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritengmodern/v10/ijw-s4b2R9Qve5V5lNJb_yRhEfSep5NbFCKmKgoEeCA4V17tPDbj7m8.ttf"
+    },
+    {
+      "family": "Playwrite NG Modern Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritengmodernguides/v1/6qLVKYQNtxD-qVlIPUIPdWMlWxy3BmFEQgxB1xvFhDarWJtyZyGU.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritengmodernguides/v1/6qLVKYQNtxD-qVlIPUIPdWMlWxy3BmFEQgxB1xvFhAaqUp8.ttf"
     },
     {
       "family": "Playwrite NL",
@@ -31595,17 +32715,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritenl/v3/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_EnYxNbPzS5HE.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritenl/v3/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG1_FnYxNbPzS5HE.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritenl/v3/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG4HFnYxNbPzS5HE.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritenl/v3/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_FnYxNbPzS5HE.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritenl/v9/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_EnYxNbPzS5HE.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritenl/v9/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG1_FnYxNbPzS5HE.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritenl/v9/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG4HFnYxNbPzS5HE.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritenl/v9/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_FnYxNbPzS5HE.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritenl/v3/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_FrY1HaA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritenl/v9/k3kCo84SPe9dzQ1UGbvoZQ37Iqp5IZJF9bmaG9_FrY1HaA.ttf"
+    },
+    {
+      "family": "Playwrite NL Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritenlguides/v1/FwZH7_8mxlw-50y5PJughoCL4jbXkMqwsWKGP6kvdPA.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritenlguides/v1/FwZH7_8mxlw-50y5PJughoCL4jbXkMqwgWOMOw.ttf"
     },
     {
       "family": "Playwrite NO",
@@ -31618,17 +32755,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteno/v3/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49whHKen-mjRVtc.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteno/v3/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-41wgHKen-mjRVtc.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteno/v3/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-44IgHKen-mjRVtc.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteno/v3/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49wgHKen-mjRVtc.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteno/v9/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49whHKen-mjRVtc.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteno/v9/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-41wgHKen-mjRVtc.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteno/v9/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-44IgHKen-mjRVtc.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteno/v9/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49wgHKen-mjRVtc.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteno/v3/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49wgLKat_g.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteno/v9/nuFrD_fYSZviRJYb-P2TrQO1DRpazaZDgnw-49wgLKat_g.ttf"
+    },
+    {
+      "family": "Playwrite NO Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritenoguides/v1/DPEwYx-Cyg4cQ2aAcFshOLL79zJKccqHe2-Z2vnLeAs.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritenoguides/v1/DPEwYx-Cyg4cQ2aAcFshOLL79zJKccqHS26T3g.ttf"
     },
     {
       "family": "Playwrite NZ",
@@ -31641,17 +32795,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritenz/v4/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAVeRt5gGCzkrs.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritenz/v4/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjnoAUeRt5gGCzkrs.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritenz/v4/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjnl4UeRt5gGCzkrs.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritenz/v4/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAUeRt5gGCzkrs.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritenz/v10/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAVeRt5gGCzkrs.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritenz/v10/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjnoAUeRt5gGCzkrs.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritenz/v10/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjnl4UeRt5gGCzkrs.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritenz/v10/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAUeRt5gGCzkrs.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritenz/v4/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAUSRpzhA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritenz/v10/d6lakaOxRsyr_zZDmUYvh2TW3NCQVvjKPjPjngAUSRpzhA.ttf"
+    },
+    {
+      "family": "Playwrite NZ Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritenzguides/v1/t5t8IQQPN4uFDRepJwiX4vzIikyGzv71Wh8xq25PL5k.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritenzguides/v1/t5t8IQQPN4uFDRepJwiX4vzIikyGzv71ah47rw.ttf"
     },
     {
       "family": "Playwrite PE",
@@ -31664,17 +32835,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v1",
-      "lastModified": "2024-08-12",
+      "version": "v5",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritepe/v1/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2lsTPHFdtSgb_A.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritepe/v1/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO-ltTPHFdtSgb_A.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritepe/v1/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesOzdtTPHFdtSgb_A.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritepe/v1/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2ltTPHFdtSgb_A.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritepe/v5/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2lsTPHFdtSgb_A.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritepe/v5/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO-ltTPHFdtSgb_A.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritepe/v5/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesOzdtTPHFdtSgb_A.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritepe/v5/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2ltTPHFdtSgb_A.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritepe/v1/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2ltfPDPcg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritepe/v5/FwZJ7-Amxlw-50y5PJugmImRrktKJDJ4lnesO2ltfPDPcg.ttf"
+    },
+    {
+      "family": "Playwrite PE Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritepeguides/v1/AMONz5uBsGadFuvf9j8ZyqI0FA3br70wwyyAlqETME8.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritepeguides/v1/AMONz5uBsGadFuvf9j8ZyqI0FA3br70w8y2Kkg.ttf"
     },
     {
       "family": "Playwrite PL",
@@ -31687,17 +32875,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritepl/v3/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfa9ZybSwcVtHQ.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritepl/v3/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmZfb9ZybSwcVtHQ.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritepl/v3/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmUnb9ZybSwcVtHQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritepl/v3/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfb9ZybSwcVtHQ.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritepl/v9/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfa9ZybSwcVtHQ.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritepl/v9/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmZfb9ZybSwcVtHQ.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritepl/v9/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmUnb9ZybSwcVtHQ.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritepl/v9/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfb9ZybSwcVtHQ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritepl/v3/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfbxZ2RTw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritepl/v9/0QIyMXVf_4C2VH-yUr5uz72U-LQiKJ_9tb1WmRfbxZ2RTw.ttf"
+    },
+    {
+      "family": "Playwrite PL Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteplguides/v1/jVyW7m_lCm7G5CZyQCAu8mgkGLk-kmibWR3aRZ2Kw7A.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteplguides/v1/jVyW7m_lCm7G5CZyQCAu8mgkGLk-kmibaRzQQQ.ttf"
     },
     {
       "family": "Playwrite PT",
@@ -31710,17 +32915,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritept/v3/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDjTfJtvlo3Qaw.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritept/v3/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9iDiTfJtvlo3Qaw.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritept/v3/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9v7iTfJtvlo3Qaw.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritept/v3/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDiTfJtvlo3Qaw.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritept/v9/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDjTfJtvlo3Qaw.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritept/v9/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9iDiTfJtvlo3Qaw.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritept/v9/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9v7iTfJtvlo3Qaw.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritept/v9/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDiTfJtvlo3Qaw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritept/v3/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDiffNnug.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritept/v9/6NUE8FidKwOcfRjj8ukv5Lg-wt21rkAVfXUe9qDiffNnug.ttf"
+    },
+    {
+      "family": "Playwrite PT Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v2",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteptguides/v2/sJoY3K5JjdGLJV3vyatrMkupgg-kWTx5F5k90TZO69o.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteptguides/v2/sJoY3K5JjdGLJV3vyatrMkupgg-kWTx5J5g31Q.ttf"
     },
     {
       "family": "Playwrite RO",
@@ -31733,17 +32955,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritero/v3/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9ZnZWMJnZeBS8.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritero/v3/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4S9YnZWMJnZeBS8.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritero/v3/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4fFYnZWMJnZeBS8.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritero/v3/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9YnZWMJnZeBS8.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritero/v9/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9ZnZWMJnZeBS8.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritero/v9/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4S9YnZWMJnZeBS8.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritero/v9/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4fFYnZWMJnZeBS8.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritero/v9/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9YnZWMJnZeBS8.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritero/v3/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9YrZSGIg.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritero/v9/gok8H6fuA1J7QPJ04HFTGSWdk_S0czhwEf0j4a9YrZSGIg.ttf"
+    },
+    {
+      "family": "Playwrite RO Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteroguides/v1/wlptgx7ZCE50snmWiOExiylvL10_b5Ym_LBte6KuGEo.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteroguides/v1/wlptgx7ZCE50snmWiOExiylvL10_b5YmzLFnfw.ttf"
     },
     {
       "family": "Playwrite SK",
@@ -31756,17 +32995,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v3",
-      "lastModified": "2024-08-12",
+      "version": "v9",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritesk/v3/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2dvsOzdK9OF68.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritesk/v3/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf22cvsOzdK9OF68.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritesk/v3/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf7OcvsOzdK9OF68.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritesk/v3/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2cvsOzdK9OF68.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritesk/v9/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2dvsOzdK9OF68.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritesk/v9/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf22cvsOzdK9OF68.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritesk/v9/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf7OcvsOzdK9OF68.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritesk/v9/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2cvsOzdK9OF68.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritesk/v3/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2cjsK5cA.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritesk/v9/9XU3lJp0klrZDw3AZHcsJTByz7latrF9yDIlf-2cjsK5cA.ttf"
+    },
+    {
+      "family": "Playwrite SK Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteskguides/v1/P5sezYaSYdfH5z93kEFk3tyPlqxeQeo_JzruWQshcbU.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteskguides/v1/P5sezYaSYdfH5z93kEFk3tyPlqxeQeo_FzvkXQ.ttf"
     },
     {
       "family": "Playwrite TZ",
@@ -31779,17 +33035,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritetz/v4/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwSue1COwjVROo.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritetz/v4/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDewTue1COwjVROo.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritetz/v4/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDTITue1COwjVROo.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritetz/v4/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwTue1COwjVROo.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritetz/v10/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwSue1COwjVROo.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritetz/v10/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDewTue1COwjVROo.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritetz/v10/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDTITue1COwjVROo.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritetz/v10/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwTue1COwjVROo.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritetz/v4/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwTiexIPw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritetz/v10/RLptK5rs6au7bzABmVQAOwnUbvHMbzSUU27JDWwTiexIPw.ttf"
+    },
+    {
+      "family": "Playwrite TZ Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritetzguides/v1/SLXUc0_L5XEkcjBPGvusk4lULgsM9U5_YQy93JQ2XEg.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritetzguides/v1/SLXUc0_L5XEkcjBPGvusk4lULgsM9U5_UQ232A.ttf"
     },
     {
       "family": "Playwrite US Modern",
@@ -31802,17 +33075,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteusmodern/v4/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNw2Da0LCgUPK.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteusmodern/v4/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YqhNg2Da0LCgUPK.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteusmodern/v4/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62Yp_Ng2Da0LCgUPK.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteusmodern/v4/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNg2Da0LCgUPK.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteusmodern/v10/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNw2Da0LCgUPK.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteusmodern/v10/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YqhNg2Da0LCgUPK.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteusmodern/v10/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62Yp_Ng2Da0LCgUPK.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteusmodern/v10/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNg2Da0LCgUPK.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteusmodern/v4/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNj2CYUY.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteusmodern/v10/H4cMBWmRlMXPhla3hmMaveiYz8nSDkIFLNIYl2TXUwK62YohNj2CYUY.ttf"
+    },
+    {
+      "family": "Playwrite US Modern Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteusmodernguides/v1/0QI1MWNf_4C2VH-yUr5uyqKOvtOynXAoku8j8Lv9pryxZQscrW1V.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteusmodernguides/v1/0QI1MWNf_4C2VH-yUr5uyqKOvtOynXAoku8j8Lv9poywbw8.ttf"
     },
     {
       "family": "Playwrite US Trad",
@@ -31825,17 +33115,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteustrad/v4/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8pgj6Kf5uBNig.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteustrad/v4/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1k8tgj6Kf5uBNig.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteustrad/v4/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1Tctgj6Kf5uBNig.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteustrad/v4/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8tgj6Kf5uBNig.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteustrad/v10/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8pgj6Kf5uBNig.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteustrad/v10/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1k8tgj6Kf5uBNig.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteustrad/v10/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1Tctgj6Kf5uBNig.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteustrad/v10/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8tgj6Kf5uBNig.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteustrad/v4/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8tQjqib.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteustrad/v10/fdNX9tyHsnVPjW9trmV7wQ0stdwRBYclCsCdzOb1-cd1E8tQjqib.ttf"
+    },
+    {
+      "family": "Playwrite US Trad Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwriteustradguides/v1/-zk29027wssz_XLkGgu8kTL39c2bMssjmiZPNnk5nJCZAyrUdw.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwriteustradguides/v1/-zk29027wssz_XLkGgu8kTL39c2bMssjmiZPNnkJnZqd.ttf"
     },
     {
       "family": "Playwrite VN",
@@ -31848,17 +33155,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwritevn/v4/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI8E-9HPWIQtD0.ttf",
-        "200": "https://fonts.gstatic.com/s/playwritevn/v4/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNcI9E-9HPWIQtD0.ttf",
-        "300": "https://fonts.gstatic.com/s/playwritevn/v4/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNRw9E-9HPWIQtD0.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwritevn/v4/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI9E-9HPWIQtD0.ttf"
+        "100": "https://fonts.gstatic.com/s/playwritevn/v10/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI8E-9HPWIQtD0.ttf",
+        "200": "https://fonts.gstatic.com/s/playwritevn/v10/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNcI9E-9HPWIQtD0.ttf",
+        "300": "https://fonts.gstatic.com/s/playwritevn/v10/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNRw9E-9HPWIQtD0.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwritevn/v10/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI9E-9HPWIQtD0.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwritevn/v4/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI9I-5NOQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwritevn/v10/mtGo4_hXJqPSu8nf5RBY5i0q0yxCxtP-9TFBNUI9I-5NOQ.ttf"
+    },
+    {
+      "family": "Playwrite VN Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritevnguides/v1/JIAvUUlydXJZq1IQU8oDBn2CUkROHFEAfXMXfpmSLuI.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritevnguides/v1/JIAvUUlydXJZq1IQU8oDBn2CUkROHFEATXIdeg.ttf"
     },
     {
       "family": "Playwrite ZA",
@@ -31871,17 +33195,34 @@
       "subsets": [
         "latin"
       ],
-      "version": "v4",
-      "lastModified": "2024-08-12",
+      "version": "v10",
+      "lastModified": "2025-02-12",
       "files": {
-        "100": "https://fonts.gstatic.com/s/playwriteza/v4/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLGbYUsn9T5dt0.ttf",
-        "200": "https://fonts.gstatic.com/s/playwriteza/v4/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0ETLHbYUsn9T5dt0.ttf",
-        "300": "https://fonts.gstatic.com/s/playwriteza/v4/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EezHbYUsn9T5dt0.ttf",
-        "regular": "https://fonts.gstatic.com/s/playwriteza/v4/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLHbYUsn9T5dt0.ttf"
+        "100": "https://fonts.gstatic.com/s/playwriteza/v10/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLGbYUsn9T5dt0.ttf",
+        "200": "https://fonts.gstatic.com/s/playwriteza/v10/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0ETLHbYUsn9T5dt0.ttf",
+        "300": "https://fonts.gstatic.com/s/playwriteza/v10/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EezHbYUsn9T5dt0.ttf",
+        "regular": "https://fonts.gstatic.com/s/playwriteza/v10/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLHbYUsn9T5dt0.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/playwriteza/v4/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLHXYQmmw.ttf"
+      "menu": "https://fonts.gstatic.com/s/playwriteza/v10/Noag6Uzhw5CTOhXKt5-vwvhrNyaNQo1LaBq0EbLHXYQmmw.ttf"
+    },
+    {
+      "family": "Playwrite ZA Guides",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin"
+      ],
+      "version": "v1",
+      "lastModified": "2024-12-10",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/playwritezaguides/v1/O4ZOFHPsmxlhCg3-iycDyEwy0BT1ribk2HDoCLfQmgE.ttf"
+      },
+      "category": "handwriting",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/playwritezaguides/v1/O4ZOFHPsmxlhCg3-iycDyEwy0BT1ribk6HHiDA.ttf"
     },
     {
       "family": "Plus Jakarta Sans",
@@ -31930,6 +33271,25 @@
       "menu": "https://fonts.gstatic.com/s/plusjakartasans/v8/LDIbaomQNQcsA88c7O9yZ4KMCoOg4IA6-91aHEjcWuA_qU79Sx_Q.ttf"
     },
     {
+      "family": "Pochaevsk",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "latin"
+      ],
+      "version": "v5",
+      "lastModified": "2025-03-03",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/pochaevsk/v5/55xuey9_OdX_Om7ReYgloJd4-bnQKg.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/pochaevsk/v5/55xuey9_OdX_Om7ReYgVoZ18.ttf"
+    },
+    {
       "family": "Podkova",
       "variants": [
         "regular",
@@ -31945,18 +33305,18 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v31",
-      "lastModified": "2024-09-04",
+      "version": "v32",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWt3zcU4EoporSHH.ttf",
-        "600": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWubysU4EoporSHH.ttf",
-        "700": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWuiysU4EoporSHH.ttf",
-        "800": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWvFysU4EoporSHH.ttf",
-        "regular": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzcU4EoporSHH.ttf"
+        "500": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWt3zcU4EoporSHH.ttf",
+        "600": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWubysU4EoporSHH.ttf",
+        "700": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWuiysU4EoporSHH.ttf",
+        "800": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWvFysU4EoporSHH.ttf",
+        "regular": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzcU4EoporSHH.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/podkova/v31/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzfU5GI4.ttf"
+      "menu": "https://fonts.gstatic.com/s/podkova/v32/K2FufZ1EmftJSV9VQpXb1lo9vC3nZWtFzfU5GI4.ttf"
     },
     {
       "family": "Poetsen One",
@@ -32052,17 +33412,18 @@
         "italic"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/poly/v16/MQpb-W6wKNitRLCAq2Lpris.ttf",
-        "italic": "https://fonts.gstatic.com/s/poly/v16/MQpV-W6wKNitdLKKr0DsviuGWA.ttf"
+        "regular": "https://fonts.gstatic.com/s/poly/v17/MQpb-W6wKNitRLCAq2Lpris.ttf",
+        "italic": "https://fonts.gstatic.com/s/poly/v17/MQpV-W6wKNitdLKKr0DsviuGWA.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/poly/v16/MQpb-W6wKNitdLGKrw.ttf"
+      "menu": "https://fonts.gstatic.com/s/poly/v17/MQpb-W6wKNitdLGKrw.ttf"
     },
     {
       "family": "Pompiere",
@@ -32080,6 +33441,43 @@
       "category": "display",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/pompiere/v19/VEMyRoxis5Dwuyeov5Ws7DQ.ttf"
+    },
+    {
+      "family": "Ponnala",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "latin",
+        "telugu"
+      ],
+      "version": "v2",
+      "lastModified": "2024-11-20",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/ponnala/v2/w8gaH2QxQOU08bbbrQut2F4OuOo.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/ponnala/v2/w8gaH2QxQOU08bbbnQqn3A.ttf"
+    },
+    {
+      "family": "Ponomar",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "latin"
+      ],
+      "version": "v5",
+      "lastModified": "2025-03-03",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/ponomar/v5/or3iQ6zp3fKD2wImbJTdArg8hzo.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/ponomar/v5/or3iQ6zp3fKD2wImXJXXBg.ttf"
     },
     {
       "family": "Pontano Sans",
@@ -32116,14 +33514,14 @@
         "korean",
         "latin"
       ],
-      "version": "v20",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/poorstory/v20/jizfREFUsnUct9P6cDfd4OmnLD0Z4zM.ttf"
+        "regular": "https://fonts.gstatic.com/s/poorstory/v23/jizfREFUsnUct9P6cDfd4OmnLD0Z4zM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/poorstory/v20/jizfREFUsnUct9P6cDfd0OitKA.ttf"
+      "menu": "https://fonts.gstatic.com/s/poorstory/v23/jizfREFUsnUct9P6cDfd0OitKA.ttf"
     },
     {
       "family": "Poppins",
@@ -32151,31 +33549,31 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-12-04",
       "files": {
-        "100": "https://fonts.gstatic.com/s/poppins/v21/pxiGyp8kv8JHgFVrLPTed3FBGPaTSQ.ttf",
-        "200": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLFj_V1tvFP-KUEg.ttf",
-        "300": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLDz8V1tvFP-KUEg.ttf",
-        "500": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLGT9V1tvFP-KUEg.ttf",
-        "600": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLEj6V1tvFP-KUEg.ttf",
-        "700": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLCz7V1tvFP-KUEg.ttf",
-        "800": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLDD4V1tvFP-KUEg.ttf",
-        "900": "https://fonts.gstatic.com/s/poppins/v21/pxiByp8kv8JHgFVrLBT5V1tvFP-KUEg.ttf",
-        "100italic": "https://fonts.gstatic.com/s/poppins/v21/pxiAyp8kv8JHgFVrJJLmE3tFOvODSVFF.ttf",
-        "200italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLmv1plEN2PQEhcqw.ttf",
-        "300italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLm21llEN2PQEhcqw.ttf",
-        "regular": "https://fonts.gstatic.com/s/poppins/v21/pxiEyp8kv8JHgFVrFJDUc1NECPY.ttf",
-        "italic": "https://fonts.gstatic.com/s/poppins/v21/pxiGyp8kv8JHgFVrJJLed3FBGPaTSQ.ttf",
-        "500italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLmg1hlEN2PQEhcqw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLmr19lEN2PQEhcqw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLmy15lEN2PQEhcqw.ttf",
-        "800italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLm111lEN2PQEhcqw.ttf",
-        "900italic": "https://fonts.gstatic.com/s/poppins/v21/pxiDyp8kv8JHgFVrJJLm81xlEN2PQEhcqw.ttf"
+        "100": "https://fonts.gstatic.com/s/poppins/v22/pxiGyp8kv8JHgFVrLPTed3FBGPaTSQ.ttf",
+        "200": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLFj_V1tvFP-KUEg.ttf",
+        "300": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLDz8V1tvFP-KUEg.ttf",
+        "500": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLGT9V1tvFP-KUEg.ttf",
+        "600": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLEj6V1tvFP-KUEg.ttf",
+        "700": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLCz7V1tvFP-KUEg.ttf",
+        "800": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLDD4V1tvFP-KUEg.ttf",
+        "900": "https://fonts.gstatic.com/s/poppins/v22/pxiByp8kv8JHgFVrLBT5V1tvFP-KUEg.ttf",
+        "100italic": "https://fonts.gstatic.com/s/poppins/v22/pxiAyp8kv8JHgFVrJJLmE3tFOvODSVFF.ttf",
+        "200italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLmv1plEN2PQEhcqw.ttf",
+        "300italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLm21llEN2PQEhcqw.ttf",
+        "regular": "https://fonts.gstatic.com/s/poppins/v22/pxiEyp8kv8JHgFVrFJDUc1NECPY.ttf",
+        "italic": "https://fonts.gstatic.com/s/poppins/v22/pxiGyp8kv8JHgFVrJJLed3FBGPaTSQ.ttf",
+        "500italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLmg1hlEN2PQEhcqw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLmr19lEN2PQEhcqw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLmy15lEN2PQEhcqw.ttf",
+        "800italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLm111lEN2PQEhcqw.ttf",
+        "900italic": "https://fonts.gstatic.com/s/poppins/v22/pxiDyp8kv8JHgFVrJJLm81xlEN2PQEhcqw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/poppins/v21/pxiEyp8kv8JHgFVrJJHedw.ttf"
+      "menu": "https://fonts.gstatic.com/s/poppins/v22/pxiEyp8kv8JHgFVrJJHedw.ttf"
     },
     {
       "family": "Port Lligat Sans",
@@ -32222,14 +33620,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-07",
+      "version": "v18",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/pottaone/v17/FeVSS05Bp6cy7xI-YfxQ3Z5nm29Gww.ttf"
+        "regular": "https://fonts.gstatic.com/s/pottaone/v18/FeVSS05Bp6cy7xI-YfxQ3Z5nm29Gww.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/pottaone/v17/FeVSS05Bp6cy7xI-Yfxg3JRj.ttf"
+      "menu": "https://fonts.gstatic.com/s/pottaone/v18/FeVSS05Bp6cy7xI-Yfxg3JRj.ttf"
     },
     {
       "family": "Pragati Narrow",
@@ -32242,15 +33640,15 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v13",
-      "lastModified": "2024-09-04",
+      "version": "v14",
+      "lastModified": "2024-12-04",
       "files": {
-        "700": "https://fonts.gstatic.com/s/pragatinarrow/v13/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5fd_GJMTlo_4.ttf",
-        "regular": "https://fonts.gstatic.com/s/pragatinarrow/v13/vm8vdRf0T0bS1ffgsPB7WZ-mD17_ytN3M48a.ttf"
+        "700": "https://fonts.gstatic.com/s/pragatinarrow/v14/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5fd_GJMTlo_4.ttf",
+        "regular": "https://fonts.gstatic.com/s/pragatinarrow/v14/vm8vdRf0T0bS1ffgsPB7WZ-mD17_ytN3M48a.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/pragatinarrow/v13/vm8vdRf0T0bS1ffgsPB7WZ-mD27-wNc.ttf"
+      "menu": "https://fonts.gstatic.com/s/pragatinarrow/v14/vm8vdRf0T0bS1ffgsPB7WZ-mD27-wNc.ttf"
     },
     {
       "family": "Praise",
@@ -32300,14 +33698,14 @@
         "khmer",
         "latin"
       ],
-      "version": "v29",
-      "lastModified": "2024-08-12",
+      "version": "v30",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/preahvihear/v29/6NUS8F-dNQeEYhzj7uluxswE49FJf8Wv.ttf"
+        "regular": "https://fonts.gstatic.com/s/preahvihear/v30/6NUS8F-dNQeEYhzj7uluxswE49FJf8Wv.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/preahvihear/v29/6NUS8F-dNQeEYhzj7uluxvwF6dU.ttf"
+      "menu": "https://fonts.gstatic.com/s/preahvihear/v30/6NUS8F-dNQeEYhzj7uluxvwF6dU.ttf"
     },
     {
       "family": "Press Start 2P",
@@ -32837,18 +34235,18 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v31",
-      "lastModified": "2024-09-04",
+      "version": "v36",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkKEo18G0wx40QDw.ttf",
-        "500": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkM0o18G0wx40QDw.ttf",
-        "600": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkCEv18G0wx40QDw.ttf",
-        "700": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkBgv18G0wx40QDw.ttf",
-        "regular": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o18G0wx40QDw.ttf"
+        "300": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkKEo18G0wx40QDw.ttf",
+        "500": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkM0o18G0wx40QDw.ttf",
+        "600": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkCEv18G0wx40QDw.ttf",
+        "700": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkBgv18G0wx40QDw.ttf",
+        "regular": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o18G0wx40QDw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/quicksand/v31/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o58C-xw.ttf"
+      "menu": "https://fonts.gstatic.com/s/quicksand/v36/6xK-dSZaM9iE8KbpRA_LJ3z8mH9BOJvgkP8o58C-xw.ttf"
     },
     {
       "family": "Quintessential",
@@ -32999,23 +34397,23 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nESkQPIJOdSSfOT.ttf",
-        "500": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nF-kQPIJOdSSfOT.ttf",
-        "600": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nGSlgPIJOdSSfOT.ttf",
-        "700": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nGrlgPIJOdSSfOT.ttf",
-        "regular": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nFMkQPIJOdSSfOT.ttf",
-        "300italic": "https://fonts.gstatic.com/s/radiocanada/v21/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0rWLLuNwTOOTa9k.ttf",
-        "italic": "https://fonts.gstatic.com/s/radiocanada/v21/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0uuLLuNwTOOTa9k.ttf",
-        "500italic": "https://fonts.gstatic.com/s/radiocanada/v21/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0tmLLuNwTOOTa9k.ttf",
-        "600italic": "https://fonts.gstatic.com/s/radiocanada/v21/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0jWMLuNwTOOTa9k.ttf",
-        "700italic": "https://fonts.gstatic.com/s/radiocanada/v21/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0gyMLuNwTOOTa9k.ttf"
+        "300": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nESkQPIJOdSSfOT.ttf",
+        "500": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nF-kQPIJOdSSfOT.ttf",
+        "600": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nGSlgPIJOdSSfOT.ttf",
+        "700": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nGrlgPIJOdSSfOT.ttf",
+        "regular": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nFMkQPIJOdSSfOT.ttf",
+        "300italic": "https://fonts.gstatic.com/s/radiocanada/v25/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0rWLLuNwTOOTa9k.ttf",
+        "italic": "https://fonts.gstatic.com/s/radiocanada/v25/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0uuLLuNwTOOTa9k.ttf",
+        "500italic": "https://fonts.gstatic.com/s/radiocanada/v25/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0tmLLuNwTOOTa9k.ttf",
+        "600italic": "https://fonts.gstatic.com/s/radiocanada/v25/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0jWMLuNwTOOTa9k.ttf",
+        "700italic": "https://fonts.gstatic.com/s/radiocanada/v25/XRX33ISXn0dBMcibU6jlAqrdcwAMBJuK9IgQn4bfnSrKcMQM2cGQ1WSE0gyMLuNwTOOTa9k.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/radiocanada/v21/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nFMkTPJLuM.ttf"
+      "menu": "https://fonts.gstatic.com/s/radiocanada/v25/XRX13ISXn0dBMcibU6jlAqr3ejLv5OLZYiYXik6db2P4jxxlsls-0nFMkTPJLuM.ttf"
     },
     {
       "family": "Radio Canada Big",
@@ -33083,18 +34481,18 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/rajdhani/v15/LDI2apCSOBg7S-QT7pasEcOsc-bGkqIw.ttf",
-        "500": "https://fonts.gstatic.com/s/rajdhani/v15/LDI2apCSOBg7S-QT7pb0EMOsc-bGkqIw.ttf",
-        "600": "https://fonts.gstatic.com/s/rajdhani/v15/LDI2apCSOBg7S-QT7pbYF8Osc-bGkqIw.ttf",
-        "700": "https://fonts.gstatic.com/s/rajdhani/v15/LDI2apCSOBg7S-QT7pa8FsOsc-bGkqIw.ttf",
-        "regular": "https://fonts.gstatic.com/s/rajdhani/v15/LDIxapCSOBg7S-QT7q4AOeekWPrP.ttf"
+        "300": "https://fonts.gstatic.com/s/rajdhani/v16/LDI2apCSOBg7S-QT7pasEcOsc-bGkqIw.ttf",
+        "500": "https://fonts.gstatic.com/s/rajdhani/v16/LDI2apCSOBg7S-QT7pb0EMOsc-bGkqIw.ttf",
+        "600": "https://fonts.gstatic.com/s/rajdhani/v16/LDI2apCSOBg7S-QT7pbYF8Osc-bGkqIw.ttf",
+        "700": "https://fonts.gstatic.com/s/rajdhani/v16/LDI2apCSOBg7S-QT7pa8FsOsc-bGkqIw.ttf",
+        "regular": "https://fonts.gstatic.com/s/rajdhani/v16/LDIxapCSOBg7S-QT7q4AOeekWPrP.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/rajdhani/v15/LDIxapCSOBg7S-QT7p4BM-M.ttf"
+      "menu": "https://fonts.gstatic.com/s/rajdhani/v16/LDIxapCSOBg7S-QT7p4BM-M.ttf"
     },
     {
       "family": "Rakkas",
@@ -33106,14 +34504,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/rakkas/v19/Qw3cZQlNHiblL3j_lttPOeMcCw.ttf"
+        "regular": "https://fonts.gstatic.com/s/rakkas/v20/Qw3cZQlNHiblL3j_lttPOeMcCw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/rakkas/v19/Qw3cZQlNHiblL3jPl9FL.ttf"
+      "menu": "https://fonts.gstatic.com/s/rakkas/v20/Qw3cZQlNHiblL3jPl9FL.ttf"
     },
     {
       "family": "Raleway",
@@ -33197,14 +34595,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/ramabhadra/v15/EYq2maBOwqRW9P1SQ83LehNGX5uWw3o.ttf"
+        "regular": "https://fonts.gstatic.com/s/ramabhadra/v16/EYq2maBOwqRW9P1SQ83LehNGX5uWw3o.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ramabhadra/v15/EYq2maBOwqRW9P1SQ83LShJMWw.ttf"
+      "menu": "https://fonts.gstatic.com/s/ramabhadra/v16/EYq2maBOwqRW9P1SQ83LShJMWw.ttf"
     },
     {
       "family": "Ramaraja",
@@ -33215,14 +34613,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v15",
-      "lastModified": "2024-08-12",
+      "version": "v16",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/ramaraja/v15/SlGTmQearpYAYG1CABIkqnB6aSQU.ttf"
+        "regular": "https://fonts.gstatic.com/s/ramaraja/v16/SlGTmQearpYAYG1CABIkqnB6aSQU.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ramaraja/v15/SlGTmQearpYAYG1CACIloHQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/ramaraja/v16/SlGTmQearpYAYG1CACIloHQ.ttf"
     },
     {
       "family": "Rambla",
@@ -33277,14 +34675,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/rampartone/v10/K2F1fZFGl_JSR1tAWNG9R6qgLS76ZHOM.ttf"
+        "regular": "https://fonts.gstatic.com/s/rampartone/v11/K2F1fZFGl_JSR1tAWNG9R6qgLS76ZHOM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/rampartone/v10/K2F1fZFGl_JSR1tAWNG9R5qhJyo.ttf"
+      "menu": "https://fonts.gstatic.com/s/rampartone/v11/K2F1fZFGl_JSR1tAWNG9R5qhJyo.ttf"
     },
     {
       "family": "Ranchers",
@@ -33406,14 +34804,14 @@
         "latin",
         "telugu"
       ],
-      "version": "v19",
-      "lastModified": "2024-08-12",
+      "version": "v20",
+      "lastModified": "2024-12-04",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/raviprakash/v19/gokpH6fsDkVrF9Bv9X8SOAKHmNZEq6TTFw.ttf"
+        "regular": "https://fonts.gstatic.com/s/raviprakash/v20/gokpH6fsDkVrF9Bv9X8SOAKHmNZEq6TTFw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/raviprakash/v19/gokpH6fsDkVrF9Bv9X8SOAK3mdxA.ttf"
+      "menu": "https://fonts.gstatic.com/s/raviprakash/v20/gokpH6fsDkVrF9Bv9X8SOAK3mdxA.ttf"
     },
     {
       "family": "Readex Pro",
@@ -33431,19 +34829,19 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2025-03-18",
       "files": {
-        "200": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCYUSmgmsglvjkag.ttf",
-        "300": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCv0Smgmsglvjkag.ttf",
-        "500": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC00Smgmsglvjkag.ttf",
-        "600": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCP0Omgmsglvjkag.ttf",
-        "700": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCBkOmgmsglvjkag.ttf",
-        "regular": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC4USmgmsglvjkag.ttf"
+        "200": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCYUSmgmsglvjkag.ttf",
+        "300": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCv0Smgmsglvjkag.ttf",
+        "500": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC00Smgmsglvjkag.ttf",
+        "600": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCP0Omgmsglvjkag.ttf",
+        "700": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTCBkOmgmsglvjkag.ttf",
+        "regular": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC4USmgmsglvjkag.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/readexpro/v21/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC4USWg2Ek.ttf"
+      "menu": "https://fonts.gstatic.com/s/readexpro/v22/SLXnc1bJ7HE5YDoGPuzj_dh8uc7wUy8ZQQyX2KY8TL0kGZN6blTC4USWg2Ek.ttf"
     },
     {
       "family": "Recursive",
@@ -33499,27 +34897,27 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbjKWckg5-Xecg3w.ttf",
-        "500": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbl6Wckg5-Xecg3w.ttf",
-        "600": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbrKRckg5-Xecg3w.ttf",
-        "700": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbouRckg5-Xecg3w.ttf",
-        "800": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbuyRckg5-Xecg3w.ttf",
-        "900": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbsWRckg5-Xecg3w.ttf",
-        "regular": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbmyWckg5-Xecg3w.ttf",
-        "300italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVxAsz_VWZk3zJGg.ttf",
-        "italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVmgsz_VWZk3zJGg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVqAsz_VWZk3zJGg.ttf",
-        "600italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVRAwz_VWZk3zJGg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVfQwz_VWZk3zJGg.ttf",
-        "800italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVGgwz_VWZk3zJGg.ttf",
-        "900italic": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVMwwz_VWZk3zJGg.ttf"
+        "300": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbjKWckg5-Xecg3w.ttf",
+        "500": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbl6Wckg5-Xecg3w.ttf",
+        "600": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbrKRckg5-Xecg3w.ttf",
+        "700": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbouRckg5-Xecg3w.ttf",
+        "800": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbuyRckg5-Xecg3w.ttf",
+        "900": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbsWRckg5-Xecg3w.ttf",
+        "regular": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbmyWckg5-Xecg3w.ttf",
+        "300italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVxAsz_VWZk3zJGg.ttf",
+        "italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVmgsz_VWZk3zJGg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVqAsz_VWZk3zJGg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVRAwz_VWZk3zJGg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVfQwz_VWZk3zJGg.ttf",
+        "800italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVGgwz_VWZk3zJGg.ttf",
+        "900italic": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIh7wUr0m80wwYf0QCXZzYzUoTg-CSvZX4Vlf1fe6TVMwwz_VWZk3zJGg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/redhatdisplay/v19/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbmyWQkkz_Q.ttf"
+      "menu": "https://fonts.gstatic.com/s/redhatdisplay/v20/8vIf7wUr0m80wwYf0QCXZzYzUoTK8RZQvRd-D1NYbmyWQkkz_Q.ttf"
     },
     {
       "family": "Red Hat Mono",
@@ -33539,23 +34937,23 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v15",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQQPI-7HNuW4QuKI.ttf",
-        "500": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQW_I-7HNuW4QuKI.ttf",
-        "600": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQYPP-7HNuW4QuKI.ttf",
-        "700": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQbrP-7HNuW4QuKI.ttf",
-        "regular": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQV3I-7HNuW4QuKI.ttf",
-        "300italic": "https://fonts.gstatic.com/s/redhatmono/v11/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLTfLHvUwVqKIJuw.ttf",
-        "italic": "https://fonts.gstatic.com/s/redhatmono/v11/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLE_LHvUwVqKIJuw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/redhatmono/v11/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLIfLHvUwVqKIJuw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/redhatmono/v11/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLzfXHvUwVqKIJuw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/redhatmono/v11/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWL9PXHvUwVqKIJuw.ttf"
+        "300": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQQPI-7HNuW4QuKI.ttf",
+        "500": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQW_I-7HNuW4QuKI.ttf",
+        "600": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQYPP-7HNuW4QuKI.ttf",
+        "700": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQbrP-7HNuW4QuKI.ttf",
+        "regular": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQV3I-7HNuW4QuKI.ttf",
+        "300italic": "https://fonts.gstatic.com/s/redhatmono/v15/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLTfLHvUwVqKIJuw.ttf",
+        "italic": "https://fonts.gstatic.com/s/redhatmono/v15/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLE_LHvUwVqKIJuw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/redhatmono/v15/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLIfLHvUwVqKIJuw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/redhatmono/v15/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWLzfXHvUwVqKIJuw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/redhatmono/v15/jVye7nDnA2uf2zVvFAhhzEsUXfZc_vk45Kb3VJWL9PXHvUwVqKIJuw.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/redhatmono/v11/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQV3Iy7DHvQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/redhatmono/v15/jVyY7nDnA2uf2zVvFAhhzEs-VMSjJpBTfgjwQV3Iy7DHvQ.ttf"
     },
     {
       "family": "Red Hat Text",
@@ -33575,23 +34973,23 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-12-04",
       "files": {
-        "300": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML-ZwVrbacYVFtIY.ttf",
-        "500": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML4pwVrbacYVFtIY.ttf",
-        "600": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML2Z3VrbacYVFtIY.ttf",
-        "700": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML193VrbacYVFtIY.ttf",
-        "regular": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML7hwVrbacYVFtIY.ttf",
-        "300italic": "https://fonts.gstatic.com/s/redhattext/v14/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAz4PXQdadApIYv_g.ttf",
-        "italic": "https://fonts.gstatic.com/s/redhattext/v14/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzvvXQdadApIYv_g.ttf",
-        "500italic": "https://fonts.gstatic.com/s/redhattext/v14/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzjPXQdadApIYv_g.ttf",
-        "600italic": "https://fonts.gstatic.com/s/redhattext/v14/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzYPLQdadApIYv_g.ttf",
-        "700italic": "https://fonts.gstatic.com/s/redhattext/v14/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzWfLQdadApIYv_g.ttf"
+        "300": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML-ZwVrbacYVFtIY.ttf",
+        "500": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML4pwVrbacYVFtIY.ttf",
+        "600": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML2Z3VrbacYVFtIY.ttf",
+        "700": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML193VrbacYVFtIY.ttf",
+        "regular": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML7hwVrbacYVFtIY.ttf",
+        "300italic": "https://fonts.gstatic.com/s/redhattext/v18/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAz4PXQdadApIYv_g.ttf",
+        "italic": "https://fonts.gstatic.com/s/redhattext/v18/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzvvXQdadApIYv_g.ttf",
+        "500italic": "https://fonts.gstatic.com/s/redhattext/v18/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzjPXQdadApIYv_g.ttf",
+        "600italic": "https://fonts.gstatic.com/s/redhattext/v18/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzYPLQdadApIYv_g.ttf",
+        "700italic": "https://fonts.gstatic.com/s/redhattext/v18/RrQEbohi_ic6B3yVSzGBrMxQbb0jEzlRoOOLOnAzWfLQdadApIYv_g.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/redhattext/v14/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML7hwZrfQdQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/redhattext/v18/RrQCbohi_ic6B3yVSzGBrMx6ZI_cy1A6Ok2ML7hwZrfQdQ.ttf"
     },
     {
       "family": "Red Rose",
@@ -33781,16 +35179,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v29",
-      "lastModified": "2024-09-04",
+      "version": "v30",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/redressed/v29/x3dickHUbrmJ7wMy9MsBfPACvy_1BA.ttf"
+        "regular": "https://fonts.gstatic.com/s/redressed/v30/x3dickHUbrmJ7wMy9MsBfPACvy_1BA.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/redressed/v29/x3dickHUbrmJ7wMy9MsxffoG.ttf"
+      "menu": "https://fonts.gstatic.com/s/redressed/v30/x3dickHUbrmJ7wMy9MsxffoG.ttf"
     },
     {
       "family": "Reem Kufi",
@@ -33806,17 +35205,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v25",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/reemkufi/v21/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQttRnEGGf3qGuvM4.ttf",
-        "600": "https://fonts.gstatic.com/s/reemkufi/v21/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtjhgEGGf3qGuvM4.ttf",
-        "700": "https://fonts.gstatic.com/s/reemkufi/v21/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtgFgEGGf3qGuvM4.ttf",
-        "regular": "https://fonts.gstatic.com/s/reemkufi/v21/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtuZnEGGf3qGuvM4.ttf"
+        "500": "https://fonts.gstatic.com/s/reemkufi/v25/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQttRnEGGf3qGuvM4.ttf",
+        "600": "https://fonts.gstatic.com/s/reemkufi/v25/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtjhgEGGf3qGuvM4.ttf",
+        "700": "https://fonts.gstatic.com/s/reemkufi/v25/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtgFgEGGf3qGuvM4.ttf",
+        "regular": "https://fonts.gstatic.com/s/reemkufi/v25/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtuZnEGGf3qGuvM4.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/reemkufi/v21/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtuZnIGCV2g.ttf"
+      "menu": "https://fonts.gstatic.com/s/reemkufi/v25/2sDPZGJLip7W2J7v7wQZZE1I0yCmYzzQtuZnIGCV2g.ttf"
     },
     {
       "family": "Reem Kufi Fun",
@@ -33832,17 +35231,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v7",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2025-03-03",
       "files": {
-        "500": "https://fonts.gstatic.com/s/reemkufifun/v7/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYR3nCgrvqZzZXq.ttf",
-        "600": "https://fonts.gstatic.com/s/reemkufifun/v7/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChob92XCgrvqZzZXq.ttf",
-        "700": "https://fonts.gstatic.com/s/reemkufifun/v7/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChobE2XCgrvqZzZXq.ttf",
-        "regular": "https://fonts.gstatic.com/s/reemkufifun/v7/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYj3nCgrvqZzZXq.ttf"
+        "500": "https://fonts.gstatic.com/s/reemkufifun/v11/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYR3nCgrvqZzZXq.ttf",
+        "600": "https://fonts.gstatic.com/s/reemkufifun/v11/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChob92XCgrvqZzZXq.ttf",
+        "700": "https://fonts.gstatic.com/s/reemkufifun/v11/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChobE2XCgrvqZzZXq.ttf",
+        "regular": "https://fonts.gstatic.com/s/reemkufifun/v11/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYj3nCgrvqZzZXq.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/reemkufifun/v7/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYj3kChpP4.ttf",
+      "menu": "https://fonts.gstatic.com/s/reemkufifun/v11/uK_m4rOFYukkmyUEbF43fIryZEk5qRZ8nrKChoYj3kChpP4.ttf",
       "colorCapabilities": [
         "COLRv0"
       ]
@@ -33858,14 +35257,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v9",
-      "lastModified": "2024-09-04",
+      "version": "v10",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/reemkufiink/v9/oPWJ_kJmmu8hCvB9iFumxZSnRj5dQnSX1ko.ttf"
+        "regular": "https://fonts.gstatic.com/s/reemkufiink/v10/oPWJ_kJmmu8hCvB9iFumxZSnRj5dQnSX1ko.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/reemkufiink/v9/oPWJ_kJmmu8hCvB9iFumxZSndj9XRg.ttf",
+      "menu": "https://fonts.gstatic.com/s/reemkufiink/v10/oPWJ_kJmmu8hCvB9iFumxZSndj9XRg.ttf",
       "colorCapabilities": [
         "COLRv1",
         "SVG"
@@ -34076,16 +35475,22 @@
       "family": "Roboto",
       "variants": [
         "100",
-        "100italic",
+        "200",
         "300",
-        "300italic",
         "regular",
-        "italic",
         "500",
-        "500italic",
+        "600",
         "700",
-        "700italic",
+        "800",
         "900",
+        "100italic",
+        "200italic",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
         "900italic"
       ],
       "subsets": [
@@ -34095,27 +35500,35 @@
         "greek-ext",
         "latin",
         "latin-ext",
+        "math",
+        "symbols",
         "vietnamese"
       ],
-      "version": "v32",
-      "lastModified": "2024-09-04",
+      "version": "v47",
+      "lastModified": "2025-01-08",
       "files": {
-        "100": "https://fonts.gstatic.com/s/roboto/v32/KFOkCnqEu92Fr1MmgWxPKTM1K9nz.ttf",
-        "300": "https://fonts.gstatic.com/s/roboto/v32/KFOlCnqEu92Fr1MmSU5vAx05IsDqlA.ttf",
-        "500": "https://fonts.gstatic.com/s/roboto/v32/KFOlCnqEu92Fr1MmEU9vAx05IsDqlA.ttf",
-        "700": "https://fonts.gstatic.com/s/roboto/v32/KFOlCnqEu92Fr1MmWUlvAx05IsDqlA.ttf",
-        "900": "https://fonts.gstatic.com/s/roboto/v32/KFOlCnqEu92Fr1MmYUtvAx05IsDqlA.ttf",
-        "100italic": "https://fonts.gstatic.com/s/roboto/v32/KFOiCnqEu92Fr1Mu51QrIzcXLsnzjYk.ttf",
-        "300italic": "https://fonts.gstatic.com/s/roboto/v32/KFOjCnqEu92Fr1Mu51TjARc9AMX6lJBP.ttf",
-        "regular": "https://fonts.gstatic.com/s/roboto/v32/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf",
-        "italic": "https://fonts.gstatic.com/s/roboto/v32/KFOkCnqEu92Fr1Mu52xPKTM1K9nz.ttf",
-        "500italic": "https://fonts.gstatic.com/s/roboto/v32/KFOjCnqEu92Fr1Mu51S7ABc9AMX6lJBP.ttf",
-        "700italic": "https://fonts.gstatic.com/s/roboto/v32/KFOjCnqEu92Fr1Mu51TzBhc9AMX6lJBP.ttf",
-        "900italic": "https://fonts.gstatic.com/s/roboto/v32/KFOjCnqEu92Fr1Mu51TLBBc9AMX6lJBP.ttf"
+        "100": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbGmTggvWl0Qn.ttf",
+        "200": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuZEbWmTggvWl0Qn.ttf",
+        "300": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuaabWmTggvWl0Qn.ttf",
+        "500": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWub2bWmTggvWl0Qn.ttf",
+        "600": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuYaammTggvWl0Qn.ttf",
+        "700": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuYjammTggvWl0Qn.ttf",
+        "800": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuZEammTggvWl0Qn.ttf",
+        "900": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWuZtammTggvWl0Qn.ttf",
+        "regular": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbWmTggvWl0Qn.ttf",
+        "100italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLoHRiA_0klQnx24.ttf",
+        "200italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLgHQiA_0klQnx24.ttf",
+        "300italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLt_QiA_0klQnx24.ttf",
+        "italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLoHQiA_0klQnx24.ttf",
+        "500italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLrPQiA_0klQnx24.ttf",
+        "600italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLl_XiA_0klQnx24.ttf",
+        "700italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLmbXiA_0klQnx24.ttf",
+        "800italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLgHXiA_0klQnx24.ttf",
+        "900italic": "https://fonts.gstatic.com/s/roboto/v47/KFOKCnqEu92Fr1Mu53ZEC9_Vu3r1gIhOszmOClHrs6ljXfMMLijXiA_0klQnx24.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/roboto/v32/KFOmCnqEu92Fr1Mu5GxP.ttf"
+      "menu": "https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbVmSiA8.ttf"
     },
     {
       "family": "Roboto Condensed",
@@ -34187,14 +35600,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/robotoflex/v26/NaNnepOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl1cKq3tHXtXi8mzLjaAQbGunCNCKMY.ttf"
+        "regular": "https://fonts.gstatic.com/s/robotoflex/v27/NaNnepOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl1cKq3tHXtXi8mzLjaAQbGunCNCKMY.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/robotoflex/v26/NaNnepOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl1cKq3tHXtXi8mzLjaAcbCkmA.ttf"
+      "menu": "https://fonts.gstatic.com/s/robotoflex/v27/NaNnepOXO_NexZs0b5QrzlOHb8wCikXpYqmZsWI-__OGbt8jZktqc2V3Zs0KvDLdBP8SBZtOs2IifRuUZQMsPJtUsR4DEK6cULNeUx9XgTnH37Ha_FIAp4Fm0PP1hw45DntW2x0wZGzhPmr1YNMYKYn9_1IQXGwJAiUJVUMdN5YUW4O8HtSoXjC1z3QSabshNFVe3e0O5j3ZjrZCu23Qd4G0EBysQNK-QKavMl1cKq3tHXtXi8mzLjaAcbCkmA.ttf"
     },
     {
       "family": "Roboto Mono",
@@ -35544,17 +36957,18 @@
       ],
       "subsets": [
         "devanagari",
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v17",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/sahitya/v17/6qLFKZkOuhnuqlJAUZsqGyQvEnvSexI.ttf",
-        "regular": "https://fonts.gstatic.com/s/sahitya/v17/6qLAKZkOuhnuqlJAaScFPywEDnI.ttf"
+        "700": "https://fonts.gstatic.com/s/sahitya/v18/6qLFKZkOuhnuqlJAUZsqGyQvEnvSexI.ttf",
+        "regular": "https://fonts.gstatic.com/s/sahitya/v18/6qLAKZkOuhnuqlJAaScFPywEDnI.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/sahitya/v17/6qLAKZkOuhnuqlJAWSYPOw.ttf"
+      "menu": "https://fonts.gstatic.com/s/sahitya/v18/6qLAKZkOuhnuqlJAWSYPOw.ttf"
     },
     {
       "family": "Sail",
@@ -35601,31 +37015,31 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rDosg7lwYmUVY.ttf",
-        "200": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA79rCosg7lwYmUVY.ttf",
-        "300": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA7wTCosg7lwYmUVY.ttf",
-        "500": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA72jCosg7lwYmUVY.ttf",
-        "600": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA74TFosg7lwYmUVY.ttf",
-        "700": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA773Fosg7lwYmUVY.ttf",
-        "800": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA79rFosg7lwYmUVY.ttf",
-        "900": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA7_PFosg7lwYmUVY.ttf",
-        "regular": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rCosg7lwYmUVY.ttf",
-        "100italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBSooxkyQjQVYmxA.ttf",
-        "200italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKByosxkyQjQVYmxA.ttf",
-        "300italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBFIsxkyQjQVYmxA.ttf",
-        "italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBSosxkyQjQVYmxA.ttf",
-        "500italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBeIsxkyQjQVYmxA.ttf",
-        "600italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBlIwxkyQjQVYmxA.ttf",
-        "700italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBrYwxkyQjQVYmxA.ttf",
-        "800italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKByowxkyQjQVYmxA.ttf",
-        "900italic": "https://fonts.gstatic.com/s/saira/v20/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKB44wxkyQjQVYmxA.ttf"
+        "100": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rDosg7lwYmUVY.ttf",
+        "200": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA79rCosg7lwYmUVY.ttf",
+        "300": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA7wTCosg7lwYmUVY.ttf",
+        "500": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA72jCosg7lwYmUVY.ttf",
+        "600": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA74TFosg7lwYmUVY.ttf",
+        "700": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA773Fosg7lwYmUVY.ttf",
+        "800": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA79rFosg7lwYmUVY.ttf",
+        "900": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA7_PFosg7lwYmUVY.ttf",
+        "regular": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rCosg7lwYmUVY.ttf",
+        "100italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBSooxkyQjQVYmxA.ttf",
+        "200italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKByosxkyQjQVYmxA.ttf",
+        "300italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBFIsxkyQjQVYmxA.ttf",
+        "italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBSosxkyQjQVYmxA.ttf",
+        "500italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBeIsxkyQjQVYmxA.ttf",
+        "600italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBlIwxkyQjQVYmxA.ttf",
+        "700italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKBrYwxkyQjQVYmxA.ttf",
+        "800italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKByowxkyQjQVYmxA.ttf",
+        "900italic": "https://fonts.gstatic.com/s/saira/v21/memUYa2wxmKQyNkiV50dulWP7s95AqZTzZHcVdxWI9WH-pKB44wxkyQjQVYmxA.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/saira/v20/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rCkskxkw.ttf"
+      "menu": "https://fonts.gstatic.com/s/saira/v21/memWYa2wxmKQyPMrZX79wwYZQMhsyuShhKMjjbU9uXuA71rCkskxkw.ttf"
     },
     {
       "family": "Saira Condensed",
@@ -36121,17 +37535,17 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v17",
+      "lastModified": "2024-11-20",
       "files": {
-        "500": "https://fonts.gstatic.com/s/scheherazadenew/v15/4UaerFhTvxVnHDvUkUiHg8jprP4DM_dFHlYC-IKnoSE.ttf",
-        "600": "https://fonts.gstatic.com/s/scheherazadenew/v15/4UaerFhTvxVnHDvUkUiHg8jprP4DM9tCHlYC-IKnoSE.ttf",
-        "700": "https://fonts.gstatic.com/s/scheherazadenew/v15/4UaerFhTvxVnHDvUkUiHg8jprP4DM79DHlYC-IKnoSE.ttf",
-        "regular": "https://fonts.gstatic.com/s/scheherazadenew/v15/4UaZrFhTvxVnHDvUkUiHg8jprP4DCwNsOl4p5Is.ttf"
+        "500": "https://fonts.gstatic.com/s/scheherazadenew/v17/4UaerFhTvxVnHDvUkUiHg8jprP4DM_dFHlYC-IKnoSE.ttf",
+        "600": "https://fonts.gstatic.com/s/scheherazadenew/v17/4UaerFhTvxVnHDvUkUiHg8jprP4DM9tCHlYC-IKnoSE.ttf",
+        "700": "https://fonts.gstatic.com/s/scheherazadenew/v17/4UaerFhTvxVnHDvUkUiHg8jprP4DM79DHlYC-IKnoSE.ttf",
+        "regular": "https://fonts.gstatic.com/s/scheherazadenew/v17/4UaZrFhTvxVnHDvUkUiHg8jprP4DCwNsOl4p5Is.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/scheherazadenew/v15/4UaZrFhTvxVnHDvUkUiHg8jprP4DOwJmPg.ttf"
+      "menu": "https://fonts.gstatic.com/s/scheherazadenew/v17/4UaZrFhTvxVnHDvUkUiHg8jprP4DOwJmPg.ttf"
     },
     {
       "family": "Schibsted Grotesk",
@@ -36409,16 +37823,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/shadowsintolight/v19/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQDcsr4xzSMYA.ttf"
+        "regular": "https://fonts.gstatic.com/s/shadowsintolight/v20/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQDcsr4xzSMYA.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/shadowsintolight/v19/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQzc8D8.ttf"
+      "menu": "https://fonts.gstatic.com/s/shadowsintolight/v20/UqyNK9UOIntux_czAvDQx_ZcHqZXBNQzc8D8.ttf"
     },
     {
       "family": "Shadows Into Light Two",
@@ -36437,6 +37852,27 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/shadowsintolighttwo/v17/4iC86LVlZsRSjQhpWGedwyOoW-0A6_kpsyNmpArHHA.ttf"
+    },
+    {
+      "family": "Shafarik",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "glagolitic",
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v3",
+      "lastModified": "2025-02-12",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/shafarik/v3/RWmLoKaF7PojpZXlW52sbsHKqLkD.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/shafarik/v3/RWmLoKaF7PojpZXlW62tZMU.ttf"
     },
     {
       "family": "Shalimar",
@@ -36748,14 +38184,14 @@
       "subsets": [
         "khmer"
       ],
-      "version": "v28",
-      "lastModified": "2023-08-25",
+      "version": "v29",
+      "lastModified": "2025-01-08",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/siemreap/v28/Gg82N5oFbgLvHAfNl2YbnA8DLXpe.ttf"
+        "regular": "https://fonts.gstatic.com/s/siemreap/v29/Gg82N5oFbgLvHAfNl2YbnA8DLXpe.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/siemreap/v28/Gg82N5oFbgLvHAfNl1Yalgs.ttf"
+      "menu": "https://fonts.gstatic.com/s/siemreap/v29/Gg82N5oFbgLvHAfNl1Yalgs.ttf"
     },
     {
       "family": "Sigmar",
@@ -36953,16 +38389,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/sixcaps/v20/6ae_4KGrU7VR7bNmabcS9XXaPCop.ttf"
+        "regular": "https://fonts.gstatic.com/s/sixcaps/v21/6ae_4KGrU7VR7bNmabcS9XXaPCop.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/sixcaps/v20/6ae_4KGrU7VR7bNmaYcT_3E.ttf"
+      "menu": "https://fonts.gstatic.com/s/sixcaps/v21/6ae_4KGrU7VR7bNmaYcT_3E.ttf"
     },
     {
       "family": "Sixtyfour",
@@ -36995,14 +38432,14 @@
         "math",
         "symbols"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-30",
+      "version": "v4",
+      "lastModified": "2025-03-03",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/sixtyfourconvergence/v1/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102hotkk3grz3g.ttf"
+        "regular": "https://fonts.gstatic.com/s/sixtyfourconvergence/v4/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102hotkk3grz3g.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/sixtyfourconvergence/v1/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102topulw.ttf",
+      "menu": "https://fonts.gstatic.com/s/sixtyfourconvergence/v4/m8IQjepPf7mIglv5K__zM9srGA7wurbybZMfZsqG2Q6EWlJro5FJSJ4acT9PoOPwGgieaK7zkSpdXP-GrR9Yw9Tg7E4HGLbUKPlOh102topulw.ttf",
       "colorCapabilities": [
         "COLRv1"
       ]
@@ -37105,16 +38542,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v28",
-      "lastModified": "2024-09-04",
+      "version": "v29",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/smokum/v28/TK3iWkUbAhopmrdGHjUHte5fKg.ttf"
+        "regular": "https://fonts.gstatic.com/s/smokum/v29/TK3iWkUbAhopmrdGHjUHte5fKg.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/smokum/v28/TK3iWkUbAhopmrd2Hz8D.ttf"
+      "menu": "https://fonts.gstatic.com/s/smokum/v29/TK3iWkUbAhopmrd2Hz8D.ttf"
     },
     {
       "family": "Smooch",
@@ -37578,17 +39016,16 @@
         "regular"
       ],
       "subsets": [
-        "korean",
-        "latin"
+        "korean"
       ],
-      "version": "v20",
-      "lastModified": "2024-08-12",
+      "version": "v21",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/songmyung/v20/1cX2aUDWAJH5-EIC7DIhr1GqhcitzeM.ttf"
+        "regular": "https://fonts.gstatic.com/s/songmyung/v21/1cX2aUDWAJH5-EIC7DIhr1GqhcitzeM.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/songmyung/v20/1cX2aUDWAJH5-EIC7DIhn1CggQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/songmyung/v21/1cX2aUDWAJH5-EIC7DIhn1CggQ.ttf"
     },
     {
       "family": "Sono",
@@ -37825,29 +39262,29 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v15",
-      "lastModified": "2024-09-04",
+      "version": "v18",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kw461EN_io6npfB.ttf",
-        "300": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kzm61EN_io6npfB.ttf",
-        "500": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8KyK61EN_io6npfB.ttf",
-        "600": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kxm7FEN_io6npfB.ttf",
-        "700": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kxf7FEN_io6npfB.ttf",
-        "800": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kw47FEN_io6npfB.ttf",
-        "900": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8KwR7FEN_io6npfB.ttf",
-        "regular": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Ky461EN_io6npfB.ttf",
-        "200italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqDlO9C4Ym4fB3Ts.ttf",
-        "300italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqOdO9C4Ym4fB3Ts.ttf",
-        "italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqLlO9C4Ym4fB3Ts.ttf",
-        "500italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqItO9C4Ym4fB3Ts.ttf",
-        "600italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqGdJ9C4Ym4fB3Ts.ttf",
-        "700italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqF5J9C4Ym4fB3Ts.ttf",
-        "800italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqDlJ9C4Ym4fB3Ts.ttf",
-        "900italic": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqBBJ9C4Ym4fB3Ts.ttf"
+        "200": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kw461EN_io6npfB.ttf",
+        "300": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kzm61EN_io6npfB.ttf",
+        "500": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8KyK61EN_io6npfB.ttf",
+        "600": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kxm7FEN_io6npfB.ttf",
+        "700": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kxf7FEN_io6npfB.ttf",
+        "800": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Kw47FEN_io6npfB.ttf",
+        "900": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8KwR7FEN_io6npfB.ttf",
+        "regular": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Ky461EN_io6npfB.ttf",
+        "200italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqDlO9C4Ym4fB3Ts.ttf",
+        "300italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqOdO9C4Ym4fB3Ts.ttf",
+        "italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqLlO9C4Ym4fB3Ts.ttf",
+        "500italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqItO9C4Ym4fB3Ts.ttf",
+        "600italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqGdJ9C4Ym4fB3Ts.ttf",
+        "700italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqF5J9C4Ym4fB3Ts.ttf",
+        "800italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqDlJ9C4Ym4fB3Ts.ttf",
+        "900italic": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpDtKy2OAdR1K-IwhWudF-R3woAa8opPOrG97lwqBBJ9C4Ym4fB3Ts.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/sourcesans3/v15/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Ky462EM9C4.ttf"
+      "menu": "https://fonts.gstatic.com/s/sourcesans3/v18/nwpBtKy2OAdR1K-IwhWudF-R9QMylBJAV3Bo8Ky462EM9C4.ttf"
     },
     {
       "family": "Source Serif 4",
@@ -37877,29 +39314,29 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v8",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2025-03-11",
       "files": {
-        "200": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjipdqrhxXD-wGvjU.ttf",
-        "300": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjiklqrhxXD-wGvjU.ttf",
-        "500": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjiiVqrhxXD-wGvjU.ttf",
-        "600": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjisltrhxXD-wGvjU.ttf",
-        "700": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjivBtrhxXD-wGvjU.ttf",
-        "800": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjipdtrhxXD-wGvjU.ttf",
-        "900": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjir5trhxXD-wGvjU.ttf",
-        "regular": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjihdqrhxXD-wGvjU.ttf",
-        "200italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pxl9dC84DrjXEXw.ttf",
-        "300italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pGF9dC84DrjXEXw.ttf",
-        "italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pRl9dC84DrjXEXw.ttf",
-        "500italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pdF9dC84DrjXEXw.ttf",
-        "600italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pmFhdC84DrjXEXw.ttf",
-        "700italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98poVhdC84DrjXEXw.ttf",
-        "800italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pxlhdC84DrjXEXw.ttf",
-        "900italic": "https://fonts.gstatic.com/s/sourceserif4/v8/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98p71hdC84DrjXEXw.ttf"
+        "200": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjipdqrhxXD-wGvjU.ttf",
+        "300": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjiklqrhxXD-wGvjU.ttf",
+        "500": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjiiVqrhxXD-wGvjU.ttf",
+        "600": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjisltrhxXD-wGvjU.ttf",
+        "700": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjivBtrhxXD-wGvjU.ttf",
+        "800": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjipdtrhxXD-wGvjU.ttf",
+        "900": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjir5trhxXD-wGvjU.ttf",
+        "regular": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjihdqrhxXD-wGvjU.ttf",
+        "200italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pxl9dC84DrjXEXw.ttf",
+        "300italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pGF9dC84DrjXEXw.ttf",
+        "italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pRl9dC84DrjXEXw.ttf",
+        "500italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pdF9dC84DrjXEXw.ttf",
+        "600italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pmFhdC84DrjXEXw.ttf",
+        "700italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98poVhdC84DrjXEXw.ttf",
+        "800italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98pxlhdC84DrjXEXw.ttf",
+        "900italic": "https://fonts.gstatic.com/s/sourceserif4/v13/vEF02_tTDB4M7-auWDN0ahZJW1ge6NmXpVAHV83Bfb_US2D2QYxoUKIkn98p71hdC84DrjXEXw.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/sourceserif4/v8/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjihdqnh1dCw.ttf"
+      "menu": "https://fonts.gstatic.com/s/sourceserif4/v13/vEFy2_tTDB4M7-auWDN0ahZJW3IX2ih5nk3AucvUHf6OAVIJmeUDygwjihdqnh1dCw.ttf"
     },
     {
       "family": "Space Grotesk",
@@ -37915,18 +39352,18 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v16",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj62UUsjNsFjTDJK.ttf",
-        "500": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7aUUsjNsFjTDJK.ttf",
-        "600": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj42VksjNsFjTDJK.ttf",
-        "700": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVksjNsFjTDJK.ttf",
-        "regular": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUUsjNsFjTDJK.ttf"
+        "300": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj62UUsjNsFjTDJK.ttf",
+        "500": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7aUUsjNsFjTDJK.ttf",
+        "600": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj42VksjNsFjTDJK.ttf",
+        "700": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVksjNsFjTDJK.ttf",
+        "regular": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUUsjNsFjTDJK.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUXsiPMU.ttf"
+      "menu": "https://fonts.gstatic.com/s/spacegrotesk/v21/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUXsiPMU.ttf"
     },
     {
       "family": "Space Mono",
@@ -37941,17 +39378,17 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v14",
-      "lastModified": "2024-09-30",
+      "version": "v15",
+      "lastModified": "2025-02-12",
       "files": {
-        "700": "https://fonts.gstatic.com/s/spacemono/v14/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf",
-        "regular": "https://fonts.gstatic.com/s/spacemono/v14/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf",
-        "italic": "https://fonts.gstatic.com/s/spacemono/v14/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/spacemono/v14/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf"
+        "700": "https://fonts.gstatic.com/s/spacemono/v15/i7dMIFZifjKcF5UAWdDRaPpZYFKQHwyVd3U.ttf",
+        "regular": "https://fonts.gstatic.com/s/spacemono/v15/i7dPIFZifjKcF5UAWdDRUEZ2RFq7AwU.ttf",
+        "italic": "https://fonts.gstatic.com/s/spacemono/v15/i7dNIFZifjKcF5UAWdDRYER8QHi-EwWMbg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/spacemono/v15/i7dSIFZifjKcF5UAWdDRYERE_FeaGy6QZ3WfYg.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spacemono/v14/i7dPIFZifjKcF5UAWdDRYEd8QA.ttf"
+      "menu": "https://fonts.gstatic.com/s/spacemono/v15/i7dPIFZifjKcF5UAWdDRYEd8QA.ttf"
     },
     {
       "family": "Special Elite",
@@ -37959,16 +39396,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/specialelite/v18/XLYgIZbkc4JPUL5CVArUVL0nhncESXFtUsM.ttf"
+        "regular": "https://fonts.gstatic.com/s/specialelite/v19/XLYgIZbkc4JPUL5CVArUVL0nhncESXFtUsM.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/specialelite/v18/XLYgIZbkc4JPUL5CVArUVL0ntnYOTQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/specialelite/v19/XLYgIZbkc4JPUL5CVArUVL0ntnYOTQ.ttf"
     },
     {
       "family": "Spectral",
@@ -38070,16 +39508,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v25",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/spicyrice/v25/uK_24rSEd-Uqwk4jY1RyGv-2WkowRcc.ttf"
+        "regular": "https://fonts.gstatic.com/s/spicyrice/v26/uK_24rSEd-Uqwk4jY1RyGv-2WkowRcc.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/spicyrice/v25/uK_24rSEd-Uqwk4jY1RyKv68Xg.ttf"
+      "menu": "https://fonts.gstatic.com/s/spicyrice/v26/uK_24rSEd-Uqwk4jY1RyKv68Xg.ttf"
     },
     {
       "family": "Spinnaker",
@@ -38517,17 +39956,16 @@
         "regular"
       ],
       "subsets": [
-        "korean",
-        "latin"
+        "korean"
       ],
-      "version": "v22",
-      "lastModified": "2024-08-12",
+      "version": "v23",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/stylish/v22/m8JSjfhPYriQkk7-fo35dLxEdmo.ttf"
+        "regular": "https://fonts.gstatic.com/s/stylish/v23/m8JSjfhPYriQkk7-fo35dLxEdmo.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/stylish/v22/m8JSjfhPYriQkk7-TozzcA.ttf"
+      "menu": "https://fonts.gstatic.com/s/stylish/v23/m8JSjfhPYriQkk7-TozzcA.ttf"
     },
     {
       "family": "Sue Ellen Francisco",
@@ -38653,16 +40091,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v26",
-      "lastModified": "2024-09-04",
+      "version": "v27",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/supermercadoone/v26/OpNXnpQWg8jc_xps_Gi14kVVEXOn60b3MClBRTs.ttf"
+        "regular": "https://fonts.gstatic.com/s/supermercadoone/v27/OpNXnpQWg8jc_xps_Gi14kVVEXOn60b3MClBRTs.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/supermercadoone/v26/OpNXnpQWg8jc_xps_Gi14kVVEXOn20f9NA.ttf"
+      "menu": "https://fonts.gstatic.com/s/supermercadoone/v27/OpNXnpQWg8jc_xps_Gi14kVVEXOn20f9NA.ttf"
     },
     {
       "family": "Sura",
@@ -38753,16 +40192,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/swankyandmoomoo/v22/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kUtbPkR64SYQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/swankyandmoomoo/v23/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kUtbPkR64SYQ.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/swankyandmoomoo/v22/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kktLng.ttf"
+      "menu": "https://fonts.gstatic.com/s/swankyandmoomoo/v23/flUlRrKz24IuWVI_WJYTYcqbEsMUZ3kktLng.ttf"
     },
     {
       "family": "Syncopate",
@@ -38771,17 +40211,18 @@
         "700"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v21",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2024-11-20",
       "files": {
-        "700": "https://fonts.gstatic.com/s/syncopate/v21/pe0pMIuPIYBCpEV5eFdKvtKaA_Rue1UwVg.ttf",
-        "regular": "https://fonts.gstatic.com/s/syncopate/v21/pe0sMIuPIYBCpEV5eFdyAv2-C99ycg.ttf"
+        "700": "https://fonts.gstatic.com/s/syncopate/v22/pe0pMIuPIYBCpEV5eFdKvtKaA_Rue1UwVg.ttf",
+        "regular": "https://fonts.gstatic.com/s/syncopate/v22/pe0sMIuPIYBCpEV5eFdyAv2-C99ycg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/syncopate/v21/pe0sMIuPIYBCpEV5eFdCA_e6.ttf"
+      "menu": "https://fonts.gstatic.com/s/syncopate/v22/pe0sMIuPIYBCpEV5eFdCA_e6.ttf"
     },
     {
       "family": "Syne",
@@ -38858,14 +40299,14 @@
         "symbols",
         "vietnamese"
       ],
-      "version": "v4",
-      "lastModified": "2024-09-04",
+      "version": "v5",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/tacone/v4/ahcZv8Cj3zw7qDr8fO4hU-FwnU0.ttf"
+        "regular": "https://fonts.gstatic.com/s/tacone/v5/ahcZv8Cj3zw7qDr8fO4hU-FwnU0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/tacone/v4/ahcZv8Cj3zw7qDr8TO8rVw.ttf"
+      "menu": "https://fonts.gstatic.com/s/tacone/v5/ahcZv8Cj3zw7qDr8TO8rVw.ttf"
     },
     {
       "family": "Tai Heritage Pro",
@@ -38879,15 +40320,15 @@
         "tai-viet",
         "vietnamese"
       ],
-      "version": "v6",
-      "lastModified": "2023-05-31",
+      "version": "v7",
+      "lastModified": "2025-03-18",
       "files": {
-        "700": "https://fonts.gstatic.com/s/taiheritagepro/v6/sZlYdQid-zgaNiNIYcUzJMU3IYyNmMB9NNRFMuhjCXY.ttf",
-        "regular": "https://fonts.gstatic.com/s/taiheritagepro/v6/sZlfdQid-zgaNiNIYcUzJMU3IYyNoHxSENxuLuE.ttf"
+        "700": "https://fonts.gstatic.com/s/taiheritagepro/v7/sZlYdQid-zgaNiNIYcUzJMU3IYyNmMB9NNRFMuhjCXY.ttf",
+        "regular": "https://fonts.gstatic.com/s/taiheritagepro/v7/sZlfdQid-zgaNiNIYcUzJMU3IYyNoHxSENxuLuE.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/taiheritagepro/v6/sZlfdQid-zgaNiNIYcUzJMU3IYyNkH1YFA.ttf"
+      "menu": "https://fonts.gstatic.com/s/taiheritagepro/v7/sZlfdQid-zgaNiNIYcUzJMU3IYyNkH1YFA.ttf"
     },
     {
       "family": "Tajawal",
@@ -39301,16 +40742,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/thegirlnextdoor/v22/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCYIV7t7w6bE2A.ttf"
+        "regular": "https://fonts.gstatic.com/s/thegirlnextdoor/v23/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCYIV7t7w6bE2A.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/thegirlnextdoor/v22/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCY4VrF_.ttf"
+      "menu": "https://fonts.gstatic.com/s/thegirlnextdoor/v23/pe0zMJCIMIsBjFxqYBIcZ6_OI5oFHCY4VrF_.ttf"
     },
     {
       "family": "The Nautigal",
@@ -39391,14 +40833,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v10",
-      "lastModified": "2024-09-04",
+      "version": "v11",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/tiltneon/v10/E21L_d7gguXdwD9LEFY2WCeElCNtd-eBqpHp1TzrkJSmwpj5ndxquXK9WualJ9DS.ttf"
+        "regular": "https://fonts.gstatic.com/s/tiltneon/v11/E21L_d7gguXdwD9LEFY2WCeElCNtd-eBqpHp1TzrkJSmwpj5ndxquXK9WualJ9DS.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/tiltneon/v10/E21L_d7gguXdwD9LEFY2WCeElCNtd-eBqpHp1TzrkJSmwpj5ndxquUK8UOI.ttf"
+      "menu": "https://fonts.gstatic.com/s/tiltneon/v11/E21L_d7gguXdwD9LEFY2WCeElCNtd-eBqpHp1TzrkJSmwpj5ndxquUK8UOI.ttf"
     },
     {
       "family": "Tilt Prism",
@@ -39410,14 +40852,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v11",
-      "lastModified": "2024-09-04",
+      "version": "v12",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/tiltprism/v11/5h11iZgyPHoZ3YikNzWGfWey2dCAZXT-bH9V4VGn-FJ7tLI25oc_rIbwoTSrn86NKw.ttf"
+        "regular": "https://fonts.gstatic.com/s/tiltprism/v12/5h11iZgyPHoZ3YikNzWGfWey2dCAZXT-bH9V4VGn-FJ7tLI25oc_rIbwoTSrn86NKw.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/tiltprism/v11/5h11iZgyPHoZ3YikNzWGfWey2dCAZXT-bH9V4VGn-FJ7tLI25oc_rIbAoD6v.ttf"
+      "menu": "https://fonts.gstatic.com/s/tiltprism/v12/5h11iZgyPHoZ3YikNzWGfWey2dCAZXT-bH9V4VGn-FJ7tLI25oc_rIbAoD6v.ttf"
     },
     {
       "family": "Tilt Warp",
@@ -39429,14 +40871,14 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v12",
-      "lastModified": "2024-09-04",
+      "version": "v13",
+      "lastModified": "2025-03-18",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/tiltwarp/v12/AlZc_zVDs5XpmO7yn3w7flUoytXJp3z29uEwmEMLEJljLXvT8UJSZTBxAVfMGOPb.ttf"
+        "regular": "https://fonts.gstatic.com/s/tiltwarp/v13/AlZc_zVDs5XpmO7yn3w7flUoytXJp3z29uEwmEMLEJljLXvT8UJSZTBxAVfMGOPb.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/tiltwarp/v12/AlZc_zVDs5XpmO7yn3w7flUoytXJp3z29uEwmEMLEJljLXvT8UJSZQBwC1M.ttf"
+      "menu": "https://fonts.gstatic.com/s/tiltwarp/v13/AlZc_zVDs5XpmO7yn3w7flUoytXJp3z29uEwmEMLEJljLXvT8UJSZQBwC1M.ttf"
     },
     {
       "family": "Timmana",
@@ -39498,14 +40940,14 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2024-12-10",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/tiny5/v1/KFOpCnmCvdGT7hw-z0hHAi88.ttf"
+        "regular": "https://fonts.gstatic.com/s/tiny5/v3/KFOpCnmCvdGT7hw-z0hHAi88.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/tiny5/v1/KFOpCnmCvdGT7iw_xUw.ttf"
+      "menu": "https://fonts.gstatic.com/s/tiny5/v3/KFOpCnmCvdGT7iw_xUw.ttf"
     },
     {
       "family": "Tiro Bangla",
@@ -39874,6 +41316,25 @@
       "menu": "https://fonts.gstatic.com/s/trainone/v14/gyB-hwkiNtc6KnxUVjW3O6zd.ttf"
     },
     {
+      "family": "Triodion",
+      "variants": [
+        "regular"
+      ],
+      "subsets": [
+        "cyrillic",
+        "cyrillic-ext",
+        "latin"
+      ],
+      "version": "v3",
+      "lastModified": "2025-02-12",
+      "files": {
+        "regular": "https://fonts.gstatic.com/s/triodion/v3/IFSnHe5TgMVEmMQV5mr5u-W10l_X.ttf"
+      },
+      "category": "display",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/triodion/v3/IFSnHe5TgMVEmMQV5lr4seE.ttf"
+    },
+    {
       "family": "Trirong",
       "variants": [
         "100",
@@ -39944,21 +41405,21 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v24",
-      "lastModified": "2024-09-04",
+      "version": "v26",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9qoQl0zHugpt0.ttf",
-        "200": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbP9roQl0zHugpt0.ttf",
-        "300": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbCFroQl0zHugpt0.ttf",
-        "500": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbE1roQl0zHugpt0.ttf",
-        "600": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbKFsoQl0zHugpt0.ttf",
-        "700": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbJhsoQl0zHugpt0.ttf",
-        "800": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbP9soQl0zHugpt0.ttf",
-        "regular": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9roQl0zHugpt0.ttf"
+        "100": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9qoQl0zHugpt0.ttf",
+        "200": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbP9roQl0zHugpt0.ttf",
+        "300": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbCFroQl0zHugpt0.ttf",
+        "500": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbE1roQl0zHugpt0.ttf",
+        "600": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbKFsoQl0zHugpt0.ttf",
+        "700": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbJhsoQl0zHugpt0.ttf",
+        "800": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbP9soQl0zHugpt0.ttf",
+        "regular": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9roQl0zHugpt0.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/trispace/v24/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9rkQh-yA.ttf"
+      "menu": "https://fonts.gstatic.com/s/trispace/v26/Yq65-LKSQC3o56LxxgRrtA6yBqsrXL5GI5KI-IUZVGsxWFIlbH9rkQh-yA.ttf"
     },
     {
       "family": "Trocchi",
@@ -40257,29 +41718,29 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2025-03-11",
       "files": {
-        "100": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt7CfqLVLT9mgk.ttf",
-        "200": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj7t6CfqLVLT9mgk.ttf",
-        "300": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj2V6CfqLVLT9mgk.ttf",
-        "500": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujwl6CfqLVLT9mgk.ttf",
-        "600": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj-V9CfqLVLT9mgk.ttf",
-        "700": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj9x9CfqLVLT9mgk.ttf",
-        "800": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj7t9CfqLVLT9mgk.ttf",
-        "regular": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt6CfqLVLT9mgk.ttf",
-        "100italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM54biBUJb4iglIHg.ttf",
-        "200italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5YbmBUJb4iglIHg.ttf",
-        "300italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5v7mBUJb4iglIHg.ttf",
-        "italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM54bmBUJb4iglIHg.ttf",
-        "500italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM507mBUJb4iglIHg.ttf",
-        "600italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5P76BUJb4iglIHg.ttf",
-        "700italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5Br6BUJb4iglIHg.ttf",
-        "800italic": "https://fonts.gstatic.com/s/ubuntusans/v2/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5Yb6BUJb4iglIHg.ttf"
+        "100": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt7CfqLVLT9mgk.ttf",
+        "200": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj7t6CfqLVLT9mgk.ttf",
+        "300": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj2V6CfqLVLT9mgk.ttf",
+        "500": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujwl6CfqLVLT9mgk.ttf",
+        "600": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj-V9CfqLVLT9mgk.ttf",
+        "700": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj9x9CfqLVLT9mgk.ttf",
+        "800": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbuj7t9CfqLVLT9mgk.ttf",
+        "regular": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt6CfqLVLT9mgk.ttf",
+        "100italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM54biBUJb4iglIHg.ttf",
+        "200italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5YbmBUJb4iglIHg.ttf",
+        "300italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5v7mBUJb4iglIHg.ttf",
+        "italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM54bmBUJb4iglIHg.ttf",
+        "500italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM507mBUJb4iglIHg.ttf",
+        "600italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5P76BUJb4iglIHg.ttf",
+        "700italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5Br6BUJb4iglIHg.ttf",
+        "800italic": "https://fonts.gstatic.com/s/ubuntusans/v3/co3mmWd6mSRtB7_9UaLWwLPLmXPrAaRZFVxauS9FrCyI9sOpp8jpmvM5Yb6BUJb4iglIHg.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ubuntusans/v2/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt6OfuBUA.ttf"
+      "menu": "https://fonts.gstatic.com/s/ubuntusans/v3/co3omWd6mSRtB7_9UaLWwJnCq5ALePfPu1tPcW235R53LqrCPWbujzt6OfuBUA.ttf"
     },
     {
       "family": "Ubuntu Sans Mono",
@@ -40301,21 +41762,21 @@
         "latin",
         "latin-ext"
       ],
-      "version": "v1",
-      "lastModified": "2024-09-04",
+      "version": "v2",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ed_kYRiqcZu3n0.ttf",
-        "600": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Hx-UYRiqcZu3n0.ttf",
-        "700": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27HI-UYRiqcZu3n0.ttf",
-        "regular": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ev_kYRiqcZu3n0.ttf",
-        "italic": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnva5SgKM7vmn0BLE.ttf",
-        "500italic": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvZxSgKM7vmn0BLE.ttf",
-        "600italic": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvXBVgKM7vmn0BLE.ttf",
-        "700italic": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvUlVgKM7vmn0BLE.ttf"
+        "500": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ed_kYRiqcZu3n0.ttf",
+        "600": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Hx-UYRiqcZu3n0.ttf",
+        "700": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27HI-UYRiqcZu3n0.ttf",
+        "regular": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ev_kYRiqcZu3n0.ttf",
+        "italic": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnva5SgKM7vmn0BLE.ttf",
+        "500italic": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvZxSgKM7vmn0BLE.ttf",
+        "600italic": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvXBVgKM7vmn0BLE.ttf",
+        "700italic": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyi7mzgBHrR5yE7ZyRg0QRJMKI45g_SchUEkQgw3KTnvUlVgKM7vmn0BLE.ttf"
       },
       "category": "monospace",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ubuntusansmono/v1/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ev_nYQgKM.ttf"
+      "menu": "https://fonts.gstatic.com/s/ubuntusansmono/v2/jVyc7mzgBHrR5yE7ZyRg0QRJMKI4zAbgjc1t-pKe27Ev_nYQgKM.ttf"
     },
     {
       "family": "Uchen",
@@ -40341,16 +41802,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v23",
-      "lastModified": "2024-09-04",
+      "version": "v24",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/ultra/v23/zOLy4prXmrtY-tT6yLOD6NxF.ttf"
+        "regular": "https://fonts.gstatic.com/s/ultra/v24/zOLy4prXmrtY-tT6yLOD6NxF.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/ultra/v23/zOLy4prXmrtY-uT7wrc.ttf"
+      "menu": "https://fonts.gstatic.com/s/ultra/v24/zOLy4prXmrtY-uT7wrc.ttf"
     },
     {
       "family": "Unbounded",
@@ -40393,16 +41855,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/uncialantiqua/v20/N0bM2S5WOex4OUbESzoESK-i-PfRS5VBBSSF.ttf"
+        "regular": "https://fonts.gstatic.com/s/uncialantiqua/v21/N0bM2S5WOex4OUbESzoESK-i-PfRS5VBBSSF.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/uncialantiqua/v20/N0bM2S5WOex4OUbESzoESK-i-MfQQZE.ttf"
+      "menu": "https://fonts.gstatic.com/s/uncialantiqua/v21/N0bM2S5WOex4OUbESzoESK-i-MfQQZE.ttf"
     },
     {
       "family": "Underdog",
@@ -41010,25 +42473,25 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v27",
-      "lastModified": "2024-09-30",
+      "version": "v29",
+      "lastModified": "2025-03-11",
       "files": {
-        "500": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2AnGuGWOdEbD63w.ttf",
-        "600": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df27nauGWOdEbD63w.ttf",
-        "700": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df213auGWOdEbD63w.ttf",
-        "800": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2sHauGWOdEbD63w.ttf",
-        "900": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2mXauGWOdEbD63w.ttf",
-        "regular": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGuGWOdEbD63w.ttf",
-        "italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJGWmmZM7Xq34g9.ttf",
-        "500italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJ0WmmZM7Xq34g9.ttf",
-        "600italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKYXWmZM7Xq34g9.ttf",
-        "700italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKhXWmZM7Xq34g9.ttf",
-        "800italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLGXWmZM7Xq34g9.ttf",
-        "900italic": "https://fonts.gstatic.com/s/vollkorn/v27/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLvXWmZM7Xq34g9.ttf"
+        "500": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2AnGuGWOdEbD63w.ttf",
+        "600": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df27nauGWOdEbD63w.ttf",
+        "700": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df213auGWOdEbD63w.ttf",
+        "800": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2sHauGWOdEbD63w.ttf",
+        "900": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2mXauGWOdEbD63w.ttf",
+        "regular": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGuGWOdEbD63w.ttf",
+        "italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJGWmmZM7Xq34g9.ttf",
+        "500italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DJ0WmmZM7Xq34g9.ttf",
+        "600italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKYXWmZM7Xq34g9.ttf",
+        "700italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DKhXWmZM7Xq34g9.ttf",
+        "800italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLGXWmZM7Xq34g9.ttf",
+        "900italic": "https://fonts.gstatic.com/s/vollkorn/v29/0ybuGDoxxrvAnPhYGxksckM2WMCpRjDj-DLvXWmZM7Xq34g9.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/vollkorn/v27/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGeGGmZ.ttf"
+      "menu": "https://fonts.gstatic.com/s/vollkorn/v29/0ybgGDoxxrvAnPhYGzMlQLzuMasz6Df2MHGeGGmZ.ttf"
     },
     {
       "family": "Vollkorn SC",
@@ -41101,16 +42564,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v21",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/waitingforthesunrise/v20/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsYZQ9h_ZYk5J.ttf"
+        "regular": "https://fonts.gstatic.com/s/waitingforthesunrise/v21/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsYZQ9h_ZYk5J.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/waitingforthesunrise/v20/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsbZR_Bs.ttf"
+      "menu": "https://fonts.gstatic.com/s/waitingforthesunrise/v21/WBL1rFvOYl9CEv2i1mO6KUW8RKWJ2zoXoz5JsbZR_Bs.ttf"
     },
     {
       "family": "Wallpoet",
@@ -41218,22 +42682,22 @@
       "subsets": [
         "latin"
       ],
-      "version": "v10",
-      "lastModified": "2024-08-12",
+      "version": "v12",
+      "lastModified": "2024-11-14",
       "files": {
-        "100": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V0rDHXKtOXOg4.ttf",
-        "200": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI1V07DHXKtOXOg4.ttf",
-        "300": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI2L07DHXKtOXOg4.ttf",
-        "500": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3n07DHXKtOXOg4.ttf",
-        "600": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI0L1LDHXKtOXOg4.ttf",
-        "700": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI0y1LDHXKtOXOg4.ttf",
-        "800": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI1V1LDHXKtOXOg4.ttf",
-        "900": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI181LDHXKtOXOg4.ttf",
-        "regular": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V07DHXKtOXOg4.ttf"
+        "100": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V0rDHXKtOXOg4.ttf",
+        "200": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI1V07DHXKtOXOg4.ttf",
+        "300": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI2L07DHXKtOXOg4.ttf",
+        "500": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3n07DHXKtOXOg4.ttf",
+        "600": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI0L1LDHXKtOXOg4.ttf",
+        "700": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI0y1LDHXKtOXOg4.ttf",
+        "800": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI1V1LDHXKtOXOg4.ttf",
+        "900": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI181LDHXKtOXOg4.ttf",
+        "regular": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V07DHXKtOXOg4.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/wavefont/v10/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V04DGVq8.ttf"
+      "menu": "https://fonts.gstatic.com/s/wavefont/v12/L0xFDF00m0cP6hefyOCpRezQNuizSrqDyx8FHbFu21B3L4m0SEzuQYwq-f_JJ8I1WI3V04DGVq8.ttf"
     },
     {
       "family": "Wellfleet",
@@ -41310,6 +42774,50 @@
       "category": "handwriting",
       "kind": "webfonts#webfont",
       "menu": "https://fonts.gstatic.com/s/windsong/v11/KR1WBsyu-P-GFEW57o94F9U.ttf"
+    },
+    {
+      "family": "Winky Sans",
+      "variants": [
+        "300",
+        "regular",
+        "500",
+        "600",
+        "700",
+        "800",
+        "900",
+        "300italic",
+        "italic",
+        "500italic",
+        "600italic",
+        "700italic",
+        "800italic",
+        "900italic"
+      ],
+      "subsets": [
+        "latin",
+        "latin-ext"
+      ],
+      "version": "v1",
+      "lastModified": "2025-03-18",
+      "files": {
+        "300": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGXUiD6F2TpBa98q.ttf",
+        "500": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGW4iD6F2TpBa98q.ttf",
+        "600": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGVUjz6F2TpBa98q.ttf",
+        "700": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGVtjz6F2TpBa98q.ttf",
+        "800": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGUKjz6F2TpBa98q.ttf",
+        "900": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGUjjz6F2TpBa98q.ttf",
+        "regular": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGWKiD6F2TpBa98q.ttf",
+        "300italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCy4jG0z5jbs8qbts.ttf",
+        "italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCy9bG0z5jbs8qbts.ttf",
+        "500italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCy-TG0z5jbs8qbts.ttf",
+        "600italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCywjB0z5jbs8qbts.ttf",
+        "700italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCyzHB0z5jbs8qbts.ttf",
+        "800italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCy1bB0z5jbs8qbts.ttf",
+        "900italic": "https://fonts.gstatic.com/s/winkysans/v1/ll8uK2SDUiG1Hpf2p06bN6gynQbuVYjYB3BCy3_B0z5jbs8qbts.ttf"
+      },
+      "category": "sans-serif",
+      "kind": "webfonts#webfont",
+      "menu": "https://fonts.gstatic.com/s/winkysans/v1/ll8sK2SDUiG1Hpf2p06bHaEAYt6HPhJ2AGWKiA6E0z4.ttf"
     },
     {
       "family": "Wire One",
@@ -41630,14 +43138,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-08-12",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yarndings12/v2/55xreyp2N8T5P2LJbZAlkY9c8ZLMI2VUnQ.ttf"
+        "regular": "https://fonts.gstatic.com/s/yarndings12/v3/55xreyp2N8T5P2LJbZAlkY9c8ZLMI2VUnQ.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yarndings12/v2/55xreyp2N8T5P2LJbZAlkY9s8JjI.ttf"
+      "menu": "https://fonts.gstatic.com/s/yarndings12/v3/55xreyp2N8T5P2LJbZAlkY9s8JjI.ttf"
     },
     {
       "family": "Yarndings 12 Charted",
@@ -41649,14 +43157,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-08-12",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yarndings12charted/v2/eLGDP_DlKhO-DUfeqM4I_vDdJgmIh7hAvvbJ0t-dHaJH.ttf"
+        "regular": "https://fonts.gstatic.com/s/yarndings12charted/v3/eLGDP_DlKhO-DUfeqM4I_vDdJgmIh7hAvvbJ0t-dHaJH.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yarndings12charted/v2/eLGDP_DlKhO-DUfeqM4I_vDdJgmIh7hAvsbI2Ns.ttf"
+      "menu": "https://fonts.gstatic.com/s/yarndings12charted/v3/eLGDP_DlKhO-DUfeqM4I_vDdJgmIh7hAvsbI2Ns.ttf"
     },
     {
       "family": "Yarndings 20",
@@ -41668,14 +43176,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-08-12",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yarndings20/v2/TuGWUVlkUohEQu8l7K8b-vNFB380PMTK1w.ttf"
+        "regular": "https://fonts.gstatic.com/s/yarndings20/v3/TuGWUVlkUohEQu8l7K8b-vNFB380PMTK1w.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yarndings20/v2/TuGWUVlkUohEQu8l7K8b-vN1BnUw.ttf"
+      "menu": "https://fonts.gstatic.com/s/yarndings20/v3/TuGWUVlkUohEQu8l7K8b-vN1BnUw.ttf"
     },
     {
       "family": "Yarndings 20 Charted",
@@ -41687,14 +43195,14 @@
         "math",
         "symbols"
       ],
-      "version": "v2",
-      "lastModified": "2024-08-12",
+      "version": "v3",
+      "lastModified": "2025-01-28",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yarndings20charted/v2/QldRNSdbpg0G8vh0W2qxe0l-hcUPtY2VaLQm4UTqz5V9.ttf"
+        "regular": "https://fonts.gstatic.com/s/yarndings20charted/v3/QldRNSdbpg0G8vh0W2qxe0l-hcUPtY2VaLQm4UTqz5V9.ttf"
       },
       "category": "display",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yarndings20charted/v2/QldRNSdbpg0G8vh0W2qxe0l-hcUPtY2VaIQn60A.ttf"
+      "menu": "https://fonts.gstatic.com/s/yarndings20charted/v3/QldRNSdbpg0G8vh0W2qxe0l-hcUPtY2VaIQn60A.ttf"
     },
     {
       "family": "Yatra One",
@@ -41721,16 +43229,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v22",
-      "lastModified": "2024-09-04",
+      "version": "v23",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yellowtail/v22/OZpGg_pnoDtINPfRIlLotlzNwED-b4g.ttf"
+        "regular": "https://fonts.gstatic.com/s/yellowtail/v23/OZpGg_pnoDtINPfRIlLotlzNwED-b4g.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yellowtail/v22/OZpGg_pnoDtINPfRIlLohl3HxA.ttf"
+      "menu": "https://fonts.gstatic.com/s/yellowtail/v23/OZpGg_pnoDtINPfRIlLohl3HxA.ttf"
     },
     {
       "family": "Yeon Sung",
@@ -41777,16 +43286,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v18",
-      "lastModified": "2024-09-04",
+      "version": "v19",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/yesteryear/v18/dg4g_p78rroaKl8kRKo1r7wHTwonmyw.ttf"
+        "regular": "https://fonts.gstatic.com/s/yesteryear/v19/dg4g_p78rroaKl8kRKo1r7wHTwonmyw.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yesteryear/v18/dg4g_p78rroaKl8kRKo1n70NSw.ttf"
+      "menu": "https://fonts.gstatic.com/s/yesteryear/v19/dg4g_p78rroaKl8kRKo1n70NSw.ttf"
     },
     {
       "family": "Yomogi",
@@ -41846,23 +43356,23 @@
         "latin-ext",
         "vietnamese"
       ],
-      "version": "v20",
-      "lastModified": "2024-09-04",
+      "version": "v22",
+      "lastModified": "2025-03-11",
       "files": {
-        "300": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaCjASNNV9rRPfrKu.ttf",
-        "500": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaCisSNNV9rRPfrKu.ttf",
-        "600": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaChAT9NV9rRPfrKu.ttf",
-        "700": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaCh5T9NV9rRPfrKu.ttf",
-        "regular": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaCieSNNV9rRPfrKu.ttf",
-        "300italic": "https://fonts.gstatic.com/s/yrsa/v20/wlptgwnQFlxs1QnF94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
-        "italic": "https://fonts.gstatic.com/s/yrsa/v20/wlptgwnQFlxs1QnF94zlCfv0bz1WCzsW_LBte6KuGEo.ttf",
-        "500italic": "https://fonts.gstatic.com/s/yrsa/v20/wlptgwnQFlxs1QnF94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
-        "600italic": "https://fonts.gstatic.com/s/yrsa/v20/wlptgwnQFlxs1QnF94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
-        "700italic": "https://fonts.gstatic.com/s/yrsa/v20/wlptgwnQFlxs1QnF94zlCfv0bz1WC9wR_LBte6KuGEo.ttf"
+        "300": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaCjASNNV9rRPfrKu.ttf",
+        "500": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaCisSNNV9rRPfrKu.ttf",
+        "600": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaChAT9NV9rRPfrKu.ttf",
+        "700": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaCh5T9NV9rRPfrKu.ttf",
+        "regular": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaCieSNNV9rRPfrKu.ttf",
+        "300italic": "https://fonts.gstatic.com/s/yrsa/v22/wlptgwnQFlxs1QnF94zlCfv0bz1WC2UW_LBte6KuGEo.ttf",
+        "italic": "https://fonts.gstatic.com/s/yrsa/v22/wlptgwnQFlxs1QnF94zlCfv0bz1WCzsW_LBte6KuGEo.ttf",
+        "500italic": "https://fonts.gstatic.com/s/yrsa/v22/wlptgwnQFlxs1QnF94zlCfv0bz1WCwkW_LBte6KuGEo.ttf",
+        "600italic": "https://fonts.gstatic.com/s/yrsa/v22/wlptgwnQFlxs1QnF94zlCfv0bz1WC-UR_LBte6KuGEo.ttf",
+        "700italic": "https://fonts.gstatic.com/s/yrsa/v22/wlptgwnQFlxs1QnF94zlCfv0bz1WC9wR_LBte6KuGEo.ttf"
       },
       "category": "serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/yrsa/v20/wlprgwnQFlxs_wD3CFSMYmFaaCieSONU_LA.ttf"
+      "menu": "https://fonts.gstatic.com/s/yrsa/v22/wlprgwnQFlxs_wD3CFSMYmFaaCieSONU_LA.ttf"
     },
     {
       "family": "Ysabeau",
@@ -42254,7 +43764,9 @@
       "variants": [
         "200",
         "300",
+        "300italic",
         "regular",
+        "italic",
         "700",
         "800",
         "900"
@@ -42263,19 +43775,21 @@
         "arabic",
         "latin"
       ],
-      "version": "v2",
-      "lastModified": "2024-09-04",
+      "version": "v3",
+      "lastModified": "2024-11-20",
       "files": {
-        "200": "https://fonts.gstatic.com/s/zain/v2/sykz-y9lm7soOBrstSq9-trEvlQ.ttf",
-        "300": "https://fonts.gstatic.com/s/zain/v2/sykz-y9lm7soOH7vtSq9-trEvlQ.ttf",
-        "700": "https://fonts.gstatic.com/s/zain/v2/sykz-y9lm7soOG7otSq9-trEvlQ.ttf",
-        "800": "https://fonts.gstatic.com/s/zain/v2/sykz-y9lm7soOHLrtSq9-trEvlQ.ttf",
-        "900": "https://fonts.gstatic.com/s/zain/v2/sykz-y9lm7soOFbqtSq9-trEvlQ.ttf",
-        "regular": "https://fonts.gstatic.com/s/zain/v2/syk8-y9lm7soANLHkSKW5tM.ttf"
+        "200": "https://fonts.gstatic.com/s/zain/v3/sykz-y9lm7soOBrstSq9-trEvlQ.ttf",
+        "300": "https://fonts.gstatic.com/s/zain/v3/sykz-y9lm7soOH7vtSq9-trEvlQ.ttf",
+        "700": "https://fonts.gstatic.com/s/zain/v3/sykz-y9lm7soOG7otSq9-trEvlQ.ttf",
+        "800": "https://fonts.gstatic.com/s/zain/v3/sykz-y9lm7soOHLrtSq9-trEvlQ.ttf",
+        "900": "https://fonts.gstatic.com/s/zain/v3/sykz-y9lm7soOFbqtSq9-trEvlQ.ttf",
+        "300italic": "https://fonts.gstatic.com/s/zain/v3/sykx-y9lm7soMND1OSi3_vjBrlSILg.ttf",
+        "regular": "https://fonts.gstatic.com/s/zain/v3/syk8-y9lm7soANLHkSKW5tM.ttf",
+        "italic": "https://fonts.gstatic.com/s/zain/v3/syky-y9lm7soMNDNlQCT9tPdpw.ttf"
       },
       "category": "sans-serif",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/zain/v2/syk8-y9lm7soMNPNlQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/zain/v3/syk8-y9lm7soMNPNlQ.ttf"
     },
     {
       "family": "Zen Antique",
@@ -42516,16 +44030,17 @@
         "regular"
       ],
       "subsets": [
-        "latin"
+        "latin",
+        "latin-ext"
       ],
-      "version": "v19",
-      "lastModified": "2024-09-04",
+      "version": "v20",
+      "lastModified": "2024-11-20",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/zeyada/v19/11hAGpPTxVPUbgZDNGatWKaZ3g.ttf"
+        "regular": "https://fonts.gstatic.com/s/zeyada/v20/11hAGpPTxVPUbgZDNGatWKaZ3g.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/zeyada/v19/11hAGpPTxVPUbgZzNWyp.ttf"
+      "menu": "https://fonts.gstatic.com/s/zeyada/v20/11hAGpPTxVPUbgZzNWyp.ttf"
     },
     {
       "family": "Zhi Mang Xing",
@@ -42536,14 +44051,14 @@
         "chinese-simplified",
         "latin"
       ],
-      "version": "v17",
-      "lastModified": "2024-08-12",
+      "version": "v18",
+      "lastModified": "2025-01-06",
       "files": {
-        "regular": "https://fonts.gstatic.com/s/zhimangxing/v17/f0Xw0ey79sErYFtWQ9a2rq-g0actfektIJ0.ttf"
+        "regular": "https://fonts.gstatic.com/s/zhimangxing/v18/f0Xw0ey79sErYFtWQ9a2rq-g0actfektIJ0.ttf"
       },
       "category": "handwriting",
       "kind": "webfonts#webfont",
-      "menu": "https://fonts.gstatic.com/s/zhimangxing/v17/f0Xw0ey79sErYFtWQ9a2rq-g4aYneQ.ttf"
+      "menu": "https://fonts.gstatic.com/s/zhimangxing/v18/f0Xw0ey79sErYFtWQ9a2rq-g4aYneQ.ttf"
     },
     {
       "family": "Zilla Slab",


### PR DESCRIPTION
Update Google Fonts to latest

Additionally, added support to the `generate` script to handle font names that start with a number (which TypeScript does not like). Does not affect external usage, but where required generated metric type names may be prefixed an underscore.