### PR TITLE
metrics: Use semver to version based on current Google Fonts

### DIFF
--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -2,7 +2,7 @@ name: Update Google Fonts
 
 on:
   schedule:
-    - cron: '30 22 14 * *'
+    - cron: '30 22 14 * *' # 8:30am on 15th of every month (AEST)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -2,7 +2,7 @@ name: Update Google Fonts
 
 on:
   schedule:
-    - cron: '0 0 15 * *'
+    - cron: '30 22 14 * *'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -68,6 +68,19 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Determine version
+        if: steps.changes.outputs.has_changes == 'true'
+        id: version
+        run: |
+          SUMMARY="${{ steps.font-changes.outputs.summary }}"
+          if echo "$SUMMARY" | grep -q '### Removed'; then
+            echo "version_increment=major" >> "$GITHUB_OUTPUT"
+          elif echo "$SUMMARY" | grep -q '### New'; then
+            echo "version_increment=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "version_increment=patch" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Get current month and year
         if: steps.changes.outputs.has_changes == 'true'
         id: date
@@ -78,10 +91,11 @@ jobs:
         run: |
           printf '%s\n' \
             '---' \
-            "'@capsizecss/metrics': minor" \
+            "'@capsizecss/metrics': ${{ steps.version.outputs.version_increment }}" \
             '---' \
             '' \
             "Update Google Fonts — ${{ steps.date.outputs.month_year }}" \
+            '' \
             "${{ steps.font-changes.outputs.summary }}" \
             > ".changeset/update-google-fonts-$(git rev-parse --short HEAD).md"
 

--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -76,6 +76,8 @@ jobs:
           SUMMARY="${{ steps.font-changes.outputs.summary }}"
           if echo "$SUMMARY" | grep -q '### Removed'; then
             echo "version_increment=major" >> "$GITHUB_OUTPUT"
+            REMOVED_COUNT=$(echo "$SUMMARY" | sed -n '/^### Removed/,/^### /{ /^- /p }' | wc -l | tr -d ' ')
+            echo "removed_count=$REMOVED_COUNT" >> "$GITHUB_OUTPUT"
           elif echo "$SUMMARY" | grep -q '### New'; then
             echo "version_increment=minor" >> "$GITHUB_OUTPUT"
           else
@@ -90,15 +92,22 @@ jobs:
       - name: Create changeset
         if: steps.changes.outputs.has_changes == 'true'
         run: |
-          printf '%s\n' \
-            '---' \
-            "'@capsizecss/metrics': ${{ steps.version.outputs.version_increment }}" \
-            '---' \
-            '' \
-            "Update Google Fonts — ${{ steps.date.outputs.month_year }}" \
-            '' \
-            "${{ steps.font-changes.outputs.summary }}" \
-            > ".changeset/update-google-fonts-$(git rev-parse --short HEAD).md"
+          BREAKING=""
+          if [ "${{ steps.version.outputs.version_increment }}" = "major" ]; then
+            BREAKING="**BREAKING CHANGE:** ${{ steps.version.outputs.removed_count }} fonts were removed due to no longer being available in the Google Fonts library (see list below)."
+          fi
+          {
+            printf '%s\n' \
+              '---' \
+              "'@capsizecss/metrics': ${{ steps.version.outputs.version_increment }}" \
+              '---' \
+              '' \
+              "Update Google Fonts — ${{ steps.date.outputs.month_year }}"
+            if [ -n "$BREAKING" ]; then
+              printf '\n%s\n' "$BREAKING"
+            fi
+            printf '\n%s\n' "${{ steps.font-changes.outputs.summary }}"
+          } > ".changeset/update-google-fonts-$(git rev-parse --short HEAD).md"
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run == false

--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -59,55 +59,17 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Compute font changes
-        if: steps.changes.outputs.has_changes == 'true'
-        id: font-changes
-        run: |
-          {
-            echo "summary<<EOF"
-            pnpm --silent metrics:diff | grep -v '^>'
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Determine version
-        if: steps.changes.outputs.has_changes == 'true'
-        id: version
-        run: |
-          SUMMARY="${{ steps.font-changes.outputs.summary }}"
-          if echo "$SUMMARY" | grep -q '### Removed'; then
-            echo "version_increment=major" >> "$GITHUB_OUTPUT"
-            REMOVED_COUNT=$(echo "$SUMMARY" | sed -n '/^### Removed/,/^### /{ /^- /p }' | wc -l | tr -d ' ')
-            echo "removed_count=$REMOVED_COUNT" >> "$GITHUB_OUTPUT"
-          elif echo "$SUMMARY" | grep -q '### New'; then
-            echo "version_increment=minor" >> "$GITHUB_OUTPUT"
-          else
-            echo "version_increment=patch" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Get current month and year
-        if: steps.changes.outputs.has_changes == 'true'
-        id: date
-        run: echo "month_year=$(date +'%B %Y')" >> "$GITHUB_OUTPUT"
-
       - name: Create changeset
         if: steps.changes.outputs.has_changes == 'true'
+        id: changeset
         run: |
-          BREAKING=""
-          if [ "${{ steps.version.outputs.version_increment }}" = "major" ]; then
-            BREAKING="**BREAKING CHANGE:** ${{ steps.version.outputs.removed_count }} fonts were removed due to no longer being available in the Google Fonts library (see list below)."
-          fi
+          CHANGESET_PATH=$(pnpm --silent metrics:changeset)
+          SUMMARY=$(sed '1,/^---$/{ /^---$/d; d; }' "$CHANGESET_PATH")
           {
-            printf '%s\n' \
-              '---' \
-              "'@capsizecss/metrics': ${{ steps.version.outputs.version_increment }}" \
-              '---' \
-              '' \
-              "Update Google Fonts — ${{ steps.date.outputs.month_year }}"
-            if [ -n "$BREAKING" ]; then
-              printf '\n%s\n' "$BREAKING"
-            fi
-            printf '\n%s\n' "${{ steps.font-changes.outputs.summary }}"
-          } > ".changeset/update-google-fonts-$(git rev-parse --short HEAD).md"
+            echo "summary<<EOF"
+            echo "$SUMMARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true' && inputs.dry_run == false
@@ -117,9 +79,7 @@ jobs:
           commit-message: 'metrics: Update Google Fonts'
           branch: update-google-fonts
           title: 'metrics: Update Google Fonts'
-          body: |
-            Update Google Fonts — ${{ steps.date.outputs.month_year }}
-            ${{ steps.font-changes.outputs.summary }}
+          body: ${{ steps.changeset.outputs.summary }}
           base: master
           delete-branch: true
 
@@ -137,8 +97,7 @@ jobs:
             echo "  Base: master"
             echo ""
             echo "Description:"
-            echo "Update Google Fonts — ${{ steps.date.outputs.month_year }}"
-            printf '%s\n' "${{ steps.font-changes.outputs.summary }}"
+            printf '%s\n' "${{ steps.changeset.outputs.summary }}"
             echo ""
             echo "Changed files:"
             git add --all && git diff --cached --stat

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "site:serve": "pnpm %site serve",
     "site:deploy": "pnpm %site run deploy",
     "site:deploy-preview": "pnpm generate && pnpm %site deploy-preview",
-    "metrics:diff": "pnpm %metrics diff",
+    "metrics:changeset": "pnpm %metrics changeset",
     "metrics:extract": "pnpm %metrics extract",
     "metrics:generate": "pnpm %metrics generate",
     "metrics:download": "pnpm %metrics download",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -50,8 +50,8 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "changeset": "tsx ./scripts/changeset.ts",
     "clean": "tsx ./scripts/clean.ts",
-    "diff": "tsx ./scripts/diff.ts",
     "download": "tsx ./scripts/download.ts",
     "extract": "tsx ./scripts/extract.ts",
     "generate": "pnpm clean && tsx ./scripts/generate.ts"

--- a/packages/metrics/scripts/changeset.ts
+++ b/packages/metrics/scripts/changeset.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { computeDiff } from './diff';
+
+const { newFonts, removedFonts, summary } = computeDiff();
+
+if (!summary) {
+  process.exit(0);
+}
+
+const versionIncrement =
+  removedFonts.length > 0 ? 'major' : newFonts.length > 0 ? 'minor' : 'patch';
+
+const monthYear = new Date().toLocaleDateString('en-US', {
+  month: 'long',
+  year: 'numeric',
+});
+
+const breakingMessage =
+  versionIncrement === 'major'
+    ? `**BREAKING CHANGE:** ${removedFonts.length} font${removedFonts.length === 1 ? ' was' : 's were'} removed due to no longer being available in the Google Fonts library (see list below).\n`
+    : '';
+
+const title = `Update Google Fonts — ${monthYear}`;
+
+const frontMatter = [
+  '---',
+  `'@capsizecss/metrics': ${versionIncrement}`,
+  '---',
+  '',
+].join('\n');
+
+const description = [title, breakingMessage, summary].join('\n\n');
+
+const shortHash = execSync('git rev-parse --short HEAD', {
+  encoding: 'utf-8',
+}).trim();
+const changesetPath = path.resolve(
+  `.changeset/update-google-fonts-${shortHash}.md`,
+);
+
+fs.writeFileSync(changesetPath, `${frontMatter}${description}\n`);
+
+console.log(changesetPath); // Read by CI to populate the body of the PR

--- a/packages/metrics/scripts/diff.ts
+++ b/packages/metrics/scripts/diff.ts
@@ -47,6 +47,14 @@ for (const name of previousByName.keys()) {
 
 const sections: string[] = [];
 
+if (removedFonts.length > 0) {
+  sections.push(
+    `### Removed\n${removedFonts
+      .sort()
+      .map((f) => `- ${f}`)
+      .join('\n')}`,
+  );
+}
 if (newFonts.length > 0) {
   sections.push(
     `### New\n${newFonts
@@ -58,14 +66,6 @@ if (newFonts.length > 0) {
 if (updatedFonts.length > 0) {
   sections.push(
     `### Updated\n${updatedFonts
-      .sort()
-      .map((f) => `- ${f}`)
-      .join('\n')}`,
-  );
-}
-if (removedFonts.length > 0) {
-  sections.push(
-    `### Removed\n${removedFonts
       .sort()
       .map((f) => `- ${f}`)
       .join('\n')}`,

--- a/packages/metrics/scripts/diff.ts
+++ b/packages/metrics/scripts/diff.ts
@@ -7,71 +7,74 @@ interface FontMetrics {
   variants: Record<string, unknown>;
 }
 
-const scriptsDir = path.join(__dirname);
+export const computeDiff = () => {
+  const currentFonts: FontMetrics[] = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'googleFonts.json'), 'utf-8'),
+  );
 
-const currentFonts: FontMetrics[] = JSON.parse(
-  fs.readFileSync(path.join(scriptsDir, 'googleFonts.json'), 'utf-8'),
-);
+  const previousFonts: FontMetrics[] = JSON.parse(
+    execSync('git show HEAD:packages/metrics/scripts/googleFonts.json', {
+      encoding: 'utf-8',
+      maxBuffer: 100 * 1024 * 1024,
+    }),
+  );
 
-const previousFonts: FontMetrics[] = JSON.parse(
-  execSync('git show HEAD:packages/metrics/scripts/googleFonts.json', {
-    encoding: 'utf-8',
-    maxBuffer: 100 * 1024 * 1024,
-  }),
-);
+  const previousByName = new Map(
+    previousFonts.map((f) => [f.familyName, JSON.stringify(f.variants)]),
+  );
+  const currentByName = new Map(
+    currentFonts.map((f) => [f.familyName, JSON.stringify(f.variants)]),
+  );
 
-const previousByName = new Map(
-  previousFonts.map((f) => [f.familyName, JSON.stringify(f.variants)]),
-);
-const currentByName = new Map(
-  currentFonts.map((f) => [f.familyName, JSON.stringify(f.variants)]),
-);
+  const newFonts: string[] = [];
+  const updatedFonts: string[] = [];
+  const removedFonts: string[] = [];
 
-const newFonts: string[] = [];
-const updatedFonts: string[] = [];
-const removedFonts: string[] = [];
-
-for (const name of currentByName.keys()) {
-  if (!previousByName.has(name)) {
-    newFonts.push(name);
-  } else if (previousByName.get(name) !== currentByName.get(name)) {
-    updatedFonts.push(name);
+  for (const name of currentByName.keys()) {
+    if (!previousByName.has(name)) {
+      newFonts.push(name);
+    } else if (previousByName.get(name) !== currentByName.get(name)) {
+      updatedFonts.push(name);
+    }
   }
-}
 
-for (const name of previousByName.keys()) {
-  if (!currentByName.has(name)) {
-    removedFonts.push(name);
+  for (const name of previousByName.keys()) {
+    if (!currentByName.has(name)) {
+      removedFonts.push(name);
+    }
   }
-}
 
-const sections: string[] = [];
+  const sections: string[] = [];
 
-if (removedFonts.length > 0) {
-  sections.push(
-    `### Removed\n${removedFonts
-      .sort()
-      .map((f) => `- ${f}`)
-      .join('\n')}`,
-  );
-}
-if (newFonts.length > 0) {
-  sections.push(
-    `### New\n${newFonts
-      .sort()
-      .map((f) => `- ${f}`)
-      .join('\n')}`,
-  );
-}
-if (updatedFonts.length > 0) {
-  sections.push(
-    `### Updated\n${updatedFonts
-      .sort()
-      .map((f) => `- ${f}`)
-      .join('\n')}`,
-  );
-}
+  if (removedFonts.length > 0) {
+    sections.push(
+      `### Removed\n${removedFonts
+        .sort()
+        .map((f) => `- ${f}`)
+        .join('\n')}`,
+    );
+  }
+  if (newFonts.length > 0) {
+    sections.push(
+      `### New\n${newFonts
+        .sort()
+        .map((f) => `- ${f}`)
+        .join('\n')}`,
+    );
+  }
+  if (updatedFonts.length > 0) {
+    sections.push(
+      `### Updated\n${updatedFonts
+        .sort()
+        .map((f) => `- ${f}`)
+        .join('\n')}`,
+    );
+  }
 
-if (sections.length > 0) {
-  console.log(sections.join('\n\n'));
-}
+  return {
+    newFonts,
+    updatedFonts,
+    removedFonts,
+    summary: sections.length > 0 ? sections.join('\n\n') : undefined,
+  };
+};


### PR DESCRIPTION
Previously, the `@capsizecss/metrics` package would always be versioned as a `minor` regardless of whether metrics were added, updated or removed. Now that we are automating the update and the analysis, we are switching the versioning to be semantically correct — purely based on whether metrics are added/updated/deleted.