### PR TITLE
unpack: Fix package json sorting

### DIFF
--- a/packages/unpack/package.json
+++ b/packages/unpack/package.json
@@ -2,9 +2,6 @@
   "name": "@capsizecss/unpack",
   "version": "3.0.0",
   "description": "Unpack capsize font metrics from fonts",
-  "engines": {
-    "node": ">=18"
-  },
   "keywords": [
     "capsize",
     "leading trim",
@@ -58,5 +55,8 @@
     "sort-keys": "^5.0.0",
     "tsx": "^4.7.0",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
Fixes the broken publish step, currently failing due to key sorting in package json.