### PR TITLE
ci: Fix duplicate git credentials in update workflow

### DIFF
--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -2,7 +2,7 @@ name: Update Google Fonts
 
 on:
   schedule:
-    - cron: '0 0 15 * *'
+    - cron: '30 9 18 * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 1
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
CI ran into an error creating the pull request to update Google Fonts. The`Duplicate header: "Authorization"` error was due to `actions/checkout` persisting its own credentials, and then `peter-evans/create-pull-request` adding a second `Authorization` header. Fixed by disabling `persist-credentials` on the checkout step.

(Also updating the time to see test run it later this morning)