### PR TITLE
Fix tsdown builds

### DIFF
--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../tsdown.base.config';
+import { baseConfig } from '../../tsdown.base.config.ts';
 
 export default defineConfig(baseConfig);

--- a/packages/metrics/tsdown.config.ts
+++ b/packages/metrics/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../tsdown.base.config';
+import { baseConfig } from '../../tsdown.base.config.ts';
 
 export default defineConfig({
   ...baseConfig,

--- a/packages/unpack/tsdown.config.ts
+++ b/packages/unpack/tsdown.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../tsdown.base.config';
+import { baseConfig } from '../../tsdown.base.config.ts';
 
 export default defineConfig(baseConfig);

--- a/packages/vanilla-extract/tsdown.config.ts
+++ b/packages/vanilla-extract/tsdown.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'tsdown';
-import { baseConfig } from '../../tsdown.base.config';
+import { baseConfig } from '../../tsdown.base.config.ts';
 
 export default defineConfig(baseConfig);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "strict": true /* Enable all strict type-checking options. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "allowSyntheticDefaultImports": true,
+    "allowImportingTsExtensions": true,
     "jsx": "preserve",
     "allowJs": true,
     "incremental": true,


### PR DESCRIPTION
Looks like the release failed here and is complaining about not finding the tsdown config files: https://github.com/seek-oss/capsize/actions/runs/19281318739/job/55132849882

Seems like it needs those to be imported with a `.ts` extension to work?