### PR TITLE
vanilla-extract: Ensure Vanilla Extract styles are bundled into isolated modules

### DIFF
--- a/.changeset/stupid-countries-tie.md
+++ b/.changeset/stupid-countries-tie.md
@@ -1,0 +1,5 @@
+---
+"@capsizecss/vanilla-extract": patch
+---
+
+Ensure Vanilla Extract styles are bundled into isolated modules

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -36,6 +36,7 @@
     },
     "./package.json": "./package.json",
     "./*": {
+      "types": "./entireMetricsCollection/*/index.d.ts",
       "import": "./entireMetricsCollection/*/index.mjs",
       "require": "./entireMetricsCollection/*/index.cjs"
     }
@@ -76,6 +77,7 @@
       },
       "./package.json": "./package.json",
       "./*": {
+        "types": "./entireMetricsCollection/*/index.d.ts",
         "import": "./entireMetricsCollection/*/index.mjs",
         "require": "./entireMetricsCollection/*/index.cjs"
       }

--- a/packages/vanilla-extract/tsdown.config.ts
+++ b/packages/vanilla-extract/tsdown.config.ts
@@ -1,4 +1,7 @@
 import { defineConfig } from 'tsdown';
 import { baseConfig } from '../../tsdown.base.config.ts';
 
-export default defineConfig(baseConfig);
+export default defineConfig({
+  ...baseConfig,
+  unbundle: true,
+});


### PR DESCRIPTION
The one thing we forgot to consider when moving to tsdown in #239 was handling Vanilla Extract styles. Since v2.0.2, Vanilla Extract code in `@capsizecss/vanilla-extract` has been bundled alongside its API code in a single `index.mjs/cjs` file. This results in a `Styles were unable to be assigned to a file` error when importing the package because Vanilla Extract usage is no longer isolated to a `.css.mjs/cjs` file (as it was in [v2.0.1](https://www.npmjs.com/package/@capsizecss/vanilla-extract/v/2.0.1?activeTab=code)).

Crackle handled this with a complicated manual chunking configuration that would "pre-compile" Vanilla Extract modules and keep them isolated from non Vanilla Extract code. The pre-compilation is an optimization of dubious utility, and in the case of this tiny library a correct bundle output can be recreated with `unbundle: true` (effectively the same as [`preserveModules: true`](https://rolldown.rs/options/output#preservemodules)).