### PR TITLE
metrics: Fix font metric types

### DIFF
--- a/.changeset/four-pots-wave.md
+++ b/.changeset/four-pots-wave.md
@@ -1,0 +1,5 @@
+---
+"@capsizecss/metrics": patch
+---
+
+metrics: Fix font metric types

--- a/packages/metrics/tsdown.config.ts
+++ b/packages/metrics/tsdown.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     customExports(pkg) {
       // Add manually built entries for each generated set of font metrics
       pkg['./*'] = {
+        types: './entireMetricsCollection/*/index.d.ts',
         import: './entireMetricsCollection/*/index.mjs',
         require: './entireMetricsCollection/*/index.cjs',
       };


### PR DESCRIPTION
Fixes the types export map for the generated font metrics that we missed when migrating to tsdown.