### PR TITLE
`createTextStyle`: Correctly pass through `debugId` and remove redundant classname

### DIFF
--- a/.changeset/real-mails-repeat.md
+++ b/.changeset/real-mails-repeat.md
@@ -1,0 +1,5 @@
+---
+'@capsizecss/vanilla-extract': patch
+---
+
+`createTextStyle`: Correctly pass through `debugId` and remove redundant classname

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -34,7 +34,7 @@ const createVanillaStyle = ({
     vars['@media'] = mqs;
   }
 
-  return style([capsizeStyle, style(vars, debugId)]);
+  return style([capsizeStyle, vars], debugId);
 };
 
 function createTextStyle(


### PR DESCRIPTION
I noticed that one of the typography styles in Braid's `Text` component contained a classname without a debug ID:

```
reset_base__1vaeyfc0
sprinkles_display_block_mobile__z3xxmb4z
typography_fontFamily__wvf7we0
typography_fontWeight_regular__wvf7we1
typography_tone_neutral__wvf7we21
typography_textSizeTrimmed_standard__wvf7wec
typography__wvf7web <---------------------------- THIS ONE
capsize_capsizeStyle__1u941fx4
typography_textSize_standard__wvf7wea
```

I believe this is the composed classname from the outer `style` call in `createTextStyle`. It doesn't automatically get a debug ID because Vanilla Extract's automatic debug ID generation only runs on `.css.*` files, but `createTextStyle` is inside an `index.mjs/cjs` file, so it gets missed. I assume this is why `debugId` is propagated through `createTextStyle`, but it should've also been passed to the outer style call.

I've made 2 changes in this PR:
1. Moved the `debugId` on the outer `style` call
2. Removed the inner `style` call

Without removing the inner `style` call, the composed classname would've had a debug ID, but by removing it we actually end up generating 1 less classname, while maintaining all debug IDs, which I think is better overall.

Braid `Text` component classnames with this change:

```
reset_base__1vaeyfc0
sprinkles_display_block_mobile__z3xxmb4z
typography_fontFamily__wvf7we0
typography_fontWeight_regular__wvf7we1
typography_tone_neutral__wvf7we1t
typography_textSizeTrimmed_standard__wvf7we9
typography_textSize_standard__wvf7we8
capsize_capsizeStyle__1u941fx4
```